### PR TITLE
Fix for skewt plots

### DIFF
--- a/Gallery/Skew-T/NCL_skewt_2_2.py
+++ b/Gallery/Skew-T/NCL_skewt_2_2.py
@@ -96,7 +96,7 @@ x1 = np.linspace(-100, 40, 8)  # The starting x values for the shaded regions
 x2 = np.linspace(-90, 50, 8)  # The ending x values for the shaded regions
 y = [1050, 100]  # The range of y values that the shades regions should cover
 for i in range(0, 8):
-    skew.shade_area(y=y,
+    skew.shade_area(y=y * units.hPa,
                     x1=x1[i],
                     x2=x2[i],
                     color='limegreen',

--- a/Gallery/Skew-T/NCL_skewt_2_2.py
+++ b/Gallery/Skew-T/NCL_skewt_2_2.py
@@ -70,12 +70,13 @@ skew.plot(p, tdc, color='blue')
 # Draw parcel path
 parcel_prof = mpcalc.parcel_profile(p, tc[0], tdc[0]).to('degC')
 skew.plot(p, parcel_prof, color='red', linestyle='--')
-u = np.where(p >= 100 * units.hPa, u, np.nan) * units.hPa
-v = np.where(p >= 100 * units.hPa, v, np.nan) * units.hPa
-p = np.where(p >= 100 * units.hPa, p, np.nan) * units.hPa
+u = np.where(p >= 100 * units.hPa, u, np.nan)
+v = np.where(p >= 100 * units.hPa, v, np.nan)
+p = np.where(ds[1].values >= 100, ds[1].values,
+             np.nan)  # unitless for plot_barbs
 
 # Add wind barbs
-skew.plot_barbs(p[::2],
+skew.plot_barbs(pressure=p[::2],
                 u=u[::2],
                 v=v[::2],
                 xloc=1.05,
@@ -96,7 +97,7 @@ x1 = np.linspace(-100, 40, 8)  # The starting x values for the shaded regions
 x2 = np.linspace(-90, 50, 8)  # The ending x values for the shaded regions
 y = [1050, 100]  # The range of y values that the shades regions should cover
 for i in range(0, 8):
-    skew.shade_area(y=y * units.hPa,
+    skew.shade_area(y=y,
                     x1=x1[i],
                     x2=x2[i],
                     color='limegreen',

--- a/Gallery/Skew-T/NCL_skewt_2_2.py
+++ b/Gallery/Skew-T/NCL_skewt_2_2.py
@@ -70,9 +70,9 @@ skew.plot(p, tdc, color='blue')
 # Draw parcel path
 parcel_prof = mpcalc.parcel_profile(p, tc[0], tdc[0]).to('degC')
 skew.plot(p, parcel_prof, color='red', linestyle='--')
-u = np.where(p >= 100 * units.hPa, u, np.nan)
-v = np.where(p >= 100 * units.hPa, v, np.nan)
-p = np.where(p >= 100 * units.hPa, p, np.nan)
+u = np.where(p >= 100 * units.hPa, u, np.nan) * units.hPa
+v = np.where(p >= 100 * units.hPa, v, np.nan) * units.hPa
+p = np.where(p >= 100 * units.hPa, p, np.nan) * units.hPa
 
 # Add wind barbs
 skew.plot_barbs(p[::2],

--- a/Gallery/Skew-T/NCL_skewt_3_2.py
+++ b/Gallery/Skew-T/NCL_skewt_3_2.py
@@ -66,8 +66,8 @@ skew.plot(p, tc, 'black')
 skew.plot(p, tdc, 'blue')
 # Plot only every third windbarb
 skew.plot_barbs(pressure=p[::3],
-                u=u[::3] * units.hPa,
-                v=v[::3] * units.hPa,
+                u=u[::3],
+                v=v[::3],
                 xloc=1.05,
                 fill_empty=True,
                 sizes=dict(emptybarb=0.075, width=0.1, height=0.2))

--- a/Gallery/Skew-T/NCL_skewt_3_2.py
+++ b/Gallery/Skew-T/NCL_skewt_3_2.py
@@ -32,7 +32,7 @@ import geocat.viz as gv
 ds = pd.read_csv(gdf.get('ascii_files/sounding_ATS.csv'), header=None)
 
 # Extract the data
-p = ds[0].values * units.hPa  # Pressure [mb/hPa]
+p = ds[0].values  # Pressure [mb/hPa] (unitless for plot_barbs)
 tc = ds[1].values * units.degC  # Temperature [C]
 tdc = ds[2].values * units.degC  # Dew pt temp  [C]
 wspd = ds[5].values * units.knots  # Wind speed   [knots or m/s]
@@ -66,8 +66,8 @@ skew.plot(p, tc, 'black')
 skew.plot(p, tdc, 'blue')
 # Plot only every third windbarb
 skew.plot_barbs(pressure=p[::3],
-                u=u[::3],
-                v=v[::3],
+                u=u[::3] * units.hPa,
+                v=v[::3] * units.hPa,
                 xloc=1.05,
                 fill_empty=True,
                 sizes=dict(emptybarb=0.075, width=0.1, height=0.2))

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - jupyterlab
   - make
   - matplotlib
-  - metpy=1.3.0
+  - metpy
   - mock
   - nbsphinx
   - netcdf4

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - jupyterlab
   - make
   - matplotlib
-  - metpy
+  - metpy=1.3.0
   - mock
   - nbsphinx
   - netcdf4


### PR DESCRIPTION
Addresses #481 

Summary of changes:
- remove units from `p` for `metpy.plot_barbs` call
- comments about making `p` unitless

Notes:
- Not clear why this started failing, other than it _might_ be connected to the newest sphinx (5.5.1) release on Wednesday.
- This change is, as far as I can tell, only reproducible by running `make html`. Neither `skewt_2_2` or `skewt_3_2` have had issues running locally outside of sphinx generation
- Might be a bug we should report to metpy. 