### PR TITLE
Reduce Concurrent Tests

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -1,0 +1,37 @@
+name: CI
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 1 * * *' # Daily “At 01:00”
+
+jobs:
+  build-and-run:
+    name: Build Sphinx Docs (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu-latest", "macos-latest"]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create conda environment
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+      uses: mamba-org/provision-with-micromamba@main
+      with:
+         micromamba-version: "latest"
+         environment-name: geocat-examples
+         environment-file: conda_environment.yml
+    - name: Make html
+      shell: bash -l {0}
+      working-directory: ./docs
+      run: |
+        conda info
+        conda list
+        make html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 on:
   pull_request:
   workflow_dispatch:
-  schedule:
-  - cron: '0 0 * * *' # Daily “At 00:00”
 
 jobs:
   build-and-run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest"]
+        os: [ "ubuntu-latest"]
         python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        include:
+          - os: "macos-latest"
+            python-version: "3.7"
+          - os: "macos-latest"
+            python-version: "3.10"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-run:
     name: Build Sphinx Docs (${{ matrix.python-version }}, ${{ matrix.os }})


### PR DESCRIPTION
Addresses #473

Summary of changes:
- adds separate `ci-nightly.yml` workflow that runs on all `os` and `python-version`s at 1 AM nightly
- modifies `ci.yml` to cancel previous workflows and to run `macos-latest` on oldest and newest versions of python we support (3.7 and 3.10) to help concurrency limit (all versions run nightly)