### PR TITLE
Address a few problems caught by testing with Python 3.12

### DIFF
--- a/Gallery/Scatter/NCL_scatter_10.py
+++ b/Gallery/Scatter/NCL_scatter_10.py
@@ -14,7 +14,6 @@ See following URLs to see the reproduced NCL plot & script:
 ###############################################################################
 # Import packages:
 
-from unittest import load_tests
 import numpy as np
 import matplotlib.pyplot as plt
 import cartopy.crs as ccrs

--- a/Gallery/Topography/NCL_topo_8.py
+++ b/Gallery/Topography/NCL_topo_8.py
@@ -37,17 +37,17 @@ ds = ds.z
 
 # Open shapefile of US counties
 open(gdf.get("shape_files/countyl010g.dbf"), 'r')
-open(gdf.get("shape_files/states.shp"), 'r')
-open(gdf.get("shape_files/states.shx"), 'r')
-open(gdf.get("shape_files/states.prj"), 'r')
-shapefile_counties = shpreader.Reader(gdf.get("shape_files/countyl010g.dbf"))
+open(gdf.get("shape_files/countyl010g.shp"), 'r')
+open(gdf.get("shape_files/countyl010g.shx"), 'r')
+open(gdf.get("shape_files/countyl010g.prj"), 'r')
+shapefile_counties = shpreader.Reader(gdf.get("shape_files/countyl010g.shp"))
 
 # Open shapefile of all rivers. This data can be downloaded from `NOAA: <https://www.weather.gov/gis/Rivers>`_
 open(gdf.get("shape_files/rv16my07.dbf"), 'r')
 open(gdf.get("shape_files/rv16my07.shx"), 'r')
 open(gdf.get("shape_files/rv16my07.shp"), 'r')
 open(gdf.get("shape_files/rv16my07.prj"), 'r')
-shapefile_rivers = shpreader.Reader(gdf.get("shape_files/rv16my07.dbf"))
+shapefile_rivers = shpreader.Reader(gdf.get("shape_files/rv16my07.shp"))
 
 ###############################################################################
 # Plot:

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - sphinx-design
   - sphinx-gallery
   - xarray
+  - dask
   - wrf-python
   - pip:
       - pre-commit


### PR DESCRIPTION
Addresses a few problems caught by testing with Python 3.12:
* an unnecessary import that will no longer work
* fix some shapefile reads that now break 
* add dask to the conda env because xarray needs it in at least one of our examples

We'll still need to wait on a few dependencies for Python 3.12, but these are probably good to get in anyway.

Related to #550.