### PR TITLE
Update ncl_skewt_2_2

### DIFF
--- a/Gallery/Skew-T/NCL_skewt_2_2.py
+++ b/Gallery/Skew-T/NCL_skewt_2_2.py
@@ -23,7 +23,6 @@ import metpy.calc as mpcalc
 
 import geocat.viz as gv
 import geocat.datafiles as gdf
-import geocat.comp.skewt_params as gcskewt
 
 ##############################################################################
 # Read in data:
@@ -48,7 +47,7 @@ u, v = mpcalc.wind_components(wspd, wdir)  # Calculate wind components
 tc0 = tc[0]  # Temperature of surface parcel
 tdc0 = tdc[0]  # Dew point temperature of surface parcel
 pro = mpcalc.parcel_profile(p, tc0, tdc0)  # Temperature profile of parcel
-subtitle = gcskewt.get_skewt_vars(p, tc, tdc, pro)  # Create subtitle
+subtitle = gv.get_skewt_vars(p, tc, tdc, pro)  # Create subtitle
 
 ##############################################################################
 # Plot:


### PR DESCRIPTION
Closes #497

This PR changes the call to `get_skewt_vars` from trying to import from geocat.comp to using the function of the same name from geocat.viz. This will resolve some build errors and keep main from failing.