### PR TITLE
Added geographiclib to conda_environment

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - sphinx_rtd_theme
   - jupyter
   - make
+  - geographiclib


### PR DESCRIPTION
This PR adds geographiclib package dependency to conda environment in favor of PR #140  