### PR TITLE
Update `NCL_skewt_2_2` to have subtitle

### DIFF
--- a/Plots/Skew-T/NCL_skewt_2_2.py
+++ b/Plots/Skew-T/NCL_skewt_2_2.py
@@ -4,7 +4,7 @@ NCL_skewt_2_2.py
 This script illustrates the following concepts:
    - Customizing the background of a Skew-T plot
    - Plotting temperature, dewpoint, and wind data on a Skew-T plot
-   - Using GeoCAT-comp function ` ``get_skewt_vars`` <https://geocat-comp.readthedocs.io/en/latest/user_api/generated/geocat.comp.skewt_params.get_skewt_vars.html#geocat.comp.skewt_params.get_skewt_vars>`_ to calculate CAPE, Precipitable Water, Showalter Index, Pressure of the lifting condensation level, and Temperature at the lifting condensation level [C]
+   - Using GeoCAT-comp function `get_skewt_vars <https://geocat-comp.readthedocs.io/en/latest/user_api/generated/geocat.comp.skewt_params.get_skewt_vars.html#geocat.comp.skewt_params.get_skewt_vars>`_ to calculate CAPE, Precipitable Water, Showalter Index, Pressure of the lifting condensation level, and Temperature at the lifting condensation level [C]
 See following URLs to see the reproduced NCL plot & script:
     - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/skewt_2.ncl
     - Original NCL plots: https://www.ncl.ucar.edu/Applications/Images/skewt_2_2_lg.png
@@ -148,7 +148,7 @@ gvutil.set_titles_and_labels(ax=ax,
                              ylabel='P (hPa)',
                              labelfontsize=14)
 
-# Manually add suptitle and subtitle
+# Manually add suptitle and subtitle for appropriate positioning
 fig.suptitle('Raob; [Wind Reports]', fontsize=24, y=0.92)
 ax.set_title(subtitle, color='darkgoldenrod')
 

--- a/Plots/Skew-T/NCL_skewt_2_2.py
+++ b/Plots/Skew-T/NCL_skewt_2_2.py
@@ -149,7 +149,7 @@ gvutil.set_titles_and_labels(ax=ax,
                              labelfontsize=14)
 
 # Manually add suptitle and subtitle
-fig.suptitle('Raob; [Wind Reports]', fontsize=24, y=0.93)
+fig.suptitle('Raob; [Wind Reports]', fontsize=24, y=0.92)
 ax.set_title(subtitle, color='darkgoldenrod')
 
 # Change the style of the gridlines

--- a/Plots/Skew-T/NCL_skewt_2_2.py
+++ b/Plots/Skew-T/NCL_skewt_2_2.py
@@ -56,7 +56,7 @@ subtitle = gcskewt.get_skewt_vars(p, tc, tdc, pro)  # Create subtitle
 # Note that MetPy forces the x axis scale to be in Celsius and the y axis
 # scale to be in hectoPascals. Once data is plotted, then the axes labels are
 # automatically added
-fig = plt.figure(figsize=(12, 12))
+fig = plt.figure(figsize=(10, 12))
 
 # The rotation keyword changes how skewed the temperature lines are. MetPy has
 # a default skew of 30 degrees
@@ -142,7 +142,7 @@ gvutil.add_major_minor_ticks(ax=ax,
 # on the left and bottom edges
 ax.tick_params('both', which='both', top=False, right=False)
 
-# Use geocat.viz utility functions to add a main title
+# Use geocat.viz utility functions to add labels
 gvutil.set_titles_and_labels(ax=ax,
                              xlabel='Temperature (C)',
                              ylabel='P (hPa)',

--- a/Plots/Skew-T/NCL_skewt_2_2.py
+++ b/Plots/Skew-T/NCL_skewt_2_2.py
@@ -4,15 +4,10 @@ NCL_skewt_2_2.py
 This script illustrates the following concepts:
    - Customizing the background of a Skew-T plot
    - Plotting temperature, dewpoint, and wind data on a Skew-T plot
+   - Using GeoCAT-comp function ` ``get_skewt_vars`` <https://geocat-comp.readthedocs.io/en/latest/user_api/generated/geocat.comp.skewt_params.get_skewt_vars.html#geocat.comp.skewt_params.get_skewt_vars>`_ to calculate CAPE, Precipitable Water, Showalter Index, Pressure of the lifting condensation level, and Temperature at the lifting condensation level [C]
 See following URLs to see the reproduced NCL plot & script:
     - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/skewt_2.ncl
     - Original NCL plots: https://www.ncl.ucar.edu/Applications/Images/skewt_2_2_lg.png
-Note:
-    Currently functions to calculate CAPE, precipitable water, the showalter
-    index, the pressure of the LCL, and the temperature of the LCL do not
-    exist in ``geocat-comp``. An `issue <https://github.com/NCAR/geocat-comp/issues/89>`_
-    has been opened on the ``geocat-comp`` GitHub. The subtitle with those
-    values will be added at a later date once that issue has been closed.
 """
 
 ##############################################################################
@@ -28,6 +23,7 @@ import metpy.calc as mpcalc
 
 import geocat.viz.util as gvutil
 import geocat.datafiles as gdf
+import geocat.comp.skewt_params as gcskewt
 
 ##############################################################################
 # Read in data:
@@ -46,6 +42,13 @@ tdc = ds[9].values * units.degC  # Dew pt temp  [C]
 wspd = np.linspace(0, 150, len(p)) * units.knots  # Wind speed   [knots or m/s]
 wdir = np.linspace(0, 360, len(p)) * units.degrees  # Meteorological wind dir
 u, v = mpcalc.wind_components(wspd, wdir)  # Calculate wind components
+
+# Generate subtitle with Pressure of LCL, Temperature of LCL, Showalter Index,
+# Precipitable Water, and CAPE
+tc0 = tc[0]  # Temperature of surface parcel
+tdc0 = tdc[0]  # Dew point temperature of surface parcel
+pro = mpcalc.parcel_profile(p, tc0, tdc0)  # Temperature profile of parcel
+subtitle = gcskewt.get_skewt_vars(p, tc, tdc, pro)  # Create subtitle
 
 ##############################################################################
 # Plot:
@@ -141,11 +144,13 @@ ax.tick_params('both', which='both', top=False, right=False)
 
 # Use geocat.viz utility functions to add a main title
 gvutil.set_titles_and_labels(ax=ax,
-                             maintitle="Raob; [Wind Reports]",
-                             maintitlefontsize=22,
                              xlabel='Temperature (C)',
                              ylabel='P (hPa)',
                              labelfontsize=14)
+
+# Manually add suptitle and subtitle
+fig.suptitle('Raob; [Wind Reports]', fontsize=24, y=0.93)
+ax.set_title(subtitle, color='darkgoldenrod', fontweight='bold')
 
 # Change the style of the gridlines
 plt.grid(True,

--- a/Plots/Skew-T/NCL_skewt_2_2.py
+++ b/Plots/Skew-T/NCL_skewt_2_2.py
@@ -150,7 +150,7 @@ gvutil.set_titles_and_labels(ax=ax,
 
 # Manually add suptitle and subtitle
 fig.suptitle('Raob; [Wind Reports]', fontsize=24, y=0.93)
-ax.set_title(subtitle, color='darkgoldenrod', fontweight='bold')
+ax.set_title(subtitle, color='darkgoldenrod')
 
 # Change the style of the gridlines
 plt.grid(True,


### PR DESCRIPTION
Closes #423 

This PR updates `NCL_skewt_2_2` to use the geocat-comp function `get_skewt_vars`. Currently geocat-viz does not have the ability to make a subtitle using `set_titles_and_labels`, so this PR implements a work around until the issue in GeoCAT-viz https://github.com/NCAR/geocat-viz/issues/52 is closed.

NCL Plot: 
![image](https://user-images.githubusercontent.com/42781301/150019258-83272a7f-a07a-4fb5-9075-c61e131a3f1a.png)

Current GeoCAT Plot: ![image](https://user-images.githubusercontent.com/42781301/150019443-8054f0a3-090e-4880-9a89-6532bba5d457.png)