### PR TITLE
Add GitHub action and ReadTheDocs badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/NCAR/GeoCAT-examples/Build%20documentation%20pages?logo=github&style=for-the-badge)](https://github.com/NCAR/GeoCAT-examples/actions)
+[![Documentation Status](https://img.shields.io/readthedocs/geocat-examples/latest.svg?style=for-the-badge)](https://geocat-examples.readthedocs.io/en/latest/?badge=latest)
+
+
 GeoCAT-examples
 ===============
 Future home of the GeoCAT-examples repository!


### PR DESCRIPTION
This makes it easy to monitor the status of readthedocs builds without needing to  check the main readthedocs webpage:

<img width="846" alt="Screen Shot 2020-06-08 at 1 12 04 PM" src="https://user-images.githubusercontent.com/13301940/84070662-bb86aa80-a989-11ea-9b26-0b4105e205e0.png">

