### PR TITLE
Adjust contour levels and colorbar ticks to adapt to updates in Matplotlib 3.6+

### DIFF
--- a/Gallery/Animations/NCL_animate_1.py
+++ b/Gallery/Animations/NCL_animate_1.py
@@ -58,38 +58,35 @@ gv.add_major_minor_ticks(ax, labelsize=10)
 gv.add_lat_lon_ticklabels(ax)
 
 # Create initial plot
-plot = tas[0, :, :].plot.contourf(ax=ax,
-                                  transform=ccrs.PlateCarree(),
-                                  vmin=195,
-                                  vmax=328,
-                                  levels=53,
-                                  cmap="inferno",
-                                  add_colorbar=False
-                                 )
+cplot = tas[0, :, :].plot.contourf(ax=ax,
+                                   transform=ccrs.PlateCarree(),
+                                   vmin=195,
+                                   vmax=328,
+                                   levels=53,
+                                   cmap="inferno",
+                                   add_colorbar=False)
 
 # Create a colorbar
-cbar = fig.colorbar(plot,
+cbar = fig.colorbar(cplot,
                     extendrect=True,
                     orientation="horizontal",
                     ticks=np.arange(195, 332, 9),
                     label="",
-                    shrink=0.90
-                   )
+                    shrink=0.90)
 
 # Remove minor ticks from colorbar that don't work well with other formatting
 cbar.ax.minorticks_off()
 
+
 # Animate function for matplotlib FuncAnimation
 def animate(i):
-    tas[i, :, :].plot.contourf(
-        ax=ax,
-        transform=ccrs.PlateCarree(),
-        vmin=195,
-        vmax=328,
-        levels=53,
-        cmap="inferno",
-        add_colorbar=False,
-    )
+    tas[i, :, :].plot.contourf(ax=ax,
+                               transform=ccrs.PlateCarree(),
+                               vmin=195,
+                               vmax=328,
+                               levels=53,
+                               cmap="inferno",
+                               add_colorbar=False)
 
     gv.set_titles_and_labels(
         ax,
@@ -97,6 +94,7 @@ def animate(i):
         str(tas.coords['time'].values[i])[:13],
         xlabel="",
         ylabel="")
+
 
 # Run the animation initiated with the frame from init and progressed with the animate function
 anim = animation.FuncAnimation(fig, animate, frames=30, interval=200)

--- a/Gallery/Animations/NCL_animate_1.py
+++ b/Gallery/Animations/NCL_animate_1.py
@@ -38,41 +38,48 @@ tas = ds.t
 # Create animation:
 
 fig = plt.figure(figsize=(10, 8))
+
 # Generate axes using Cartopy and draw coastlines
 ax = plt.axes(projection=ccrs.PlateCarree(central_longitude=150))
 ax.coastlines(linewidths=0.5)
 ax.set_extent([-180, 180, -90, 90], ccrs.PlateCarree())
 
-# Use geocat.viz.util convenience function to set axes limits & tick values
+# Use geocat-viz convenience function to set axes limits & tick values
 gv.set_axes_limits_and_ticks(ax,
                              xlim=(-180, 180),
                              ylim=(-90, 90),
                              xticks=np.linspace(-180, 180, 13),
                              yticks=np.linspace(-90, 90, 7))
 
-# Use geocat.viz.util convenience function to add minor and major tick lines
+# Use geocat-viz convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, labelsize=10)
 
-# Use geocat.viz.util convenience function to make latitude, longitude tick labels
+# Use geocat-viz convenience function to make latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
 
-# create initial plot that establishes a colorbar
-tas[0, :, :].plot.contourf(ax=ax,
-                           transform=ccrs.PlateCarree(),
-                           vmin=195,
-                           vmax=328,
-                           levels=53,
-                           cmap="inferno",
-                           cbar_kwargs={
-                               "extendrect": True,
-                               "orientation": "horizontal",
-                               "ticks": np.arange(195, 332, 9),
-                               "label": "",
-                               "shrink": 0.90
-                           })
+# Create initial plot
+plot = tas[0, :, :].plot.contourf(ax=ax,
+                                  transform=ccrs.PlateCarree(),
+                                  vmin=195,
+                                  vmax=328,
+                                  levels=53,
+                                  cmap="inferno",
+                                  add_colorbar=False
+                                 )
 
+# Create a colorbar
+cbar = fig.colorbar(plot,
+                    extendrect=True,
+                    orientation="horizontal",
+                    ticks=np.arange(195, 332, 9),
+                    label="",
+                    shrink=0.90
+                   )
 
-# animate function for matplotlib FuncAnimation
+# Remove minor ticks from colorbar that don't work well with other formatting
+cbar.ax.minorticks_off()
+
+# Animate function for matplotlib FuncAnimation
 def animate(i):
     tas[i, :, :].plot.contourf(
         ax=ax,
@@ -91,9 +98,8 @@ def animate(i):
         xlabel="",
         ylabel="")
 
-
-# runs the animation initiated with the frame from init and progressed with the animate function
+# Run the animation initiated with the frame from init and progressed with the animate function
 anim = animation.FuncAnimation(fig, animate, frames=30, interval=200)
 
-# Uncomment this line to save the created animation
+# Uncomment this line to save the animation
 #anim.save('animate_1.gif', writer='pillow', fps=5)

--- a/Gallery/Colors/CB_Height.py
+++ b/Gallery/Colors/CB_Height.py
@@ -79,7 +79,7 @@ def Plot(color, row, col, pos, title):
     # Contourf-plot data
     hgt = t.plot.contourf(ax=ax1,
                           transform=projection,
-                          levels=40,
+                          levels=31,
                           vmin=100,
                           vmax=1600,
                           cmap=newcmp,

--- a/Gallery/Colors/CB_Rain.py
+++ b/Gallery/Colors/CB_Rain.py
@@ -79,7 +79,7 @@ def Plot(color, row, col, pos, title):
     # Contourf-plot data
     pre = t.plot.contourf(ax=ax1,
                           transform=projection,
-                          levels=14,
+                          levels=13,
                           vmin=0,
                           vmax=240,
                           cmap=newcmp,

--- a/Gallery/Colors/CB_Temperature.py
+++ b/Gallery/Colors/CB_Temperature.py
@@ -81,7 +81,7 @@ def Plot(color, row, col, pos, title):
     # Contourf-plot data
     temp = t.plot.contourf(ax=ax1,
                            transform=projection,
-                           levels=40,
+                           levels=33,
                            vmin=0,
                            vmax=32,
                            cmap=newcmp,

--- a/Gallery/Masking/NCL_mask_5.py
+++ b/Gallery/Masking/NCL_mask_5.py
@@ -90,7 +90,7 @@ contour = wrap_t.plot.contourf(ax=ax1,
                                transform=ccrs.PlateCarree(),
                                vmin=235,
                                vmax=315,
-                               levels=18,
+                               levels=17,
                                cmap='magma',
                                add_colorbar=False)
 
@@ -103,7 +103,7 @@ cbar = plt.colorbar(contour,
                     extendrect=True,
                     extendfrac='auto',
                     use_gridspec=False,
-                    ticks=np.arange(240, 315, 5))
+                    ticks=np.arange(235, 315, 5))
 
 cbar.ax.tick_params(labelsize=10)
 

--- a/Gallery/Vectors/NCL_vector_1.py
+++ b/Gallery/Vectors/NCL_vector_1.py
@@ -73,9 +73,9 @@ ax.set_extent((66, 96, 5, 25), crs=ccrs.PlateCarree())
 sst_plot = sst.plot.contourf(
     ax=ax,
     transform=proj,
-    levels=50,
+    levels=51,
     vmin=24,
-    vmax=28.8,
+    vmax=29,
     cmap="magma",
     add_colorbar=False,
 )


### PR DESCRIPTION
Either adjusts the contouring to align with the assigned labels or for the animation example turns off the minor ticks.

Some minor updates to comments in the animation example as well to reflect prior changes.

Closes #574 