### PR TITLE
Adjust notebook plot sizing

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -5,10 +5,12 @@ dependencies:
   - python>=3.8, <3.11  # minimum support 3.8, 3.11 not yet fully supported
   - geocat-comp
   - cf_xarray>=0.3.1
+  - datashader
   - geocat-datafiles
   - eofs
   - fiona
   - geocat-viz
+  - geoviews
   - holoviews
   - cartopy
   - geographiclib

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - eofs
   - fiona
   - geocat-viz
+  - holoviews
   - cartopy
   - geographiclib
   - jupyter

--- a/docs/gallery-notebooks/Datashader/MPAS_Datashader_Trimesh.ipynb
+++ b/docs/gallery-notebooks/Datashader/MPAS_Datashader_Trimesh.ipynb
@@ -66,8 +66,8 @@
     "hv.extension(\"bokeh\",\"matplotlib\")\n",
     "\n",
     "opts.defaults(\n",
-    "    opts.Image(responsive=True, aspect='equal'),\n",
-    "    opts.RGB(responsive=True, aspect='equal'))\n"
+    "    opts.Image(frame_width=600, data_aspect=1),\n",
+    "    opts.RGB(frame_width=600, data_aspect=1))\n"
    ]
   },
   {
@@ -106,7 +106,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# This funtion splits a global mesh along longitude\n",
@@ -121,7 +123,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Compute the signed area of a triangle\n",
@@ -133,7 +137,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Reorder triangles as necessary so they all have counter clockwise winding order. CCW is what Datashader and MPL\n",
@@ -147,7 +153,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Create a Holoviews Triangle Mesh suitable for rendering with Datashader\n",
@@ -181,7 +189,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Triangulate MPAS primary mesh:\n",

--- a/docs/gallery-notebooks/Datashader/MPAS_Datashader_Trimesh.ipynb
+++ b/docs/gallery-notebooks/Datashader/MPAS_Datashader_Trimesh.ipynb
@@ -66,8 +66,8 @@
     "hv.extension(\"bokeh\",\"matplotlib\")\n",
     "\n",
     "opts.defaults(\n",
-    "    opts.Image(responsive=True),\n",
-    "    opts.RGB(responsive=True))\n"
+    "    opts.Image(responsive=True, aspect='equal'),\n",
+    "    opts.RGB(responsive=True, aspect='equal'))\n"
    ]
   },
   {


### PR DESCRIPTION
Adjust notebook plot sizing to look cleaner with the new theme.  

For context: I was hoping to be able to use the responsive options that would adjust with the window size, but unfortunately those don't seem to work well in this case.  I could only get the responsive width to work, but that was distorting the visualizations.  Setting the width in pixels to something that should look reasonable in most cases was a compromise.  

This PR also adds needed dependencies (e.g. geoviews, holoviews, datashader) to the environment so that everything builds with the clean notebook (no cells run ahead of time).  This may take a little longer to build for testing and obviously adds some dependencies so open to pulling this from the PR.  

Closes #519.