### PR TITLE
ce_3_1 with Contour

### DIFF
--- a/Gallery/Contours/NCL_ce_3_1.py
+++ b/Gallery/Contours/NCL_ce_3_1.py
@@ -13,9 +13,9 @@ See following URLs to see the reproduced NCL plot & script:
     - Original NCL plot: https://www.ncl.ucar.edu/Applications/Images/ce_3_1_lg.png
 
 .. Warning::
-    This is an experimental version of the script. Go to the [latest](https://geocat-examples.readthedocs.io/en/latest/gallery/Contours/NCL_ce_3_1.html) version for the stable version.
+    This is an experimental version of the script. Go to the `latest <https://geocat-examples.readthedocs.io/en/latest/gallery/Contours/NCL_ce_3_1.html>`_ version for the stable version.
 
-    See the geocat-viz experimental documentation for the functionality in this script [here](https://geocat-viz.readthedocs.io/en/experimental/).
+    See the geocat-viz experimental documentation for the functionality in this script `here <https://geocat-viz.readthedocs.io/en/experimental/>`_.
 """
 
 ###############################################################################

--- a/Gallery/Contours/NCL_ce_3_1.py
+++ b/Gallery/Contours/NCL_ce_3_1.py
@@ -12,7 +12,10 @@ See following URLs to see the reproduced NCL plot & script:
     - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/ce_3.ncl
     - Original NCL plot: https://www.ncl.ucar.edu/Applications/Images/ce_3_1_lg.png
 
-A previous version of this script that does not use geocat-viz Contour function can be found here: https://geocat-examples.readthedocs.io/en/v2022.5.0/gallery/Contours/NCL_ce_3_1.html#sphx-glr-gallery-contours-ncl-ce-3-1-py
+Note:
+    This is an experimental version of the script. Go to the [latest](https://geocat-examples.readthedocs.io/en/latest/gallery/Contours/NCL_ce_3_1.html) version for the stable version.
+
+    See the geocat-viz experimental documentation for the functionality in this script [here](https://geocat-viz.readthedocs.io/en/experimental/).
 """
 
 ###############################################################################

--- a/Gallery/Contours/NCL_ce_3_1.py
+++ b/Gallery/Contours/NCL_ce_3_1.py
@@ -12,7 +12,7 @@ See following URLs to see the reproduced NCL plot & script:
     - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/ce_3.ncl
     - Original NCL plot: https://www.ncl.ucar.edu/Applications/Images/ce_3_1_lg.png
 
-Note:
+.. Warning::
     This is an experimental version of the script. Go to the [latest](https://geocat-examples.readthedocs.io/en/latest/gallery/Contours/NCL_ce_3_1.html) version for the stable version.
 
     See the geocat-viz experimental documentation for the functionality in this script [here](https://geocat-viz.readthedocs.io/en/experimental/).

--- a/Gallery/Contours/NCL_ce_3_1.py
+++ b/Gallery/Contours/NCL_ce_3_1.py
@@ -4,27 +4,24 @@ NCL_ce_3_1.py
 
 This script illustrates the following concepts:
    - Drawing color-filled contours over a cylindrical equi-distant map
-   - Selecting a different color map
    - Changing the contour level spacing
    - Turning off contour lines
-   - Comparing styles of map tickmarks labels
-   - Changing the stride of the colorbar labels
    - Zooming in on a particular area on the map
-   - Turning off the addition of a longitude cyclic point
 
 See following URLs to see the reproduced NCL plot & script:
     - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/ce_3.ncl
     - Original NCL plot: https://www.ncl.ucar.edu/Applications/Images/ce_3_1_lg.png
+
+A previous version of this script that does not use geocat-viz Contour function can be found here: https://geocat-examples.readthedocs.io/en/v2022.5.0/gallery/Contours/NCL_ce_3_1.html#sphx-glr-gallery-contours-ncl-ce-3-1-py
 """
 
 ###############################################################################
 # Import packages:
+
 import numpy as np
 import xarray as xr
-import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
-import cartopy.feature as cfeature
-import cmaps
+from cartopy.mpl.gridliner import LongitudeFormatter, LatitudeFormatter
 
 import geocat.datafiles as gdf
 import geocat.viz as gv
@@ -35,61 +32,42 @@ import geocat.viz as gv
 # Open a netCDF data file using xarray default engine and load the data into xarray
 ds = xr.open_dataset(gdf.get('netcdf_files/h_avg_Y0191_D000.00.nc'),
                      decode_times=False)
+
 # Extract a slice of the data
 t = ds.T.isel(time=0, z_t=0).sel(lat_t=slice(-60, 30), lon_t=slice(30, 120))
 
 ###############################################################################
 # Plot:
 
-# Generate figure (set its size (width, height) in inches)
-fig = plt.figure(figsize=(7, 7))
+# Use geocat.viz utility function to create a contour plot
+plot_ = gv.Contour(
+    t,  # data
+    w=10,  # width of plot
+    h=8,  # height of plot
+    contour_lines=False,
+    xlim=(30, 120),
+    ylim=(-60, 30),
+    cb_orientation="vertical",  # orientation of colorbar
+    cb_tick_labels=np.arange(0, 32, 2),  # colorbar tick labels
+    cb_ticks=np.arange(0, 32, 2),  # colorbar tick locations
+    levels=np.linspace(0, 31, 40),  # contour levels
+    main_title_fontsize=23,
+    left_title_fontsize=23,
+    right_title_fontsize=23,
+    land_on=True,  # Show land on plot
+    main_title="30-degree major and 10-degree minor ticks")
 
-# Generate axes, using Cartopy, drawing coastlines, and adding features
-projection = ccrs.PlateCarree()
-ax = plt.axes(projection=projection)
-ax.coastlines(linewidths=0.5)
-ax.add_feature(cfeature.LAND, facecolor='lightgray')
+# Additional formatting
+# Get current axis
+ax = plt.gca()
 
-# Import an NCL colormap
-newcmp = cmaps.BlAqGrYeOrRe
+# Customize tick length and width
+ax.tick_params(axis='both', which='minor', length=5, width=0.8)
+ax.tick_params(axis='both', which='major', length=12, width=1)
 
-# Contourf-plot data
-heatmap = t.plot.contourf(ax=ax,
-                          transform=projection,
-                          levels=40,
-                          vmin=0,
-                          vmax=32,
-                          cmap=newcmp,
-                          add_colorbar=False)
-
-# Add colorbar
-cbar = plt.colorbar(heatmap, ticks=np.arange(0, 32, 2))
-cbar.ax.set_yticklabels([str(i) for i in np.arange(0, 32, 2)])
-
-# Usa geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
-# Set axes limits, and tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(30, 120),
-                             ylim=(-60, 30),
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
-
-# Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
-gv.add_lat_lon_ticklabels(ax)
-
-# Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax, labelsize=12)
-
-# Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-gv.set_titles_and_labels(ax,
-                         maintitle="30-degree major and 10-degree minor ticks",
-                         maintitlefontsize=16,
-                         lefttitle="Potential Temperature",
-                         lefttitlefontsize=14,
-                         righttitle="Celsius",
-                         righttitlefontsize=14,
-                         xlabel="",
-                         ylabel="")
+# Remove degree symbol from tick labels
+ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
+ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Show the plot
-plt.show()
+plot_.show()


### PR DESCRIPTION
Creates NCL example ce_3_1 using geocat-viz Contour function. Includes link to previous version that does not use Contour.

Resolves issue #467 

[Previous script](https://geocat-examples.readthedocs.io/en/v2022.5.0/gallery/Contours/NCL_ce_3_1.html#sphx-glr-gallery-contours-ncl-ce-3-1-py)

Original NCL plot:
https://www.ncl.ucar.edu/Applications/Images/ce_3_1_lg.png

New version of plot using Contour:
![ce_3_1_python](https://user-images.githubusercontent.com/99711690/177611821-4e8c559f-e897-4b5f-bc1a-a8fc6c56893e.png)

