### PR TITLE
Github actions build failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Create conda environment
-      uses: goanpeca/setup-miniconda@v2
+      uses: goanpeca/setup-miniconda@v1
       with:
          activate-environment: geocat-examples
          environment-file: conda_environment.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Create conda environment
+      env: 
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       uses: goanpeca/setup-miniconda@v1
       with:
          activate-environment: geocat-examples

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Create conda environment
-      uses: goanpeca/setup-miniconda@v1
+      uses: goanpeca/setup-miniconda@v2
       with:
          activate-environment: geocat-examples
          environment-file: conda_environment.yml


### PR DESCRIPTION
Addresses #292 

There is a ticket working its way through the action on github now, so I assume the issue will eventually be resolved by itself, but for now, to allow the commands ```add-path``` and ```set-env``` to run as before, I added the ```ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true' ``` tag to the build.yml file as suggested in the error read out. This allows the two deprecated commands to still be used in our build process while the action we are using updates.