### PR TITLE
Added GeoCAT-comp usage examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /_build/
 /gallery/
+/gallery-geocat-comp/
 *.ncl
 .vscode/
 .idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ following contribution guidelines:
 1. Please check the followings to ensure that the example you are about to work on has not been ported yet:
     
     - [GeoCAT-Examples Gallery](https://geocat-examples.readthedocs.io/en/latest/) or 
-    the `Plots` as well as `GeoCAT-comp` directories of this repo,
+    the `Plots` as well as `GeoCAT-comp-examples` directories of this repo,
     
     - The list of [Issues](https://github.com/NCAR/GeoCAT-examples/issues) for this repo to see if any of 
     the existing to-do items are something you might be interested in working on. 

--- a/GeoCAT-comp-examples/README.rst
+++ b/GeoCAT-comp-examples/README.rst
@@ -14,9 +14,8 @@ characteristics.
 
 For visualization, mainly `matplotlib` and `cartopy` are used. In addition,
 `geocat-datafiles <https://github.com/NCAR/geocat-datafiles>`_ is used as a
-dataset storage, `geocat-viz <https://github.com/NCAR/geocat-viz>`_ is used for
-a higher level implementation for low level `matplotlib` functionalities, as
-well as `xarray` and `numpy` are used for data processing.
+dataset storage and `geocat-viz <https://github.com/NCAR/geocat-viz>`_ is used for
+a higher level implementation for low level `matplotlib` functionalitie., `Xarray` and `numpy` are used for data processing.
 
 Click on any image to see the full image and source code as well as to
 download Python script and/or Jupyter notebook.

--- a/GeoCAT-comp-examples/README.rst
+++ b/GeoCAT-comp-examples/README.rst
@@ -15,7 +15,8 @@ characteristics.
 For visualization, mainly `matplotlib` and `cartopy` are used. In addition,
 `geocat-datafiles <https://github.com/NCAR/geocat-datafiles>`_ is used as a
 dataset storage and `geocat-viz <https://github.com/NCAR/geocat-viz>`_ is used for
-a higher level implementation for low level `matplotlib` functionalitie., `Xarray` and `numpy` are used for data processing.
+a higher level implementation for low level `matplotlib` functionalitie.
+`Xarray` and `numpy` are used for data processing.
 
 Click on any image to see the full image and source code as well as to
 download Python script and/or Jupyter notebook.

--- a/GeoCAT-comp-examples/README.rst
+++ b/GeoCAT-comp-examples/README.rst
@@ -1,13 +1,16 @@
-.. _examples-index:
+.. _comp-examples-index:
 
-.. _gallery:
+.. _gallery-geocat-comp:
 
-=======
-Gallery
-=======
+====================
+GeoCAT-comp Examples
+====================
 
-This gallery contains visualization examples from many plotting categories
-for geosciences data.
+This gallery contains usage examples for the GeoCAT-comp functions.
+These examples are represented as Python scripts and their
+corresponding Jupyter notebooks, which may or may not contain
+visualizations (i.e. Matplotlib plots), depending on the function
+characteristics.
 
 For visualization, mainly `matplotlib` and `cartopy` are used. In addition,
 `geocat-datafiles <https://github.com/NCAR/geocat-datafiles>`_ is used as a

--- a/GeoCAT-comp-examples/comp_only/README.rst
+++ b/GeoCAT-comp-examples/comp_only/README.rst
@@ -1,0 +1,6 @@
+.. _computation-only-examples:
+
+.. _computation-only-examples-index:
+
+Computation-only
+================

--- a/GeoCAT-comp-examples/comp_only/moc_globe_atl_example.py
+++ b/GeoCAT-comp-examples/comp_only/moc_globe_atl_example.py
@@ -1,0 +1,92 @@
+"""
+moc_globe_atl_example.py
+========================
+
+This script illustrates the following concepts:
+   - Usage of geocat-comp's `moc_globe_atl` function
+   - Computing POP MOC field offline from POP netcdf history files (designed for the CESM4 ocean component)
+   - Usage of geocat-datafiles for accessing NetCDF files
+   - Usage of geocat-viz plotting convenience functions
+
+See following GitHub repositories to see further information about the function and to access data:
+    - For `moc_globe_atl` function: https://github.com/NCAR/geocat-comp
+    - For "tavg_downsized.nc" file: https://github.com/NCAR/geocat-datafiles/tree/main/netcdf_files
+
+Dependencies:
+    - geocat.comp
+    - geocat.datafiles (Not necessary but for conveniently accessing the NetCDF data file)
+    - numpy
+    - xarray
+
+"""
+
+###############################################################################
+# Import packages:
+
+import numpy as np
+import xarray as xr
+
+import geocat.datafiles as gdf
+from geocat.comp import moc_globe_atl
+
+
+###############################################################################
+# Read in data:
+
+# Open a netCDF data file using xarray default engine and load the data
+# into xarrays
+ds = xr.open_dataset(gdf.get('netcdf_files/tavg_downsized.nc'))
+
+lat_aux_grid = ds.lat_aux_grid[:].values.astype(np.double)
+w_e = ds.WVEL[:].values.astype(np.double)
+w_i = ds.WISOP[:].values.astype(np.double)
+w_sm = ds.WSUBM[:].values.astype(np.double)
+tarea = ds.TAREA[:]
+rmask = ds.REGION_MASK[:]
+kmt = ds.KMT[:]
+tlat = ds.TLAT[:].values.astype(np.double)
+
+# Read important parameters from input data
+nyaux = lat_aux_grid.shape[0]  # 395
+km = np.max(kmt.values).astype(np.int)
+ny = tarea.shape[0]
+nx = tarea.shape[1]
+
+
+###############################################################################
+# Generate the data needed for function call:
+
+# Generate rmlak: region_mask_lat_aux
+rmlak = np.tile(rmask, (2, 1, 1)).astype(np.int32)
+rmlak[0, :, :] = np.where(rmask > 0, 1, 0)
+rmlak[1, :, :] = np.where(np.logical_and(rmask >= 6, rmask <= 11), 1, 0)
+# todo Convert rmlak to xArray
+
+# Generate a_wvel, a_bolus, and a_submeso
+k3d = np.repeat(np.repeat(np.arange(0, km, 1).reshape(km, 1), ny,
+                          axis=1)[:, :, np.newaxis],
+                nx,
+                axis=2)
+kmt3d = np.repeat(kmt.values[np.newaxis, :, :], km, axis=0)
+tarea3d = np.repeat(tarea.values[np.newaxis, :, :], km, axis=0)
+ocean = k3d <= kmt3d
+
+a_wvel = np.where(ocean, w_e[0, :, :, :] * tarea3d, 0.0)
+a_bolus = np.where(ocean, w_i[0, :, :, :] * tarea3d, 0.0)
+a_submeso = np.where(ocean, w_sm[0, :, :, :] * tarea3d, 0.0)
+
+
+###############################################################################
+# GeoCAT-comp function call:
+
+# Invoke `moc_globe_atl` from `geocat-comp`
+result = moc_globe_atl(lat_aux_grid,
+                                   a_wvel,
+                                   a_bolus,
+                                   a_submeso,
+                                   tlat,
+                                   rmlak,
+                                   msg=None,
+                                   meta=False)
+
+print("moc_globe_atl successfully generated output.")

--- a/GeoCAT-comp-examples/matplotlib/README.rst
+++ b/GeoCAT-comp-examples/matplotlib/README.rst
@@ -1,0 +1,6 @@
+.. _comp-vis-examples:
+
+.. _comp-vis-examples-index:
+
+Computation & visualization
+===========================

--- a/GeoCAT-comp-examples/matplotlib/linint2_example.py
+++ b/GeoCAT-comp-examples/matplotlib/linint2_example.py
@@ -1,0 +1,138 @@
+"""
+linint2_example.py
+==================
+
+This script illustrates the following concepts:
+   - Usage of geocat-comp's `linint2` function
+   - Bilinear Interpolation from a rectilinear grid to another rectilinear grid
+   - Usage of geocat-datafiles for accessing NetCDF files
+   - Usage of geocat-viz plotting convenience functions
+
+See following GitHub repositories to see further information about the function and to access data:
+    - For `linint2` function: https://github.com/NCAR/geocat-comp
+    - For "sst.nc" file: https://github.com/NCAR/geocat-datafiles/tree/main/netcdf_files
+
+Dependencies:
+    - geocat.comp
+    - geocat.datafiles (Not necessary but for conveniently accessing the NetCDF data file)
+    - geocat.viz (Not necessary but for plotting convenience)
+    - numpy
+    - xarray
+    - cartopy
+    - matplotlib
+    - mpl_toolkits
+"""
+
+###############################################################################
+# Import packages:
+
+import numpy as np
+import xarray as xr
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+from matplotlib import cm
+from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+from cartopy.mpl.geoaxes import GeoAxes
+from mpl_toolkits.axes_grid1 import AxesGrid
+
+import geocat.datafiles as gdf
+from geocat.comp import linint2
+import geocat.viz.util as gvutil
+
+
+###############################################################################
+# Read in data:
+
+# Open a netCDF data file using xarray default engine and load the data
+# into xarray.DataArrays
+ds = xr.open_dataset(gdf.get('netcdf_files/sst.nc'))
+sst = ds.TEMP[0, 0, :, :].chunk()
+lat = ds.LAT[:]
+lon = ds.LON[:]
+
+
+###############################################################################
+# GeoCAT-comp function call:
+
+# Provide (output) interpolation grid
+newlat = np.linspace(min(lat), max(lat), 24)
+newlon = np.linspace(min(lon), max(lon), 72)
+
+# Invoke `linint2` from `geocat.comp`
+newsst = linint2(sst, newlon, newlat, icycx=False)
+
+###############################################################################
+# Plot:
+
+# Generate figure and set its size (width, height) in inches
+fig = plt.figure(figsize=(10, 8))
+
+# Generate Axes grid using a Cartopy projection
+projection = ccrs.PlateCarree()
+axes_class = (GeoAxes, dict(map_projection=projection))
+axgr = AxesGrid(fig,
+                111,
+                axes_class=axes_class,
+                nrows_ncols=(2, 1),
+                axes_pad=0.7,
+                cbar_location='right',
+                cbar_mode='single',
+                cbar_pad=0.5,
+                cbar_size='3%',
+                label_mode='')  # note the empty label_mode
+
+# Create a dictionary for common plotting options for both subplots
+plot_options = dict(transform=projection,
+                    cmap=cm.jet,
+                    vmin=-30,
+                    vmax=30,
+                    levels=16,
+                    extend='neither',
+                    add_colorbar=False,
+                    add_labels=False)
+
+# Plot original grid and linint2 interpolations as two subplots
+# within the figure
+for i, ax in enumerate(axgr):
+
+    # Plot contours for both the subplots
+    if (i == 0):
+        sst.plot.contourf(ax=ax, **plot_options)
+        ax.set_title('Original Grid',
+                     fontsize=14,
+                     fontweight='bold',
+                     y=1.04)
+    else:
+        p = newsst.plot.contourf(ax=ax, **plot_options)
+        ax.set_title('Regrid (to coarse) - linint2',
+                     fontsize=14,
+                     fontweight='bold',
+                     y=1.04)
+
+    # Add coastlines to the subplots
+    ax.coastlines()
+
+    # Use geocat.viz.util convenience function to add minor and major tick
+    # lines
+    gvutil.add_major_minor_ticks(ax)
+
+    # Use geocat.viz.util convenience function to set axes limits & tick
+    # values without calling several matplotlib functions
+    gvutil.set_axes_limits_and_ticks(ax,
+                                     xticks=np.linspace(-180, 180, 13),
+                                     yticks=np.linspace(-60, 60, 5))
+
+    # Use geocat.viz.util convenience function to make plots look like NCL
+    # plots by using latitude, longitude tick labels
+    gvutil.add_lat_lon_ticklabels(ax, zero_direction_label=False)
+
+
+# Add color bar and label details (title, size, etc.)
+cax = axgr.cbar_axes[0]
+cax.colorbar(p)
+axis = cax.axis[cax.orientation]
+axis.label.set_text(r'Temperature ($^{\circ} C$)')
+axis.label.set_size(16)
+axis.major_ticklabels.set_size(10)
+
+plt.show()

--- a/GeoCAT-comp-examples/matplotlib/linint2pts_example.py
+++ b/GeoCAT-comp-examples/matplotlib/linint2pts_example.py
@@ -1,0 +1,140 @@
+"""
+linint2pts_example.py
+=====================
+
+This script illustrates the following concepts:
+   - Usage of geocat-comp's `linint2pts` function
+   - Bilinear interpolation from a rectilinear grid to an unstructured grid or locations
+   - Usage of geocat-datafiles for accessing NetCDF files
+   - Usage of geocat-viz plotting convenience functions
+
+See following GitHub repositories to see further information about the function and to access data:
+    - For `linint2pts` function: https://github.com/NCAR/geocat-comp
+    - For "sst.nc" data file: https://github.com/NCAR/geocat-datafiles/tree/main/netcdf_files
+
+Dependencies:
+    - geocat.comp
+    - geocat.datafiles (Not necessary but for conveniently accessing the NetCDF data file)
+    - geocat.viz (Not necessary but for plotting convenience)
+    - numpy
+    - xarray
+    - cartopy
+    - matplotlib
+    - mpl_toolkits
+"""
+
+###############################################################################
+# Import packages:
+
+from geocat.comp import linint2pts
+import geocat.datafiles as gdf
+import geocat.viz.util as gvutil
+
+import numpy as np
+import xarray as xr
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+from matplotlib import cm
+from cartopy.mpl.geoaxes import GeoAxes
+from mpl_toolkits.axes_grid1 import AxesGrid
+
+###############################################################################
+# Read in data:
+
+# Open a netCDF data file (Sea surface temperature) using xarray default
+# engine and load the data into xarrays
+ds = xr.open_dataset(gdf.get('netcdf_files/sst.nc'))
+
+sst = ds.TEMP[0, 0, :, :].chunk()
+lat = ds.LAT[:]
+lon = ds.LON[:]
+
+
+###############################################################################
+# GeoCAT-comp function call:
+
+# Provide (output) interpolation locations. This script uses 3000 arbitrary
+# locations world-wide in order to demonstrate an extensive comparison of the
+# linint2pts outputs to the original grid throughout the globe. The function
+# can even be used for a single location though.
+newlat = np.random.uniform(low=min(lat), high=max(lat), size=(3000,))
+newlon = np.random.uniform(low=min(lon), high=max(lon), size=(3000,))
+
+# Call `linint2pts` from `geocat-comp`
+newsst = linint2pts(sst, newlon, newlat, False)
+
+###############################################################################
+# Plot:
+
+# Generate figure and set its size (width, height) in inches
+fig = plt.figure(figsize=(10, 8))
+
+# Generate Axes grid using a Cartopy projection
+projection = ccrs.PlateCarree()
+axes_class = (GeoAxes, dict(map_projection=projection))
+axgr = AxesGrid(fig,
+                111,
+                axes_class=axes_class,
+                nrows_ncols=(2, 1),
+                axes_pad=0.7,
+                cbar_location='right',
+                cbar_mode='single',
+                cbar_pad=0.5,
+                cbar_size='3%',
+                label_mode='')
+
+# Create a dictionary for common plotting options for both subplots
+common_options = dict(vmin=-30, vmax=30, cmap=cm.jet)
+
+# Plot original grid and linint2pts interpolations as two subplots
+# within the figure
+for i, ax in enumerate(axgr):
+
+    # Plot original grid and linint2pts interpolations within the subplots
+    if (i == 0):
+        p = sst.plot.contourf(ax=ax,
+                              **common_options,
+                              transform=projection,
+                              levels=16,
+                              extend='neither',
+                              add_colorbar=False,
+                              add_labels=False)
+        ax.set_title('Sea Surface Temperature - Original Grid',
+                     fontsize=14,
+                     fontweight='bold',
+                     y=1.04)
+    else:
+        ax.scatter(newlon, newlat, c=newsst, **common_options, s=25)
+        ax.set_title(
+            'linint2pts - Bilinear interpolation for 3000 random locations',
+            fontsize=14,
+            fontweight='bold',
+            y=1.04)
+
+    # Add coastlines to the subplots
+    ax.coastlines()
+
+    # Use geocat.viz.util convenience function to add minor and major tick
+    # lines
+    gvutil.add_major_minor_ticks(ax)
+
+    # Use geocat.viz.util convenience function to set axes limits & tick
+    # values without calling several matplotlib functions
+    gvutil.set_axes_limits_and_ticks(ax,
+                                     ylim=(-60, 60),
+                                     xticks=np.linspace(-180, 180, 13),
+                                     yticks=np.linspace(-60, 60, 5))
+
+    # Use geocat.viz.util convenience function to make plots look like NCL
+    # plots by using latitude, longitude tick labels
+    gvutil.add_lat_lon_ticklabels(ax, zero_direction_label=False)
+
+# Add color bar and label details (title, size, etc.)
+cax = axgr.cbar_axes[0]
+cax.colorbar(p)
+axis = cax.axis[cax.orientation]
+axis.label.set_text(r'Temperature ($^{\circ} C$)')
+axis.label.set_size(16)
+axis.major_ticklabels.set_size(10)
+
+plt.show()

--- a/Plots/README.rst
+++ b/Plots/README.rst
@@ -7,13 +7,13 @@ Gallery
 =======
 
 This gallery contains visualization examples from many plotting categories
-for geosciences data.
+of geosciences data.
 
 For visualization, mainly `matplotlib` and `cartopy` are used. In addition,
 `geocat-datafiles <https://github.com/NCAR/geocat-datafiles>`_ is used as a
-dataset storage, `geocat-viz <https://github.com/NCAR/geocat-viz>`_ is used for
-a higher level implementation for low level `matplotlib` functionalities, as
-well as `xarray` and `numpy` are used for data processing.
+dataset storage and `geocat-viz <https://github.com/NCAR/geocat-viz>`_ is used for
+a higher level implementation for low level `matplotlib` functionalitie.
+`Xarray` and `numpy` are used for data processing.
 
 Click on any image to see the full image and source code as well as to
 download Python script and/or Jupyter notebook.

--- a/Plots/WRF/NCL_WRF_zoom_1_2.py
+++ b/Plots/WRF/NCL_WRF_zoom_1_2.py
@@ -1,6 +1,6 @@
 """
 NCL_WRF_zoom_1_2.py
-==================
+===================
 This script illustrates the following concepts:
     - Plotting WRF data on native grid
     - Subsetting data to 'zoom in' on an area

--- a/conf.py
+++ b/conf.py
@@ -19,8 +19,13 @@ import warnings
 # -- Project information -----------------------------------------------------
 
 project = 'GeoCAT-examples'
-copyright = '2019, GeoCAT'
-author = 'GeoCAT'
+
+import datetime
+
+current_year = datetime.datetime.now().year
+copyright = u'{}, University Corporation for Atmospheric Research'.format(
+    current_year)
+author = u'GeoCAT'
 
 # -- General configuration ---------------------------------------------------
 

--- a/conf.py
+++ b/conf.py
@@ -86,9 +86,9 @@ master_doc = 'index'
 # Configure sphinx-gallery plugin
 from sphinx_gallery.sorting import ExampleTitleSortKey
 sphinx_gallery_conf = {
-    'examples_dirs': ['Plots',],  # path to your example scripts
+    'examples_dirs': ['Plots', 'GeoCAT-comp-examples'],  # path to your example scripts
     'filename_pattern': '^((?!sgskip).)*$',
-    'gallery_dirs': ['gallery'
+    'gallery_dirs': ['gallery', 'gallery-geocat-comp'
                     ],  # path to where to save gallery generated output
     'within_subsection_order': ExampleTitleSortKey,
     'matplotlib_animations': True,

--- a/index.rst
+++ b/index.rst
@@ -7,7 +7,7 @@ GeoCAT-examples
 ===============
 
 This gallery contains visualization examples from many plotting categories
-for geosciences data (under the
+of geosciences data (under the
 `Gallery <https://geocat-examples.readthedocs.io/en/latest/gallery/index.html>`_
 tab) and usage examples for the functions of the GeoCAT computational component,
 `GeoCAT-comp <https://geocat-comp.readthedocs.io>`_ (under the
@@ -17,9 +17,9 @@ tab).
 
 For visualization, mainly `matplotlib` and `cartopy` are used. In addition,
 `geocat-datafiles <https://github.com/NCAR/geocat-datafiles>`_ is used as a
-dataset storage, `geocat-viz <https://github.com/NCAR/geocat-viz>`_ is used for
-a higher level implementation for low level `matplotlib` functionalities, as
-well as `xarray` and `numpy` are used for data processing.
+dataset storage and `geocat-viz <https://github.com/NCAR/geocat-viz>`_ is used for
+a higher level implementation for low level `matplotlib` functionalitie.
+`Xarray` and `numpy` are used for data processing.
 
 Click on any image to see the full image and source code as well as to
 download Python script and/or Jupyter notebook.

--- a/index.rst
+++ b/index.rst
@@ -3,14 +3,33 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to GeoCAT-examples's documentation!
-===========================================
+GeoCAT-examples
+===============
+
+This gallery contains visualization examples from many plotting categories
+for geosciences data (under the
+`Gallery <https://geocat-examples.readthedocs.io/en/latest/gallery/index.html>`_
+tab) and usage examples for the functions of the GeoCAT computational component,
+`GeoCAT-comp <https://geocat-comp.readthedocs.io>`_ (under the
+`GeoCAT-comp Examples
+<https://geocat-examples.readthedocs.io/en/latest/gallery-geocat-comp/index.html>`_
+tab).
+
+For visualization, mainly `matplotlib` and `cartopy` are used. In addition,
+`geocat-datafiles <https://github.com/NCAR/geocat-datafiles>`_ is used as a
+dataset storage, `geocat-viz <https://github.com/NCAR/geocat-viz>`_ is used for
+a higher level implementation for low level `matplotlib` functionalities, as
+well as `xarray` and `numpy` are used for data processing.
+
+Click on any image to see the full image and source code as well as to
+download Python script and/or Jupyter notebook.
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
    ./gallery/index.rst
+   ./gallery-geocat-comp/index.rst
    ./install.rst
    ./support.rst
 


### PR DESCRIPTION
This PR adds the usage example scripts from GeoCAT-comp (only `linint2`, `linint2pts`, and `moc_globe_atl` were implemented so far) to this gallery. It also makes several updates, paraphrasing, etc. related to this insertion. 

@michaelavs @anissa111 could you please look at the generated [webpage here](https://geocat-examples.readthedocs.io/en/geocat_comp_examples/) and let me know anything else you want to be changed (text, titles, hierarchy, etc.)