### PR TITLE
Rename nightly workflow to be distinct

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Nightly
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Summary of changes:
- renames workflow from`ci-nightly.yml` from "CI" to "CI Nightly" to be distinct from the "CI" workflow coming from `ci.yml`