### PR TITLE
Changing xy_5 to plot data using fractional dates

### DIFF
--- a/Plots/XY/NCL_xy_5.py
+++ b/Plots/XY/NCL_xy_5.py
@@ -6,7 +6,7 @@ This script illustrates the following concepts:
    - Drawing a Y reference line in an XY plot
    - Filling the areas of an XY curve above and below a reference line
    - Using named colors to indicate a fill color
-   - Creating array of dates to use as x-axis tick labels
+   - Converting dates from YYYYMM format to floats
    - Creating a main title
    - Setting the mininum/maximum value of the Y axis in an XY plot
 
@@ -59,20 +59,20 @@ ax.plot(date_frac, dsoik, color='black', linewidth=0.5)
 ax.plot(date_frac, dsoid, color='black')
 
 # Fill above and below the 0 line
-ax.fill_between(date_frac, dsoik, where=dsoik>0, color='red')
-ax.fill_between(date_frac, dsoik, where=dsoik<0, color='blue')
+ax.fill_between(date_frac, dsoik, where=dsoik > 0, color='red')
+ax.fill_between(date_frac, dsoik, where=dsoik < 0, color='blue')
 
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gvutil.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, 
+gvutil.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5,
                              labelsize=14)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gvutil.set_axes_limits_and_ticks(ax, ylim=(-3, 3), 
-                                     yticks=np.linspace(-3, 3, 7),
-                                     yticklabels=np.linspace(-3, 3, 7),
-                                     xlim=(date_frac[0], date_frac[-1]),
-                                     xticks=np.linspace(1880, 1980, 6))
+gvutil.set_axes_limits_and_ticks(ax, ylim=(-3, 3),
+                                 yticks=np.linspace(-3, 3, 7),
+                                 yticklabels=np.linspace(-3, 3, 7),
+                                 xlim=(date_frac[0], date_frac[-1]),
+                                 xticks=np.linspace(1880, 1980, 6))
 
 # Use geocat.viz.util convenience function to set titles and labels
 gvutil.set_titles_and_labels(ax, maintitle="Darwin Southern Oscillation Index")

--- a/Plots/XY/NCL_xy_5.py
+++ b/Plots/XY/NCL_xy_5.py
@@ -32,16 +32,19 @@ ds = xr.open_dataset(gdf.get("netcdf_files/soi.nc"))
 dsoik = ds.DSOI_KET
 dsoid = ds.DSOI_DEC
 date = ds.date
+num_months = np.shape(date)[0]
 
 # Creating a new array for x axis labels
 datedim = np.shape(date)[0]
 new_date = np.empty_like(date)
-# Dates in the file are represented by year and month
-# Create array that represents data by year and months as a fraction of a year
-for n in np.arange(0, datedim, 1):
-    yyyy = date[n]/100
-    mon = date[n]-yyyy*100
-    new_date[n] = yyyy + (mon-1)/12
+# Dates in the file are represented by year and month (YYYYMM)
+# representing them fractionally will make ploting the data easier
+# This produces the same results as NCL's yyyymm_to_yyyyfrac() function
+date_frac = np.empty_like(date)
+for n in np.arange(0, num_months, 1):
+    yyyy = int(date[n]/100)
+    mon = (date[n]/100-yyyy)*100
+    date_frac[n] = yyyy + (mon-1)/12
 
 ###############################################################################
 # Plot:

--- a/Plots/XY/NCL_xy_5.py
+++ b/Plots/XY/NCL_xy_5.py
@@ -34,9 +34,6 @@ dsoid = ds.DSOI_DEC
 date = ds.date
 num_months = np.shape(date)[0]
 
-# Creating a new array for x axis labels
-datedim = np.shape(date)[0]
-new_date = np.empty_like(date)
 # Dates in the file are represented by year and month (YYYYMM)
 # representing them fractionally will make ploting the data easier
 # This produces the same results as NCL's yyyymm_to_yyyyfrac() function
@@ -54,16 +51,16 @@ plt.figure(figsize=(8, 4))
 ax = plt.gca()
 
 # Plot reference line
-plt.plot([0, datedim], [0, 0], color='grey', linewidth=0.75)
+ax.axhline(y=0, color='grey', linewidth=0.75)
 
 # Plot data
 # _labels=False prevents axis labels from being drawn
-dsoik.plot.line(ax=ax, color='black', linewidth=0.5, _labels=False)
-dsoid.plot.line(ax=ax, color='black', _labels=False)
+ax.plot(date_frac, dsoik, color='black', linewidth=0.5)
+ax.plot(date_frac, dsoid, color='black')
 
 # Fill above and below the 0 line
-ax.fill_between(dsoik.time, dsoik, where=dsoik>0, color='red')
-ax.fill_between(dsoik.time, dsoik, where=dsoik<0, color='blue')
+ax.fill_between(date_frac, dsoik, where=dsoik>0, color='red')
+ax.fill_between(date_frac, dsoik, where=dsoik<0, color='blue')
 
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
@@ -74,9 +71,8 @@ gvutil.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5,
 gvutil.set_axes_limits_and_ticks(ax, ylim=(-3, 3), 
                                      yticks=np.linspace(-3, 3, 7),
                                      yticklabels=np.linspace(-3, 3, 7),
-                                     xlim=(0, datedim),
-                                     xticks=np.arange(0, datedim, 12*20),
-                                     xticklabels=np.arange(1880, 1995, 20))
+                                     xlim=(date_frac[0], date_frac[-1]),
+                                     xticks=np.linspace(1880, 1980, 6))
 
 # Use geocat.viz.util convenience function to set titles and labels
 gvutil.set_titles_and_labels(ax, maintitle="Darwin Southern Oscillation Index")


### PR DESCRIPTION
Closes #153 
In the NCL version of the xy_5 example, the datafile represents dates in a YYYYMM format. To make the plot, the NCL example first converts the dates into floats using a format where the decimal component represents a fraction of the year in place of months. 

The GeoCAT version of xy_5 uses another method to accurately plot the date while also converting the dates; however the fractional dates are never used and are also calculated incorrectly. This PR makes the GeoCAT example more accurate and consistent with the NCL one.