### PR TITLE
fix panel 19 links

### DIFF
--- a/Plots/Panels/NCL_panel_19.py
+++ b/Plots/Panels/NCL_panel_19.py
@@ -7,8 +7,8 @@ This script illustrates the following concepts:
    - Using a blue-red color map
 
 See following URLs to see the reproduced NCL plot & script:
-    - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/dev_1.ncl
-    - Original NCL plot: https://www.ncl.ucar.edu/Applications/Images/dev_1_lg.png
+    - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/panel_19.ncl
+    - Original NCL plot: https://www.ncl.ucar.edu/Applications/Images/panel_19_1_lg.png and https://www.ncl.ucar.edu/Applications/Images/panel_19_2_lg.png
 """
 
 ##############################################################################


### PR DESCRIPTION
Current panel 19 [script](https://geocat-examples.readthedocs.io/en/latest/gallery/Panels/NCL_panel_19.html#sphx-glr-gallery-panels-ncl-panel-19-py) is linked to wrong NCL script and plot.

- Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/panel_19.ncl
- Original NCL plot: https://www.ncl.ucar.edu/Applications/Images/panel_19_1_lg.png and https://www.ncl.ucar.edu/Applications/Images/panel_19_2_lg.png