### PR TITLE
Remove "Edit on Github" buttons from RTD builds

### DIFF
--- a/_templates/breadcrumbs.html
+++ b/_templates/breadcrumbs.html
@@ -1,0 +1,4 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% endblock %}

--- a/index.rst
+++ b/index.rst
@@ -12,6 +12,7 @@ Welcome to GeoCAT-examples's documentation!
 
    ./gallery/index.rst
    ./install.rst
+   ./support.rst
 
 
 Indices and tables

--- a/support.rst
+++ b/support.rst
@@ -1,0 +1,14 @@
+Support
+==========
+
+GitHub
+----------------
+
+For crashes and other issues related to the software,
+you can submit an issue to the
+`GitHub repository <https://github.com/NCAR/geocat-examples>`_.
+
+This should be used strictly for crashes and bugs.  For general usage
+questions, please submit an issue to the
+`GeoCAT project GitHub repository <https://github.com/NCAR/geocat>`_.
+


### PR DESCRIPTION
Addresses #298 

Summary of changes:
- overrides sphinx theme read the docs button

I have made the [sphinx_delete branch visible on RTD](https://geocat-examples.readthedocs.io/en/sphinx_delete/) so you can go look at how the change affects the documentation generation.