### PR TITLE
change deprecated np.int alias to np.int32

### DIFF
--- a/Gallery/Contours/NCL_conwomap_3.py
+++ b/Gallery/Contours/NCL_conwomap_3.py
@@ -79,7 +79,7 @@ cp = ax.contour(xdata, ydata, zdata, colors='black', linewidths=1.0)
 ax.clabel(cp, inline=True, fontsize=10, colors='black', fmt="%.0f")
 
 # Ignore second half of the graph
-y1 = np.full(shape=len(xlist), fill_value=0, dtype=np.int)
+y1 = np.full(shape=len(xlist), fill_value=0, dtype=np.int32)
 y2 = x
 ax.fill_between(x,
                 y1,

--- a/Gallery/Meteograms/NCL_meteo_1.py
+++ b/Gallery/Meteograms/NCL_meteo_1.py
@@ -129,7 +129,7 @@ cont3labels = ax1.clabel(contour3,
 ]
 
 # Determine the labels for each tick on the x and y axes
-yticklabels = np.array(levels, dtype=np.int)
+yticklabels = np.array(levels, dtype=np.int32)
 xticklabels = [
     '12z', '15z', '18z', '21z', 'Apr29', '03z', '06z', '09z', '12z', '15z',
     '18z', '21z', 'Apr30', '03z', '06z', '09z', '12z', '15z', '18z', '21z',

--- a/GeoCAT-comp-examples/comp_only/moc_globe_atl_example.py
+++ b/GeoCAT-comp-examples/comp_only/moc_globe_atl_example.py
@@ -47,7 +47,7 @@ tlat = ds.TLAT[:].values.astype(np.double)
 
 # Read important parameters from input data
 nyaux = lat_aux_grid.shape[0]  # 395
-km = np.max(kmt.values).astype(np.int)
+km = np.max(kmt.values).astype(np.int32)
 ny = tarea.shape[0]
 nx = tarea.shape[1]
 


### PR DESCRIPTION
Changes the deprecated `np.int` alias to `np.int32` per the guidance from numpy: 
https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated

Opted to use `np.int32` rather than `int` for specificity.

Closes #510 .