### PR TITLE
Add upstream CI

### DIFF
--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -1,0 +1,43 @@
+name: CI Upstream
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily at 00:00 UTC
+  workflow_dispatch: # allows you to trigger the workflow run manually
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upstream-dev:
+    name: upstream-dev
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - name: checkout
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # fetch all history for all branches and tags.
+      - name: set up environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: conda_environment.yml
+          create-args: >-
+            python=${{ matrix.python-version }}
+      - name: install upstream versions
+        run: |
+          bash ci/install-upstream.sh
+      - name: environment info
+        run: |
+          conda info
+          conda list
+      - name: make html
+        working-directory: ./docs
+        run: |
+          make html

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ["3.11"]
     steps:
       - name: checkout
-      - uses: actions/checkout@v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # fetch all history for all branches and tags.
       - name: set up environment

--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# adapted from https://github.com/pydata/xarray/blob/main/ci/install-upstream-wheels.sh
+
+# forcibly remove packages to avoid artifacts
+conda remove -y --force \
+    metpy \
+    numpy \
+    pandas \
+    scipy \
+    xarray \
+    matplotlib \
+    geocat-viz \
+    geocat-comp
+
+# conda list
+conda list
+
+# if available install from nightly wheels
+python -m pip install \
+    -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \
+    --no-deps \
+    --pre \
+    --upgrade \
+    numpy \
+    pandas \
+    scipy \
+    xarray \
+    matplotlib
+
+# install rest from source
+python -m pip install \
+    git+https://github.com/Unidata/MetPy.git \
+    git+https://github.com/NCAR/geocat-comp \
+    git+https://github.com/NCAR/geocat-viz

--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -18,7 +18,8 @@ conda list
 
 # if available install from nightly wheels
 python -m pip install \
-    -i https://pypi.anaconda.org/scipy-wheels-nightly/simple \
+    --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+    --extra-index-url https://pypi.org/simple \
     --no-deps \
     --pre \
     --upgrade \

--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -30,5 +30,5 @@ python -m pip install \
 # install rest from source
 python -m pip install \
     git+https://github.com/Unidata/MetPy.git \
-    git+https://github.com/NCAR/geocat-comp \
-    git+https://github.com/NCAR/geocat-viz
+    git+https://github.com/NCAR/geocat-comp.git \
+    git+https://github.com/NCAR/geocat-viz.git

--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -10,7 +10,8 @@ conda remove -y --force \
     xarray \
     matplotlib \
     geocat-viz \
-    geocat-comp
+    geocat-comp \
+    cartopy
 
 # conda list
 conda list
@@ -31,4 +32,5 @@ python -m pip install \
 python -m pip install \
     git+https://github.com/Unidata/MetPy.git \
     git+https://github.com/NCAR/geocat-comp.git \
-    git+https://github.com/NCAR/geocat-viz.git
+    git+https://github.com/NCAR/geocat-viz.git \
+    git+https://github.com/SciTools/cartopy.git

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -14,9 +14,12 @@ dependencies:
   - metpy
   - nbsphinx
   - netcdf4
+  - numpy
+  - pandas
   - pillow
   - pip
   - scikit-learn
+  - scipy
   - sphinx-book-theme
   - sphinx-design
   - sphinx-gallery


### PR DESCRIPTION
Adds upstream CI based upon what @anissa111 set up for geocat-comp and xarray's upstream CI.  Includes geocat-viz and geocat-comp along with some key dependencies.  

I was able to run this on my fork, but didn't realize turning off actions would break the link to prior runs.  Let me know if you'd like me to turn it back on so you can check out some runs / logs.

I think this is probably a good start, but do wonder if it might catch "too much" the way it's currently configured (e.g. the frequency of testing and number of upstream dev packages we're testing).     

We could also think about adding some sort of automation to generate issues when this fails.  xarray and matplotlib both have this set up in slightly different ways.  xarray's is a bit custom, but some other packages are using it as well (i.e. dask).  matplotlib uses this [issue-bot](https://github.com/imjohnbo/issue-bot).

Closes #507 and #544.