### PR TITLE
Downgrade cartopy to 0.18.0 to fix CI errors

### DIFF
--- a/Plots/Polygons/NCL_polyg_2.py
+++ b/Plots/Polygons/NCL_polyg_2.py
@@ -85,7 +85,7 @@ ax = plt.axes([.05, -.05, .9, 1],
 ax.set_extent([-119, -74, 18, 50], ccrs.Geodetic())
 
 # Set shape name of map (which depicts the United States)
-shapename = 'admin_1_states_provinces_lakes_shp'
+shapename = 'admin_1_states_provinces_lakes'
 states_shp = shpreader.natural_earth(resolution='110m',
                                      category='cultural',
                                      name=shapename)

--- a/Plots/WRF/NCL_WRF_zoom_1_2.py
+++ b/Plots/WRF/NCL_WRF_zoom_1_2.py
@@ -73,7 +73,7 @@ ax = plt.axes(projection=cart_proj)
 states = NaturalEarthFeature(category="cultural",
                              scale="50m",
                              facecolor="none",
-                             name="admin_1_states_provinces_shp")
+                             name="admin_1_states_provinces")
 
 ax.add_feature(states, linewidth=0.5, edgecolor="black")
 ax.coastlines('50m', linewidth=0.8)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For further information, please refer to
 
 
 [github-ci-badge]: https://img.shields.io/github/workflow/status/NCAR/geocat-examples/CI?label=CI&logo=github&style=for-the-badge
-[github-ci-link]: https://github.com/NCAR/geocat-comp/actions?query=workflow%3ACI
+[github-ci-link]: https://github.com/NCAR/geocat-examples/actions?query=workflow%3ACI
 [rtd-badge]: https://img.shields.io/readthedocs/geocat-examples/latest.svg?style=for-the-badge
 [rtd-link]: https://geocat-comp.readthedocs.io/en/latest/?badge=latest
 [license-badge]: https://img.shields.io/github/license/NCAR/geocat-examples?style=for-the-badge

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - geocat-comp
   - geocat-datafiles
   - geocat-viz=2020.7.30.1
-  - cartopy=0.18.0
+  - cartopy
   - geographiclib
   - jupyter
   - make

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - geocat-comp
   - geocat-datafiles
   - geocat-viz=2020.7.30.1
-  - cartopy
+  - cartopy=0.18.0
   - geographiclib
   - jupyter
   - make


### PR DESCRIPTION
After `cartopy`'s version 0.19.0 release, shape file errors occurred in two scripts, which are not occurring in local: 

- `NCL_polyg_2`: KeyError: "There is no item named 'ne_110m_admin_1_states_provinces_lakes_shp.cpg' in the archive" 
- `NCL_WRF_zoom_1_2`: KeyError: "There is no item named 'ne_50m_admin_1_states_provinces_shp.cpg' in the archive"

Above errors can be found in scheduled CI actions, e.g. [see this one](https://github.com/NCAR/GeoCAT-examples/runs/2442188579?check_suite_focus=true).

This PR downgrades `cartopy` to 0.18.0, and it seems to have worked. 

It also fixes CI link in Badge, which was accidentally linking to `geocat-comp`'s badge before.