### PR TITLE
Update citation texts per Zenodo DOI implementation per-version

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,7 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - given-names: "Visualization & Analysis Systems Technologies"
+title: "Geoscience Community Analysis Toolkit: GeoCAT-examples"
+doi: 10.5281/zenodo.6678258
+url: "https://github.com/NCAR/geocat-examples"

--- a/README.md
+++ b/README.md
@@ -47,21 +47,8 @@ Please see our documentation for [installation instructions](https://github.com/
 
 # Citing GeoCAT-examples
 
-Cite GeoCAT-examples using the following text:
-
-<> Visualization & Analysis Systems Technologies. (Year).
-Geoscience Community Analysis Toolkit (GeoCAT-examples) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.
-
-Update the year as appropriate. For example:
-
-<> Visualization & Analysis Systems Technologies. (2021).
-Geoscience Community Analysis Toolkit (GeoCAT-examples) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.
-
-For further information, please refer to
-[GeoCAT homepage - Citation](https://geocat.ucar.edu/pages/citation.html).
-
+If you use this software, please cite it as described at the [GeoCAT-examples - Citation](
+https://geocat-examples.readthedocs.io/en/latest/citation.html) page.
 
 
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,14 @@ https://geocat-examples.readthedocs.io/en/latest/citation.html) page.
 
 
 
+
 [github-ci-badge]: https://img.shields.io/github/workflow/status/NCAR/geocat-examples/CI?label=CI&logo=github&style=for-the-badge
 [github-ci-link]: https://github.com/NCAR/geocat-examples/actions?query=workflow%3ACI
 [rtd-badge]: https://img.shields.io/readthedocs/geocat-examples/latest.svg?style=for-the-badge
 [rtd-link]: https://geocat-examples.readthedocs.io/en/latest/?badge=latest
 [license-badge]: https://img.shields.io/github/license/NCAR/geocat-examples?style=for-the-badge
-[doi-badge]: https://img.shields.io/badge/DOI-10.5065%2Fa8pp--4358-brightgreen?style=for-the-badge
-[doi-link]: https://doi.org/10.5065/a8pp-4358
+[doi-badge]: https://zenodo.org/badge/DOI/10.5281/zenodo.6678258.svg
+[doi-link]: https://doi.org/10.5281/zenodo.6678258
+[comment]: <> ([doi-badge]: https://img.shields.io/badge/DOI-10.5065%2Fa8pp--4358-brightgreen?style=for-the-badge)
+[comment]: <> ([doi-link]: https://doi.org/10.5065/a8pp-4358)
 [repo-link]: https://github.com/NCAR/geocat-examples

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -4,17 +4,43 @@ Citation
 How to cite GeoCAT-examples
 ---------------------------
 
-Cite GeoCAT-examples using the following text:
+If you use this software, please cite it as described below.
+
+GeoCAT-examples is a collection of standalone visualization examples, and it is not distributed
+as a versioned software tool (see
+`here <https://geocat-examples.readthedocs.io/en/latest/install.html>`_ for further details);
+however, we still generate Github tags/releases for it to distinguish between newly added functions
+and the older ones. Each GeoCAT-examples Github release is assigned a separate Digital Object
+Identifier (DOI) to allow users to access older releases. This ensures that users are not only able
+to cite the specific Github release through DOIs but are also able to download & use the
+corresponding release for reproducibility purposes.
+
+If you would like to cite GeoCAT-examples as a whole (without referring to a specific Github release),
+use the following text:
 
 **Visualization & Analysis Systems Technologies. (Year).
-Geoscience Community Analysis Toolkit (GeoCAT-examples) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.**
+Geoscience Community Analysis Toolkit: GeoCAT-examples [Software].
+Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6678258.**
 
-Update the year as appropriate. For example:
+Instead, if you would like to cite a specific Github release of GeoCAT-examples, use the following text:
 
-**Visualization & Analysis Systems Technologies. (2021).
-Geoscience Community Analysis Toolkit (GeoCAT-examples) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.**
+**Visualization & Analysis Systems Technologies. (Year).
+Geoscience Community Analysis Toolkit: GeoCAT-examples (v\<version\>) [Software].
+Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:\<DOI\>.**
+
+In the above citation text, update the year, GeoCAT-examples version, and DOI as appropriate. For
+example:
+
+**Visualization & Analysis Systems Technologies. (2022).
+Geoscience Community Analysis Toolkit: GeoCAT-examples (v2022.05.0) [Software].
+Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6678263.**
+
+Please find DOIs for all the GeoCAT-examples Github releases `here
+<https://zenodo.org/record/6678263>`_.
+
+Please note: The DOI minting service, Zenodo, might be suggesting their own citation text (as
+they are the publisher of such DOIs) in their website. We prefer the text we recommend here to be used;
+however, either way is acceptable.
 
 For further information, please refer to
 `GeoCAT homepage - Citation <https://geocat.ucar.edu/pages/citation.html>`_.


### PR DESCRIPTION
We are starting to generate DOIs for each GeoCAT-comp version via the Zenodo minting service. Texts regarding citation are updated to reflect this change.