### PR TITLE
Unpin geocat-viz

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - cf_xarray>=0.3.1
   - geocat-datafiles
   - eofs
-  - geocat-viz=2020.7.30.1
+  - geocat-viz
   - cartopy
   - geographiclib
   - jupyter


### PR DESCRIPTION
Summary of changes:
- unpins geocat-viz from 2020.07.0 to use the most recent version