### PR TITLE
Bug fix for multiple axes

### DIFF
--- a/Gallery/Vectors/NCL_vector_1.py
+++ b/Gallery/Vectors/NCL_vector_1.py
@@ -56,7 +56,7 @@ lon_uv = u['lon']
 # Plot:
 
 # Generate figure (set its size (width, height) in inches)
-plt.subplots(figsize=(10, 7))
+plt.figure(figsize=(10, 7))
 
 # Generate axes using Cartopy projection
 ax = plt.axes(projection=ccrs.PlateCarree())

--- a/Gallery/Vectors/NCL_vector_3.py
+++ b/Gallery/Vectors/NCL_vector_3.py
@@ -42,7 +42,7 @@ ds = file_in.isel(time=1, lon=slice(0, -1, 3), lat=slice(1, -1, 3))
 # Plot:
 
 # Generate figure (set its size (width, height) in inches)
-plt.subplots(figsize=(10, 5.25))
+plt.figure(figsize=(10, 5.25))
 
 # Generate axes using Cartopy projection
 ax = plt.axes(projection=ccrs.PlateCarree())

--- a/Gallery/Vectors/NCL_vector_4.py
+++ b/Gallery/Vectors/NCL_vector_4.py
@@ -40,7 +40,7 @@ ds = file_in.isel(time=0, lev=12, lon=slice(0, -1, 5), lat=slice(2, -1, 3))
 # this plot does not look as identical as the NCL version.
 
 # Generate figure (set its size (width, height) in inches)
-fig, ax = plt.subplots(figsize=(10, 7.25))
+fig = plt.figure(figsize=(10, 7.25))
 
 # Generate axes using Cartopy projection
 ax = plt.axes(projection=ccrs.PlateCarree())


### PR DESCRIPTION
`NCL_vector_1.py`, `NCL_vector_3.py`, and `NCL_vector_4.py` all had an issue with multiple axes. This PR fixes that bug by replacing `plt.subplots` with `plt.figure` since none of the scripts required multiple axes.

This bug is recent and the cause of it is still uncertain given that `matplotlib` has not had recent updates and the recently released `cartopy` [v0.20.3](https://github.com/SciTools/cartopy/releases/tag/v0.20.3) has no changes to `GeoAxes` in it's change log.