### PR TITLE
Bumped oldest python version from 3.6 to 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest"]
-        python-version: [ "3.6", "3.9" ]
+        python-version: [ "3.7", "3.9" ]
 
     steps:
     - uses: actions/checkout@v2

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - ncar
 dependencies:
-  - python>3.6
+  - python>=3.7
   - geocat-comp
   - cf_xarray>=0.3.1
   - geocat-datafiles

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - ncar
 dependencies:
-  - python=3
+  - python>3.6
   - geocat-comp
   - cf_xarray>=0.3.1
   - geocat-datafiles


### PR DESCRIPTION
Changed oldest supported Python version from 3.6 to 3.7. Updated dependency list accordingly. Changed ci workflow to check against Python versions 3.7 and 3.9 rather than 3.6 and 3.9.