### PR TITLE
Use geocat-viz for plotting utility functions

### DIFF
--- a/.rtd_conda_environment.yml
+++ b/.rtd_conda_environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3
   - geocat-comp
+  - geocat-viz
   - netcdf4
   - cartopy
   - mock

--- a/Plots/Contours/NCL_coneff_16.py
+++ b/Plots/Contours/NCL_coneff_16.py
@@ -13,7 +13,7 @@ from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as tic
-from util.make_byr_cmap import make_byr_cmap
+from geocat.viz.util import make_byr_cmap
 
 
 from pprint import pprint

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python=3
   - geocat-comp
+  - geocat-viz
   - netcdf4
   - cartopy
   - mock


### PR DESCRIPTION
Added geocat-viz as conda dependency and modified `NCL_coneff_16.py` to use `make_byr_cmap()` from `geocat-viz` instead of from `Plots/Contours/util/make_byr_cmap.py`.