### PR TITLE
Fix workflow not triggering from forked repo issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
     - '*'
+  pull_request_target:
+    branches:
+    - '*'
 
 jobs:
   build-and-run:


### PR DESCRIPTION
Adds `pull_request_target` event into `.github/workflows/build.yml` per the following improvement from this [Github anouncement](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) :

"GitHub Actions has always been about more than just continuous integration. Our goal is to enable repository maintainers to automate a variety of workflows and reduce manual effort. In order to protect public repositories for malicious users we run all pull request workflows raised from repository forks with a read-only token and no access to secrets. This makes common workflows like labeling or commenting on pull requests very difficult.

In order to solve this, we’ve added a new `pull_request_target` event, which behaves in an almost identical way to the `pull_request` event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well."