### PR TITLE
Fix geocat.comp import issue by forcing python=3.7

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - ncar
 dependencies:
-  - python=3
+  - python=3.7
   - geocat-comp
   - geocat-datafiles
   - geocat-viz=2020.7.30.1


### PR DESCRIPTION
Fixes the recent RTD and Github actions build issues due to importing `eofunc` from `geocat.comp`