### PR TITLE
Fix references to geocat-f2py functions that were broken by the latest release of geocat-comp

### DIFF
--- a/GeoCAT-comp-examples/comp_only/moc_globe_atl_example.py
+++ b/GeoCAT-comp-examples/comp_only/moc_globe_atl_example.py
@@ -3,18 +3,18 @@ moc_globe_atl_example.py
 ========================
 
 This script illustrates the following concepts:
-   - Usage of geocat-comp's `moc_globe_atl` function
+   - Usage of geocat-f2py's `moc_globe_atl` function
    - Computing POP MOC field offline from POP netcdf history files (designed for the CESM4 ocean component)
    - Usage of geocat-datafiles for accessing NetCDF files
    - Usage of geocat-viz plotting convenience functions
 
 See following GitHub repositories to see further information about the function and to access data:
-    - For `moc_globe_atl` function: https://github.com/NCAR/geocat-comp
+    - For `moc_globe_atl` function: https://github.com/NCAR/geocat-f2py
     - For "tavg_downsized.nc" file: https://github.com/NCAR/geocat-datafiles/tree/main/netcdf_files
 
 Dependencies:
-    - geocat.comp
     - geocat.datafiles (Not necessary but for conveniently accessing the NetCDF data file)
+    - geocat.f2py
     - numpy
     - xarray
 
@@ -27,7 +27,7 @@ import numpy as np
 import xarray as xr
 
 import geocat.datafiles as gdf
-from geocat.comp import moc_globe_atl
+from geocat.f2py import moc_globe_atl
 
 ###############################################################################
 # Read in data:
@@ -74,9 +74,9 @@ a_bolus = np.where(ocean, w_i[0, :, :, :] * tarea3d, 0.0)
 a_submeso = np.where(ocean, w_sm[0, :, :, :] * tarea3d, 0.0)
 
 ###############################################################################
-# GeoCAT-comp function call:
+# GeoCAT-f2py function call:
 
-# Invoke `moc_globe_atl` from `geocat-comp`
+# Invoke `moc_globe_atl` from `geocat-f2py`
 result = moc_globe_atl(lat_aux_grid,
                        a_wvel,
                        a_bolus,

--- a/GeoCAT-comp-examples/matplotlib/linint2_example.py
+++ b/GeoCAT-comp-examples/matplotlib/linint2_example.py
@@ -3,17 +3,17 @@ linint2_example.py
 ==================
 
 This script illustrates the following concepts:
-   - Usage of geocat-comp's `linint2` function
+   - Usage of geocat-f2py's `linint2` function
    - Bilinear Interpolation from a rectilinear grid to another rectilinear grid
    - Usage of geocat-datafiles for accessing NetCDF files
    - Usage of geocat-viz plotting convenience functions
 
 See following GitHub repositories to see further information about the function and to access data:
-    - For `linint2` function: https://github.com/NCAR/geocat-comp
+    - For `linint2` function: https://github.com/NCAR/geocat-f2py
     - For "sst.nc" file: https://github.com/NCAR/geocat-datafiles/tree/main/netcdf_files
 
 Dependencies:
-    - geocat.comp
+    - geocat.f2py
     - geocat.datafiles (Not necessary but for conveniently accessing the NetCDF data file)
     - geocat.viz (Not necessary but for plotting convenience)
     - numpy
@@ -36,7 +36,7 @@ from mpl_toolkits.axes_grid1 import AxesGrid
 
 import geocat.datafiles as gdf
 import geocat.viz as gv
-from geocat.comp import linint2
+from geocat.f2py import linint2
 
 ###############################################################################
 # Read in data:
@@ -49,13 +49,13 @@ lat = ds.LAT[:]
 lon = ds.LON[:]
 
 ###############################################################################
-# GeoCAT-comp function call:
+# GeoCAT-f2py function call:
 
 # Provide (output) interpolation grid
 newlat = np.linspace(min(lat), max(lat), 24)
 newlon = np.linspace(min(lon), max(lon), 72)
 
-# Invoke `linint2` from `geocat.comp`
+# Invoke `linint2` from `geocat.f2py`
 newsst = linint2(sst, newlon, newlat, icycx=False)
 
 ###############################################################################

--- a/GeoCAT-comp-examples/matplotlib/linint2pts_example.py
+++ b/GeoCAT-comp-examples/matplotlib/linint2pts_example.py
@@ -3,17 +3,17 @@ linint2pts_example.py
 =====================
 
 This script illustrates the following concepts:
-   - Usage of geocat-comp's `linint2pts` function
+   - Usage of geocat-f2py's `linint2pts` function
    - Bilinear interpolation from a rectilinear grid to an unstructured grid or locations
    - Usage of geocat-datafiles for accessing NetCDF files
    - Usage of geocat-viz plotting convenience functions
 
 See following GitHub repositories to see further information about the function and to access data:
-    - For `linint2pts` function: https://github.com/NCAR/geocat-comp
+    - For `linint2pts` function: https://github.com/NCAR/geocat-f2py
     - For "sst.nc" data file: https://github.com/NCAR/geocat-datafiles/tree/main/netcdf_files
 
 Dependencies:
-    - geocat.comp
+    - geocat.f2py
     - geocat.datafiles (Not necessary but for conveniently accessing the NetCDF data file)
     - geocat.viz (Not necessary but for plotting convenience)
     - numpy
@@ -36,7 +36,7 @@ from mpl_toolkits.axes_grid1 import AxesGrid
 
 import geocat.viz as gv
 import geocat.datafiles as gdf
-from geocat.comp import linint2pts
+from geocat.f2py import linint2pts
 
 ###############################################################################
 # Read in data:
@@ -50,7 +50,7 @@ lat = ds.LAT[:]
 lon = ds.LON[:]
 
 ###############################################################################
-# GeoCAT-comp function call:
+# GeoCAT-f2py function call:
 
 # Provide (output) interpolation locations. This script uses 3000 arbitrary
 # locations world-wide in order to demonstrate an extensive comparison of the
@@ -59,7 +59,7 @@ lon = ds.LON[:]
 newlat = np.random.uniform(low=min(lat), high=max(lat), size=(3000,))
 newlon = np.random.uniform(low=min(lon), high=max(lon), size=(3000,))
 
-# Call `linint2pts` from `geocat-comp`
+# Call `linint2pts` from `geocat-f2py`
 newsst = linint2pts(sst, newlon, newlat, False)
 
 ###############################################################################

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python>=3.8, <3.11  # minimum support 3.8, 3.11 not yet fully supported
   - geocat-comp
+  - geocat-f2py
   - cf_xarray>=0.3.1
   - datashader
   - geocat-datafiles


### PR DESCRIPTION
Adds geocat-f2py to the environment and changes references to geocat-f2py from comp for functions that were removed from comp in the comp / f2py disentanglement.  

Closes #525