### PR TITLE
Pin Sphinx version to address gallery issues

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - pip
   - scikit-learn
   - scipy
+  - sphinx<7
   - sphinx-book-theme
   - sphinx-design
   - sphinx-gallery


### PR DESCRIPTION
Pins Sphinx < 7 to address the broken gallery links / thumbnail issues (for the time being).

I'd like to understand a bit better what's going on so we can address it more fully and/or log some issues, but building the gallery locally is a bit challenging at the moment (because of wrf-python).

Relates to #587.