### PR TITLE
Updating examples to use geocat-viz set_map_boundary()

### DIFF
--- a/Plots/Contours/NCL_conOncon_5.py
+++ b/Plots/Contours/NCL_conOncon_5.py
@@ -46,9 +46,9 @@ ax = plt.axes(projection=ccrs.NorthPolarStereo())
 # Add land feature to map
 ax.add_feature(cfeature.LAND, facecolor='lightgray')
 
-# Set extent to include latitudes between 0 and 40 and longitudes between
-# -180 and 180 only
-ax.set_extent([-180, 180, 0, 40], ccrs.PlateCarree())
+# Set map boundary to include latitudes between 0 and 40 and longitudes
+# between -180 and 180 only
+gvutil.set_map_boundary(ax, [-180, 180], [0, 40], south_pad=1)
 
 # Set draw_labels to False so that you can manually manipulate it later
 gl = ax.gridlines(
@@ -62,13 +62,6 @@ gl = ax.gridlines(
 # Manipulate latitude and longitude gridline numbers and spacing
 gl.ylocator = mticker.FixedLocator(np.arange(0, 90, 15))
 gl.xlocator = mticker.FixedLocator(np.arange(-180, 180, 30))
-
-# Set boundary to a circle
-theta = np.linspace(0, 2 * np.pi, 100)
-center, radius = [0.5, 0.5], 0.5
-verts = np.vstack([np.sin(theta), np.cos(theta)]).T
-circle = mpath.Path(verts * radius + center)
-ax.set_boundary(circle, transform=ax.transAxes)
 
 # Manipulate longitude labels (0, 30 E, 60 E, ..., 30 W, etc.)
 ticks = np.arange(0, 210, 30)

--- a/Plots/Contours/NCL_polar_1_lg.py
+++ b/Plots/Contours/NCL_polar_1_lg.py
@@ -43,9 +43,9 @@ projection = ccrs.NorthPolarStereo()
 ax = plt.axes(projection=projection)
 ax.add_feature(cfeature.LAND, facecolor='lightgray')
 
-# Set extent to include latitudes between 0 and 40 and longitudes between
-# -180 and 180 only
-ax.set_extent([-180, 180, 0, 40], ccrs.PlateCarree())
+# Set map boundary to include latitudes between 0 and 40 and longitudes
+# between -180 and 180 only
+gvutil.set_map_boundary(ax, [-180, 180], [0, 40], south_pad=1)
 
 # Set draw_labels to False so that you can manually manipulate it later
 gl = ax.gridlines(
@@ -57,13 +57,6 @@ gl = ax.gridlines(
 # Manipulate latitude and longitude gridline numbers and spacing
 gl.ylocator = mticker.FixedLocator(np.arange(0, 90, 15))
 gl.xlocator = mticker.FixedLocator(np.arange(-180, 180, 30))
-
-# Set boundary to a circle
-theta = np.linspace(0, 2 * np.pi, 100)
-center, radius = [0.5, 0.5], 0.5
-verts = np.vstack([np.sin(theta), np.cos(theta)]).T
-circle = mpath.Path(verts * radius + center)
-ax.set_boundary(circle, transform=ax.transAxes)
 
 # Manipulate longitude labels (0, 30 E, 60 E, ..., 30 W, etc.)
 ticks = np.arange(0, 210, 30)

--- a/Plots/Masking/NCL_lcmask_1.py
+++ b/Plots/Masking/NCL_lcmask_1.py
@@ -26,45 +26,6 @@ from geocat.viz import cmaps as gvcmaps
 from geocat.viz import util as gvutil
 
 ###############################################################################
-# Utility function to create a wedge shaped path for plot boundary:
-def wedge_boundary(ax, lon_range, lat_range, res=1):
-    """
-    Utility function to create a custom wedge shaped map boundary using given
-    ranges of longitudes and latitudes.
-
-    Args:
-
-        ax (:class:'matplotlib.axes'):
-            The axes to which the boundary will be applied.
-
-        lon_range (:class:'tuple'):
-            The two-tuple containting the start and end of the desired range of
-            longitudes. The first entry must be smaller than the second entry.
-            Both entries must be between [-180 , 180].
-
-        lat_range (:class:'tuple'):
-            The two-tuple containting the start and end of the desired range of
-            longitudes. The first entry must be smaller than the second entry.
-            Both entries must be between (-90 , 90).
-
-        res (:class:'int'):
-            The size of the incrementation for vertices in degrees. Default is
-            a vertex every one degree of longitude.
-
-    """
-
-    # Set extent of map
-    ax.set_extent([lon_range[0], lon_range[1], lat_range[0], lat_range[1]],
-                  ccrs.PlateCarree())
-    # Make a boundary path in PlateCarree projection begining in the bottom
-    # left and continuing anitclockwise creating a point every `res` degree
-    vertices = [(lon, lat_range[0]) for lon in range(lon_range[0], lon_range[1] + 1, res)] + \
-               [(lon, lat_range[1]) for lon in range(lon_range[1], lon_range[0] - 1, -res)]
-    boundary = mpath.Path(vertices)
-    ax.set_boundary(boundary, transform=ccrs.PlateCarree())
-
-
-###############################################################################
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into
@@ -128,7 +89,7 @@ ax = plt.axes(projection=proj)
 ax.coastlines(linewidth=0.5)
 
 # Make a custom boundary using convenience function
-wedge_boundary(ax, [-85, 40], [20, 80])
+gvutil.set_map_boundary(ax, [-85, 40], [20, 80], south_pad=1)
 
 # Plot data and create colorbar
 wind = masked.plot.contourf(ax=ax, cmap=newcmp, transform=ccrs.PlateCarree(),


### PR DESCRIPTION
Closes #91 
In addition to updating `NCL_lcmask_1.py` and `NCL_polar_1.lg.py`, this PR also updates `NCL_panel_6.py` and `NCL_conOncon_5.py` which use custom helper functions to draw circle boundaries for polar stereographic maps. Those examples were created after issue #91 and were not mentioned in it. The plots all appear the same as they did before this update.