### PR TITLE
Fix xarray.DataArray keyword args in mask_1.py

### DIFF
--- a/Plots/Masking/mask_1.py
+++ b/Plots/Masking/mask_1.py
@@ -48,14 +48,14 @@ def xr_add_cyclic(da, coord):
 
     coords = da.coords.to_dataset()
     coords[coord] = cyclic_coord
-    return xr.DataArray(
+    da_out = xr.DataArray(
         cyclic_data,
         dims=da.dims,
         coords=coords.coords,
         attrs=da.attrs,
-        encoding=da.encoding,
     )
-
+    da_out.encoding = da.encoding
+    return da_out
 
 # Use xarray's where function to mask out land and then ocean data
 


### PR DESCRIPTION
The xr_add_cyclic function defined in mask_1.py includes the 'encoding' keyword argument to the xarray.DataArray constructor that was deprecated as of Xarray 0.14 and was removed in 0.15.

I believe the xr_add_cyclic function will eventually go into geocat-viz, so we should make this change there as well.