### PR TITLE
Adding calendar_average example

### DIFF
--- a/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
+++ b/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
@@ -13,7 +13,7 @@ data:
 
 Dependencies:
     - geocat.comp
-    - geocat.datafiles (Not necessary for figure but used for accessing the data file)
+    - geocat.datafiles (for accessing data file only)
     - geocat.viz
     - cftime (installed with geocat.comp)
     - matplotlib (installed with geocat.viz)

--- a/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
+++ b/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
@@ -70,7 +70,7 @@ time_num_day = cftime.date2num(daily.time, 'hours since 1990-01-01 00:00:00')
 time_num_month = cftime.date2num(monthly.time, 'hours since 1990-01-01 00:00:00')
 time_num_season = cftime.date2num(season.time, 'hours since 1990-01-01 00:00:00')
 
-# Start and end time for axes limits
+# Start and end time for axes limits in units of hours since 1990-01-01 00:00:00
 tstart = time_num_raw[0]
 tend = time_num_raw[-1]
 
@@ -78,8 +78,12 @@ tend = time_num_raw[-1]
 # Plot:
 
 # Make three subplots with shared axes
-fig, ax = plt.subplots(4, 1, figsize=(8, 10),
-                       sharex=True, sharey=True, constrained_layout=True)
+fig, ax = plt.subplots(4,
+                       1,
+                       figsize=(8, 10),
+                       sharex=True,
+                       sharey=True,
+                       constrained_layout=True)
 
 # Plot data
 ax[0].plot(time_num_raw, temp.data)
@@ -90,8 +94,8 @@ ax[3].plot(time_num_season, season.data)
 # Use geocat.viz.util convenience function to set axes parameters without
 # calling several matplotlib functions
 gvutil.set_axes_limits_and_ticks(ax[0],
-                                 xlim=(tstart, tend+1),
-                                 xticks=range(tstart, tend+1, 365*24),
+                                 xlim=(tstart, tend + 1),
+                                 xticks=range(tstart, tend + 1, 365 * 24),
                                  xticklabels=range(1990, 1997),
                                  ylim=(297, 304))
 
@@ -103,11 +107,9 @@ gvutil.set_titles_and_labels(ax[0],
                              righttitle=temp.units,
                              righttitlefontsize=14)
 
-gvutil.set_titles_and_labels(ax[1],
-                             ylabel='Daily Average')
+gvutil.set_titles_and_labels(ax[1], ylabel='Daily Average')
 
-gvutil.set_titles_and_labels(ax[2],
-                             ylabel='Monthly Average')
+gvutil.set_titles_and_labels(ax[2], ylabel='Monthly Average')
 
 gvutil.set_titles_and_labels(ax[3],
                              ylabel='Season Average',

--- a/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
+++ b/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
@@ -18,6 +18,23 @@ Dependencies:
     - geocat.viz
     - matplotlib
     - xarray
+
+Figure Description:
+The top subplot is raw surface temperature data from a model run with a
+temporal resolution of 6-hours.
+
+The second subplot shows the output of the raw data being aggregated using the
+`calendar_average` function with the `freq` argument set to 'daily'. This
+function averages all data points within each 24-hour period.
+
+The third subplot shows the output of `calendar_average` with the `freq`
+argument set to `monthly`. This works much the same as for the middle plot;
+however, the data is now grouped by month which yeilds a smoother curve.
+
+The bottom subplot shows the output of `calendar_average` with the `freq`
+argument set to `season`. This averages all data points in each meteorological
+season. Those seasons are each comprised of three month periods with the first
+consisting of December, January, and February for meteorological winter.
 """
 
 ###############################################################################

--- a/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
+++ b/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
@@ -54,7 +54,7 @@ from geocat.viz import util as gvutil
 ds = xr.open_dataset(gdf.get('netcdf_files/atm.20C.hourly6-1990-1995-TS.nc'))
 ds = ds.isel(member_id=0)  # select one model from the ensemble
 
-temp = ds.TS # surface temperature data
+temp = ds.TS  # surface temperature data
 
 ###############################################################################
 # Calculate daily, monthly, and seasonal averages using `calendar_average`
@@ -67,8 +67,10 @@ season = calendar_average(temp, 'season')
 # This must be done in order to use the time for the x axis
 time_num_raw = cftime.date2num(temp.time, 'hours since 1990-01-01 00:00:00')
 time_num_day = cftime.date2num(daily.time, 'hours since 1990-01-01 00:00:00')
-time_num_month = cftime.date2num(monthly.time, 'hours since 1990-01-01 00:00:00')
-time_num_season = cftime.date2num(season.time, 'hours since 1990-01-01 00:00:00')
+time_num_month = cftime.date2num(monthly.time,
+                                 'hours since 1990-01-01 00:00:00')
+time_num_season = cftime.date2num(season.time,
+                                  'hours since 1990-01-01 00:00:00')
 
 # Start and end time for axes limits in units of hours since 1990-01-01 00:00:00
 tstart = time_num_raw[0]

--- a/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
+++ b/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
@@ -8,16 +8,16 @@ This script illustrates the following concepts:
 
 See following GitHub repositories to see further information about the function and how to access
 data:
-    - For GeoCAT functions: https://github.com/NCAR/geocat-comp
+    - For GeoCAT-comp functions: https://github.com/NCAR/geocat-comp
     - For atm.20C.hourly6-1990-1995.nc file: https://github.com/NCAR/geocat-datafiles/tree/main/netcdf_files
 
 Dependencies:
-    - cftime
     - geocat.comp
     - geocat.datafiles (Not necessary for figure but used for accessing the data file)
     - geocat.viz
-    - matplotlib
-    - xarray
+    - cftime (installed with geocat.comp)
+    - matplotlib (installed with geocat.viz)
+    - xarray (installed with geocat.comp)
 
 Figure Description:
 The top subplot is raw surface temperature data from a model run with a

--- a/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
+++ b/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
@@ -1,6 +1,6 @@
 """
 calendar_average_example.py
-=========================
+===========================
 This script illustrates the following concepts:
     - Usage of geocat-comp's calendar_average function
     - Usage of geocat-datafiles for accessing NetCDF files
@@ -14,7 +14,7 @@ data:
 Dependencies:
     - cftime
     - geocat.comp
-    - geocat.datafiles (Not necessary but for conveniently accessing the data file)
+    - geocat.datafiles (Not necessary for figure but used for accessing the data file)
     - geocat.viz
     - matplotlib
     - xarray
@@ -37,7 +37,7 @@ from geocat.viz import util as gvutil
 ds = xr.open_dataset(gdf.get('netcdf_files/atm.20C.hourly6-1990-1995-TS.nc'))
 ds = ds.isel(member_id=0)  # select one model from the ensemble
 
-temp = ds.TS
+temp = ds.TS # surface temperature data
 
 ###############################################################################
 # Calculate climatologies using `calendar_average`

--- a/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
+++ b/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
@@ -40,7 +40,7 @@ ds = ds.isel(member_id=0)  # select one model from the ensemble
 temp = ds.TS # surface temperature data
 
 ###############################################################################
-# Calculate climatologies using `calendar_average`
+# Calculate daily, monthly, and seasonal averages using `calendar_average`
 
 daily = calendar_average(temp, 'day')
 monthly = calendar_average(temp, 'month')
@@ -95,5 +95,8 @@ gvutil.set_titles_and_labels(ax[2],
 gvutil.set_titles_and_labels(ax[3],
                              ylabel='Season Average',
                              xlabel=temp.time.long_name)
+
+# Add title manually to control spacing
+fig.suptitle('Calendar Average on 6-hourly Data', fontsize=20)
 
 plt.show()

--- a/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
+++ b/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
@@ -1,8 +1,8 @@
 """
-climatology_example.py
+calendar_average_example.py
 =========================
 This script illustrates the following concepts:
-    - Usage of geocat-comp's calendar_average functions
+    - Usage of geocat-comp's calendar_average function
     - Usage of geocat-datafiles for accessing NetCDF files
     - Creating a figure with stacked subplots
 

--- a/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
+++ b/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
@@ -1,0 +1,99 @@
+"""
+climatology_example.py
+=========================
+This script illustrates the following concepts:
+    - Usage of geocat-comp's calendar_average functions
+    - Usage of geocat-datafiles for accessing NetCDF files
+    - Creating a figure with stacked subplots
+
+See following GitHub repositories to see further information about the function and how to access
+data:
+    - For GeoCAT functions: https://github.com/NCAR/geocat-comp
+    - For atm.20C.hourly6-1990-1995.nc file: https://github.com/NCAR/geocat-datafiles/tree/main/netcdf_files
+
+Dependencies:
+    - cftime
+    - geocat.comp
+    - geocat.datafiles (Not necessary but for conveniently accessing the data file)
+    - geocat.viz
+    - matplotlib
+    - xarray
+"""
+
+###############################################################################
+# Import packages
+
+import cftime
+import matplotlib.pyplot as plt
+import xarray as xr
+
+from geocat.comp import calendar_average
+import geocat.datafiles as gdf
+from geocat.viz import util as gvutil
+
+###############################################################################
+# Read in data:
+
+ds = xr.open_dataset(gdf.get('netcdf_files/atm.20C.hourly6-1990-1995-TS.nc'))
+ds = ds.isel(member_id=0)  # select one model from the ensemble
+
+temp = ds.TS
+
+###############################################################################
+# Calculate climatologies using `calendar_average`
+
+daily = calendar_average(temp, 'day')
+monthly = calendar_average(temp, 'month')
+season = calendar_average(temp, 'season')
+
+# Convert datetimes to number of hours since 1990-01-01 00:00:00
+# This must be done in order to use the time for the x axis
+time_num_raw = cftime.date2num(temp.time, 'hours since 1990-01-01 00:00:00')
+time_num_day = cftime.date2num(daily.time, 'hours since 1990-01-01 00:00:00')
+time_num_month = cftime.date2num(monthly.time, 'hours since 1990-01-01 00:00:00')
+time_num_season = cftime.date2num(season.time, 'hours since 1990-01-01 00:00:00')
+
+# Start and end time for axes limits
+tstart = time_num_raw[0]
+tend = time_num_raw[-1]
+
+###############################################################################
+# Plot:
+
+# Make three subplots with shared axes
+fig, ax = plt.subplots(4, 1, figsize=(8, 10),
+                       sharex=True, sharey=True, constrained_layout=True)
+
+# Plot data
+ax[0].plot(time_num_raw, temp.data)
+ax[1].plot(time_num_day, daily.data)
+ax[2].plot(time_num_month, monthly.data)
+ax[3].plot(time_num_season, season.data)
+
+# Use geocat.viz.util convenience function to set axes parameters without
+# calling several matplotlib functions
+gvutil.set_axes_limits_and_ticks(ax[0],
+                                 xlim=(tstart, tend+1),
+                                 xticks=range(tstart, tend+1, 365*24),
+                                 xticklabels=range(1990, 1997),
+                                 ylim=(297, 304))
+
+# Use geocat.viz.util convenience function to set titles and labels
+gvutil.set_titles_and_labels(ax[0],
+                             ylabel='Raw Data (6-hourly)',
+                             lefttitle=temp.long_name,
+                             lefttitlefontsize=14,
+                             righttitle=temp.units,
+                             righttitlefontsize=14)
+
+gvutil.set_titles_and_labels(ax[1],
+                             ylabel='Daily Average')
+
+gvutil.set_titles_and_labels(ax[2],
+                             ylabel='Monthly Average')
+
+gvutil.set_titles_and_labels(ax[3],
+                             ylabel='Season Average',
+                             xlabel=temp.time.long_name)
+
+plt.show()

--- a/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
+++ b/GeoCAT-comp-examples/matplotlib/calendar_average_example.py
@@ -2,7 +2,7 @@
 calendar_average_example.py
 ===========================
 This script illustrates the following concepts:
-    - Usage of geocat-comp's calendar_average function
+    - Usage of geocat-comp's `calendar_average <https://geocat-comp.readthedocs.io/en/latest/user_api/generated/geocat.comp.climatologies.calendar_average.html?highlight=CALENDER%20average>`_ function.
     - Usage of geocat-datafiles for accessing NetCDF files
     - Creating a figure with stacked subplots
 


### PR DESCRIPTION
This PR adds an example script for the `geocat-comp` function `calendar_average`. The produced plot is shown below, and there is an explanation of what the plot shows in the beginning notes of the example.
![image](https://user-images.githubusercontent.com/42781301/150000299-1dedb5d5-8987-42e8-bd62-43c3a7a4118b.png)
