### PR TITLE
Documentation generation failure

### DIFF
--- a/Plots/Bar/NCL_bar_7.py
+++ b/Plots/Bar/NCL_bar_7.py
@@ -113,5 +113,4 @@ gvutil.set_titles_and_labels(ax,
                              ylabel="Number of Deaths")
 
 # Show the plot
-plt.tight_layout()
 plt.show()

--- a/Plots/Bar/NCL_unique_5.py
+++ b/Plots/Bar/NCL_unique_5.py
@@ -113,5 +113,4 @@ gvutil.set_titles_and_labels(ax,
                              ylabel="(" + u'\N{DEGREE SIGN}' + "C)")
 
 # Show the plot
-plt.tight_layout()
 plt.show()

--- a/Plots/Contours/NCL_conOncon_1.py
+++ b/Plots/Contours/NCL_conOncon_1.py
@@ -89,5 +89,4 @@ axRHS.yaxis.label.set_size(20)
 axRHS.tick_params('both', length=20, width=2, which='major', labelsize=18)
 
 # Show the plot
-plt.tight_layout()
 plt.show()

--- a/Plots/Contours/NCL_conOncon_5.py
+++ b/Plots/Contours/NCL_conOncon_5.py
@@ -145,8 +145,5 @@ gvutil.set_titles_and_labels(ax,
                              lefttitle=slon.long_name,
                              righttitle=slon.units)
 
-# Make tight layout
-plt.tight_layout()
-
 # Show the plot
 plt.show()

--- a/Plots/Contours/NCL_hov_3.py
+++ b/Plots/Contours/NCL_hov_3.py
@@ -116,5 +116,4 @@ ax.text(1,
                   facecolor='white',
                   edgecolor='black'))
 
-plt.tight_layout()
 plt.show()

--- a/Plots/MapProjections/NCL_sat_1.py
+++ b/Plots/MapProjections/NCL_sat_1.py
@@ -413,7 +413,4 @@ ax.text(0.40,
         fontsize=16,
         bbox=props)
 
-# Make layout tight
-plt.tight_layout()
-
 plt.show()

--- a/Plots/MapProjections/NCL_sat_2.py
+++ b/Plots/MapProjections/NCL_sat_2.py
@@ -401,7 +401,4 @@ gl = ax.gridlines(color='gray', linestyle='--')
 gl.xlocator = mticker.FixedLocator(np.arange(-180, 180, 20))
 gl.ylocator = mticker.FixedLocator(np.arange(-90, 90, 20))
 
-# Make layout tight
-plt.tight_layout()
-
 plt.show()

--- a/Plots/MapProjections/NCL_sat_3.py
+++ b/Plots/MapProjections/NCL_sat_3.py
@@ -170,5 +170,4 @@ plotOrthoTicks([(-120, 60), (-60, 82.5)], 'top')
 plotOrthoTicks([(-75, 16.0), (-60, 25.0), (-45, 29.0), (-30, 29.5),
                 (-15, 26.5)], 'bottom')
 
-plt.tight_layout()
 plt.show()

--- a/Plots/Panels/NCL_panel_1.py
+++ b/Plots/Panels/NCL_panel_1.py
@@ -37,6 +37,8 @@ ds = xr.open_dataset(gdf.get("netcdf_files/uv300.nc")).isel(time=1)
 projection = ccrs.PlateCarree()
 fig, ax = plt.subplots(3,
                        1,
+                       figsize=(7, 10),
+                       gridspec_kw=dict(hspace=0.3),
                        subplot_kw={"projection": projection})
 
 # Set figure size (width, height) in inches
@@ -81,9 +83,9 @@ ax[0].clabel(hdl, np.arange(0, 32, 8), fontsize="small", fmt="%.0f")
 # Use geocat.viz.util convenience function to add left and right title to the plot axes.
 gvutil.set_titles_and_labels(ax[0],
                              lefttitle="Zonal Wind",
-                             lefttitlefontsize=12,
+                             lefttitlefontsize=10,
                              righttitle=ds.U.units,
-                             righttitlefontsize=12)
+                             righttitlefontsize=10)
 
 # Panel 2 (Subplot 2)
 # Contour-plot V data (for borderlines)
@@ -95,9 +97,9 @@ ax[1].clabel(hdl, [0], fontsize="small", fmt="%.0f")
 # Use geocat.viz.util convenience function to add left and right title to the plot axes.
 gvutil.set_titles_and_labels(ax[1],
                              lefttitle="Meridional Wind",
-                             lefttitlefontsize=12,
+                             lefttitlefontsize=10,
                              righttitle=ds.V.units,
-                             righttitlefontsize=12)
+                             righttitlefontsize=10)
 
 # Panel 3 (Subplot 3)
 # Draw arrows
@@ -119,9 +121,9 @@ ax[2].set_title("Vector Wind", loc="left", y=1.05)
 # Use geocat.viz.util convenience function to add left and right title to the plot axes.
 gvutil.set_titles_and_labels(ax[2],
                              lefttitle="Vector Wind",
-                             lefttitlefontsize=12,
+                             lefttitlefontsize=10,
                              righttitle=ds.U.units,
-                             righttitlefontsize=12)
+                             righttitlefontsize=10)
 
 # cartopy axes require this to be manual
 ax[2].set_xticks(kwargs["xticks"])

--- a/Plots/Panels/NCL_panel_1.py
+++ b/Plots/Panels/NCL_panel_1.py
@@ -33,13 +33,10 @@ ds = xr.open_dataset(gdf.get("netcdf_files/uv300.nc")).isel(time=1)
 # Plot:
 
 # Make three panels (i.e. subplots in matplotlib)
-# Specify ``constrained_layout=True`` to automatically layout panels, colorbars and axes decorations nicely.
-# See https://matplotlib.org/tutorials/intermediate/constrainedlayout_guide.html
 # Generate figure and axes using Cartopy projection
 projection = ccrs.PlateCarree()
 fig, ax = plt.subplots(3,
                        1,
-                       constrained_layout=True,
                        subplot_kw={"projection": projection})
 
 # Set figure size (width, height) in inches

--- a/Plots/Panels/NCL_panel_13.py
+++ b/Plots/Panels/NCL_panel_13.py
@@ -59,7 +59,6 @@ fig, axs = plt.subplots(2,
                         1,
                         figsize=(7, 10),
                         subplot_kw={"projection": projection})
-plt.tight_layout(pad=4, h_pad=-5)
 
 # Add coastlines, the zorder keyword specifies the order in which the elements
 # are drawn where elements with lower zorder values are drawn first

--- a/Plots/Panels/NCL_panel_3.py
+++ b/Plots/Panels/NCL_panel_3.py
@@ -105,10 +105,9 @@ def plot_labelled_filled_contours(data, ax=None):
 projection = ccrs.PlateCarree()
 fig, ax = plt.subplots(2,
                        1,
+                       figsize=(8, 12),
+                       gridspec_kw=dict(hspace=0.3),
                        subplot_kw={"projection": projection})
-
-# Set figure size (width, height) in inches
-fig.set_size_inches((8, 8.2))
 
 # Define the contour levels
 levels = np.linspace(-10, 50, 13)
@@ -128,7 +127,10 @@ cbar = plt.colorbar(handles["filled"],
                     orientation="horizontal",
                     ticks=levels[:-1],
                     drawedges=True,
-                    aspect=30)
+                    aspect=30,
+                    pad = 0.05,
+                    fraction=0.4)
+
 cbar.ax.tick_params(labelsize=10)
 
 # Show the plot

--- a/Plots/Panels/NCL_panel_3.py
+++ b/Plots/Panels/NCL_panel_3.py
@@ -101,13 +101,10 @@ def plot_labelled_filled_contours(data, ax=None):
 # Plot:
 
 # Make two panels (i.e. subplots in matplotlib)
-# Specify ``constrained_layout=True`` to automatically layout panels, colorbars and axes decorations nicely.
-# See https://matplotlib.org/tutorials/intermediate/constrainedlayout_guide.html
 # Generate figure and axes using Cartopy projection
 projection = ccrs.PlateCarree()
 fig, ax = plt.subplots(2,
                        1,
-                       constrained_layout=True,
                        subplot_kw={"projection": projection})
 
 # Set figure size (width, height) in inches

--- a/Plots/Panels/NCL_panel_3.py
+++ b/Plots/Panels/NCL_panel_3.py
@@ -128,7 +128,7 @@ cbar = plt.colorbar(handles["filled"],
                     ticks=levels[:-1],
                     drawedges=True,
                     aspect=30,
-                    pad = 0.05,
+                    pad=0.05,
                     fraction=0.4)
 
 cbar.ax.tick_params(labelsize=10)

--- a/Plots/Scatter/NCL_scatter_4.py
+++ b/Plots/Scatter/NCL_scatter_4.py
@@ -74,5 +74,4 @@ gvutil.set_titles_and_labels(ax,
                              ylabel="Surface temperature")
 
 # Show the plot
-plt.tight_layout()
 plt.show()

--- a/Plots/Streamlines/NCL_stream_1.py
+++ b/Plots/Streamlines/NCL_stream_1.py
@@ -84,5 +84,4 @@ gvutil.set_titles_and_labels(ax,
                              ylabel="")
 
 # Show the plot
-plt.tight_layout()
 plt.show()

--- a/Plots/Tables/NCL_table_2.py
+++ b/Plots/Tables/NCL_table_2.py
@@ -79,7 +79,5 @@ plt.table(cellText=[['CAM METRICS']],
           cellLoc='center',
           bbox=[-.694, .815, 0.694, 0.091])
 
-# Give plot a tight layout
-fig.tight_layout()
 
 plt.show()

--- a/Plots/Vectors/NCL_vector_4.py
+++ b/Plots/Vectors/NCL_vector_4.py
@@ -113,6 +113,5 @@ ax.add_feature(cartopy.feature.LAND,
                facecolor='lightgray',
                zorder=0)
 
-# Generate plot!
-plt.tight_layout()
+# Generate plot
 plt.show()

--- a/Plots/XY/NCL_xy_18.py
+++ b/Plots/XY/NCL_xy_18.py
@@ -242,5 +242,4 @@ ax.fill_between(time, gavan_min, gavan_max, color='lightblue', zorder=0)
 ax.fill_between(time, gavav_min, gavav_max, color='lightpink', zorder=1)
 
 # Show the plot
-plt.tight_layout()
 plt.show()

--- a/Plots/XY/NCL_xy_2_1.py
+++ b/Plots/XY/NCL_xy_2_1.py
@@ -72,5 +72,4 @@ gvutil.set_titles_and_labels(ax,
                              ylabel="Zonal Wind")
 
 # Show the plot
-plt.tight_layout()
 plt.show()

--- a/Plots/XY/NCL_xy_7_2.py
+++ b/Plots/XY/NCL_xy_7_2.py
@@ -81,5 +81,4 @@ gvutil.set_axes_limits_and_ticks(ax2,
 ax2.set_ylabel(f"{ds.P.long_name} [dash]", fontsize=16)
 
 # Show the plot
-plt.tight_layout()
 plt.show()


### PR DESCRIPTION
Closes #235 

Fixes sphinx documentation generation errors by:

- Removing `plt.tight_layout()` calls from the following files:
Plots/Bar/NCL_bar_7.py
Plots/Bar/NCL_unique_5.py
Plots/Contours/NCL_conOncon_1.py
Plots/Contours/NCL_conOncon_5.py
Plots/Contours/NCL_hov_3.py
Plots/MapProjections/NCL_sat_1.py
Plots/MapProjections/NCL_sat_2.py
Plots/MapProjections/NCL_sat_3.py
Plots/Panels/NCL_panel_13.py
Plots/Scatter/NCL_scatter_4.py
Plots/Streamlines/NCL_stream_1.py
Plots/Tables/NCL_table_2.py
Plots/Vectors/NCL_vector_4.py
Plots/XY/NCL_xy_18.py
Plots/XY/NCL_xy_2_1.py
Plots/XY/NCL_xy_7_2.py

- Removing `constrained_layout=True `and re doing plot layouts on:
Plots/Panels/NCL_panel_1.py
Plots/Panels/NCL_panel_3.py