### PR TITLE
Use geocat-datafiles for downloading data files

### DIFF
--- a/.rtd_conda_environment.yml
+++ b/.rtd_conda_environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3
   - geocat-comp
+  - geocat-datafiles
   - netcdf4
   - cartopy
   - mock

--- a/Plots/Contours/NCL_coneff_16.py
+++ b/Plots/Contours/NCL_coneff_16.py
@@ -17,7 +17,9 @@ from util.make_byr_cmap import make_byr_cmap
 
 
 from pprint import pprint
-ds = xr.open_dataset('../../data/netcdf_files/uv300.nc')
+
+import geocat.datafiles
+ds = xr.open_dataset(geocat.datafiles.get('netcdf_files/uv300.nc'))
 U = ds.U[1,:,:]
 
 plt.rcParams['figure.figsize'] = [20, 10]

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python=3
   - geocat-comp
+  - geocat-datafiles
   - netcdf4
   - cartopy
   - mock


### PR DESCRIPTION
Added geocat-datafiles as conda dependency and modified NCL_coneff_16.py to use geocat.datafiles.get to fetch data files instead of using the `/data` submodule directory of this repository.