### PR TITLE
Matplotlib 3.8+ compatibility - positional to keyword args and contour label specification fixes

### DIFF
--- a/Gallery/Polygons/NCL_polyg_19.py
+++ b/Gallery/Polygons/NCL_polyg_19.py
@@ -164,13 +164,13 @@ def plotRegion(region, axis, xlim, puertoRico, waterBody):
             color = findDivColor(colorbounds, pop)
             # Set characteristics and measurements of each filled polygon "patch"
             patches.append(
-                Polygon(np.vstack((x, y)).T, True, color=color, linewidth=0.1))
+                Polygon(np.vstack((x, y)).T, closed=True, color=color, linewidth=0.1))
 
         # If the region being plotted is a body of water with no population
         else:
             # Set characteristics and measurements of each filled polygon "patch"
             water_patches.append(
-                Polygon(np.vstack((x, y)).T, True, color='white', linewidth=.7))
+                Polygon(np.vstack((x, y)).T, closed=True, color='white', linewidth=.7))
 
     pc = PatchCollection(patches,
                          match_original=True,

--- a/Gallery/Polygons/NCL_polyg_19.py
+++ b/Gallery/Polygons/NCL_polyg_19.py
@@ -164,13 +164,19 @@ def plotRegion(region, axis, xlim, puertoRico, waterBody):
             color = findDivColor(colorbounds, pop)
             # Set characteristics and measurements of each filled polygon "patch"
             patches.append(
-                Polygon(np.vstack((x, y)).T, closed=True, color=color, linewidth=0.1))
+                Polygon(np.vstack((x, y)).T,
+                        closed=True,
+                        color=color,
+                        linewidth=0.1))
 
         # If the region being plotted is a body of water with no population
         else:
             # Set characteristics and measurements of each filled polygon "patch"
             water_patches.append(
-                Polygon(np.vstack((x, y)).T, closed=True, color='white', linewidth=.7))
+                Polygon(np.vstack((x, y)).T,
+                        closed=True,
+                        color='white',
+                        linewidth=.7))
 
     pc = PatchCollection(patches,
                          match_original=True,

--- a/Gallery/Polygons/NCL_polyg_4.py
+++ b/Gallery/Polygons/NCL_polyg_4.py
@@ -101,7 +101,6 @@ def make_base_plot():
     ]
     ax.clabel(
         hdl,
-        np.arange(-8, 24, 8),  # Only label these contour levels: [-8, 0, 8, 16]
         fontsize="small",
         colors="black",
         fmt="%.0f",  # Turn off decimal points


### PR DESCRIPTION
A couple of minor changes for matplotlib 3.8+ compatibility (all backward compatible):
* Changes the way an argument is specified (positional to keyword)
* Adjusts the way contour labels are specified to avoid an error

Closes #578