### PR TITLE
Update examples with new geocat-viz utility functions

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -26,3 +26,4 @@ dependencies:
   - wrf-python
   - pip:
       - pre-commit
+      - git+https://github.com/NCAR/geocat-viz@main


### PR DESCRIPTION
Incorporates #410, #409, and #407

Note: reverse change in first commit before merging, unless we decide to permanently pull from main instead of a release of geocat-viz.

- [ ] 407
- [ ] 409
- [ ] 410