### PR TITLE
Pin xarray in conda_environment.yml

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - sphinx
   - sphinx-gallery
   - sphinx_rtd_theme
+  - xarray<=2023.02.0
   - wrf-python
   - pip:
       - pre-commit


### PR DESCRIPTION
This PR pins the xarray version to <=2023.02.0 as the latest versoin of xarray is causing checks to fail. This is a temporary fix, see #495 for more details