### PR TITLE
Unpin matplotlib and remove old ncar channel

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -2,7 +2,7 @@ name: geocat-examples
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8
+  - python>=3.8, <3.11  # minimum support 3.8, 3.11 not yet fully supported
   - geocat-comp
   - cf_xarray>=0.3.1
   - geocat-datafiles

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -1,7 +1,6 @@
 name: geocat-examples
 channels:
   - conda-forge
-  - ncar
 dependencies:
   - python>=3.8
   - geocat-comp
@@ -15,7 +14,7 @@ dependencies:
   - jupyter
   - jupyterlab
   - make
-  - matplotlib<3.6
+  - matplotlib
   - metpy
   - mock
   - nbsphinx


### PR DESCRIPTION
Unpin matplotlib version and remove old ncar channel from the conda env file.  I did double check that datafiles and wrf-python are both on conda-forge as well and we should be good.

Closes #517