### PR TITLE
Set up Google Analytics for RTD documentation page

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,15 @@
+{% extends "!layout.html" %} {% block extrahead %}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script
+        async
+        src="https://www.googletagmanager.com/gtag/js?id=G-BY9T11S8QG"
+></script>
+<script>
+    window.dataLayer = window.dataLayer || []
+    function gtag() {
+        dataLayer.push(arguments)
+    }
+    gtag('js', new Date())
+    gtag('config', 'G-BY9T11S8QG')
+</script>
+{{ super() }} {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,15 +1,14 @@
-{% extends "!layout.html" %} {% block extrahead %}
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script
-        async
-        src="https://www.googletagmanager.com/gtag/js?id=G-BY9T11S8QG"
-></script>
-<script>
-    window.dataLayer = window.dataLayer || []
-    function gtag() {
-        dataLayer.push(arguments)
-    }
-    gtag('js', new Date())
-    gtag('config', 'G-BY9T11S8QG')
-</script>
-{{ super() }} {% endblock %}
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BY9T11S8QG"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-BY9T11S8QG');
+    </script>
+    {{ super() }}
+{% endblock %}


### PR DESCRIPTION
This PR adds `docs/_templates/layout.html` that refers to a Google Analytics tracking ID to track analytics for https://geocat-examples.readthedocs.io/en/latest/