### PR TITLE
Datashader

### DIFF
--- a/Plots/Line/NCL_leg_1.ipynb
+++ b/Plots/Line/NCL_leg_1.ipynb
@@ -1,0 +1,105 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"\n",
+    "NCL_leg_1.py\n",
+    "===============\n",
+    "This script illustrates the following concepts:\n",
+    "   - Drawing a legend inside an XY plot\n",
+    "   - Changing the width and height of a legend\n",
+    "   - Turning off the perimeter around a legend\n",
+    "   - Changing the font size of legend labels\n",
+    "   - Customizing the labels in a legend\n",
+    "\n",
+    "See following URLs to see the reproduced NCL plot & script:\n",
+    "    - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/leg_1.ncl\n",
+    "    - Original NCL plot: https://www.ncl.ucar.edu/Applications/Images/leg_1_lg.png\n",
+    "\"\"\"\n",
+    "\n",
+    "###############################################################################\n",
+    "# Import packages:\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import holoviews as hv\n",
+    "\n",
+    "import geocat.datafiles as gdf\n",
+    "from geocat.viz import util as gvutil\n",
+    "\n",
+    "hv.extension(\"matplotlib\",\"bokeh\")\n",
+    "\n",
+    "###############################################################################\n",
+    "# Read in data:\n",
+    "\n",
+    "# Open a netCDF data file using xarray default engine and load the data into xarrays\n",
+    "ds = xr.open_dataset(gdf.get(\"netcdf_files/uv300.nc\"))\n",
+    "# Extract variables\n",
+    "uz = ds.U.isel(time=0).mean(dim=['lon'])\n",
+    "vz = ds.V.isel(time=0).mean(dim=['lon'])\n",
+    "\n",
+    "###############################################################################\n",
+    "# Plot:\n",
+    "\n",
+    "# basic version (works with Matplotlib or Bokeh plotting)\n",
+    "hv.Curve(vz, label=\"V\") * hv.Curve(uz, label=\"U\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# customized Matplotlib plot\n",
+    "hv.output(backend='matplotlib')\n",
+    "\n",
+    "ticks = list(zip(np.linspace(-90, 90, 7), ['90S', '60S', '30S', '0', '30N', '60N', '90N']))\n",
+    "\n",
+    "vc = hv.Curve(vz, label=\"V\").opts(color=\"gray\", linestyle='--') \n",
+    "uc = hv.Curve(uz, label=\"U\").opts(color=\"gray\")\n",
+    "\n",
+    "(vc * uc).opts(xticks=ticks, show_legend=True, legend_opts=dict(loc=\"upper left\"), fig_inches=5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# customized Bokeh plot\n",
+    "hv.output(backend='bokeh')\n",
+    "\n",
+    "vc = hv.Curve(vz, label=\"V\").opts(color=\"gray\", line_dash='dashed', tools=['hover']) \n",
+    "uc = hv.Curve(uz, label=\"U\").opts(color=\"gray\", tools=['hover'])\n",
+    "\n",
+    "(vc * uc).opts(xticks=ticks, legend_opts={\"location\":\"top_right\"}, width=350, height=350)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/Plots/Line/NCL_leg_1.py
+++ b/Plots/Line/NCL_leg_1.py
@@ -17,10 +17,12 @@ See following URLs to see the reproduced NCL plot & script:
 # Import packages:
 import numpy as np
 import xarray as xr
-import matplotlib.pyplot as plt
+import holoviews as hv
 
 import geocat.datafiles as gdf
 from geocat.viz import util as gvutil
+
+hv.extension("matplotlib")
 
 ###############################################################################
 # Read in data:
@@ -34,29 +36,13 @@ vz = ds.V.isel(time=0).mean(dim=['lon'])
 ###############################################################################
 # Plot:
 
-# Generate figure (set its size (width, height) in inches) and axes
-plt.figure(figsize=(5, 5))
-ax = plt.gca()
+# basic version (works with Matplotlib or Bokeh plotting)
+basic = hv.Curve(vz, label="V") * hv.Curve(uz, label="U")
+hv.save(basic, "/tmp/basic.png", fmt='png')
 
-# Plot data and add a legend
-plt.plot(vz.lat, vz.values, '--', dashes=[6.5, 3.7], c='gray', label='V')
-plt.plot(uz.lat, uz.values, c='gray', label='U')
-plt.legend(loc='upper left', frameon=False, prop={'weight': 'bold'})
-
-# Use geocat.viz.util convenience function to add minor and major tick lines
-gvutil.add_major_minor_ticks(ax,
-                             x_minor_per_major=3,
-                             y_minor_per_major=5,
-                             labelsize=12)
-
-# Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
-# Set axes limits, tick values, and tick labels to show latitude & longitude (i.e. North (N) - South (S))
-gvutil.set_axes_limits_and_ticks(
-    ax,
-    xlim=(-90, 90),
-    ylim=(-10, 40),
-    xticks=np.linspace(-90, 90, 7),
-    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'])
-
-# Show the plot
-plt.show()
+# customized Matplotlib plot
+ticks = list(zip(np.linspace(-90, 90, 7), ['90S', '60S', '30S', '0', '30N', '60N', '90N']))
+vc = hv.Curve(vz, label="V").opts(color="gray", linestyle='--') 
+uc = hv.Curve(uz, label="U").opts(color="gray")
+custom = (vc * uc).opts(xticks=ticks, show_legend=True, legend_opts=dict(loc="upper left"), fig_inches=5)
+hv.save(custom, "/tmp/custom.png", fmt='png')

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -1,7 +1,8 @@
 name: geocat-examples
 channels:
-  - conda-forge
+  - pyviz
   - ncar
+  - conda-forge
 dependencies:
   - python=3
   - geocat-comp
@@ -22,3 +23,6 @@ dependencies:
   - geographiclib
   - wrf-python
   - metpy
+  - datashader
+  - hvplot
+  - geoviews


### PR DESCRIPTION
Speculative branch for exploring Datashader, HoloViews, and GeoViews. Fine to merge to the `datashader` branch, but not to master.

So far, includes changes to three files:

- conda_environment.yml
   * Added datashader, hvplot, and geoviews
   * Added the pyviz channel, as that's always the most up to date and is faster when used with conda's strict channel priority due to it being a small channel, but conda-forge alone probably works fine too.
   * Creating the environment is _very_ slow with or without strict channel priority.
- NCL_leg_1.py
   * Very simple example of a plot with a legend, using HoloViews+Matplotlib
   * Basic plot is only one line of code (`hv.Curve(vz, label="V") * hv.Curve(uz, label="U")`)
   * Customized to look like the original takes four lines of code
- NCL_leg_1.ipynb
   * Jupyter Notebook version of NCL_leg_1.py
   * Shows off Bokeh-based interactive plots (with hover, zoom, etc.)
   * Launch with `jupyter notebook NCL_leg_1.ipynb`, then Run All
- issue272_case2i_ds.py
   * Extended with a context manager to do timings
   * Sent output to a PNG to allow accurate timing comparisons
   * Accepted a command-line argument `factor` for selecting the resolution; higher values make it quicker to run
   * Compares timings for Matplotlib-based and SciPy-based Delaunay triangulation (704 vs 529 seconds at 10km res)
   * Compares timings for Matplotlib-based and Datashader-based trimesh plotting (113 vs 3 seconds at 10km res)
   
The full timings for issue272_case2i_ds.py on my MacBook Pro are:

$ python issue272_case2i_ds.py 200
MPL Triangulation takes: 0.0015921592712402344 seconds
SciPy Triangulation takes: 0.002576112747192383 seconds
Datashader-based rendering 1 takes: 1.8307688236236572 seconds
Datashader-based rendering 2 takes: 0.3103179931640625 seconds
Matplotlib-based rendering takes: 0.17391610145568848 seconds

$ python issue272_case2i_ds.py 10
MPL Triangulation takes: 0.7670328617095947 seconds
SciPy Triangulation takes: 0.8238921165466309 seconds
Datashader-based rendering 1 takes: 1.839228868484497 seconds
Datashader-based rendering 2 takes: 0.40596699714660645 seconds
Matplotlib-based rendering takes: 1.5457789897918701 seconds

$ python issue272_case2i_ds.py 5
MPL Triangulation takes: 3.4231629371643066 seconds
SciPy Triangulation takes: 3.4271531105041504 seconds
Datashader-based rendering 1 takes: 1.807750940322876 seconds
Datashader-based rendering 2 takes: 0.47564196586608887 seconds
Matplotlib-based rendering takes: 4.945454120635986 seconds

$ python issue272_case2i_ds.py 1
MPL Triangulation takes: 704.985121011734 seconds
SciPy Triangulation takes: 529.0948584079742 seconds
Datashader-based rendering 1 takes: 9.263015031814575 seconds
Datashader-based rendering 2 takes: 3.3065507411956787 seconds
Matplotlib-based rendering takes: 113.213791847229 seconds

Note that in issue272_case2i_ds.py the `np.arange()` calls don't actually cover `lon_max` or `lat_max`, which you can see clearly in the factor=200 run (big whitespace on top and right of plot). Probably `np.linspace()` is more appropriate here, but even then you have to worry what happens at the latitude edge; presumably those values should be copied from one edge to the other.

# Takeaways

- SciPy's Delaunay triangulation is a bit faster for large arrays, but maybe not that dramatically
- Datashader's first rendering is more than 10X faster than Matplotlib for large arrays
- Datashader is another 3X faster for subsequent renderings, which probably (untested) is what applies to interactive usage
- Triangulation dominates the overall time, but in practice I think most people with gridded data will create the grid once and render data on that grid many times, so the rendering step seems more important to speed up.
