### PR TITLE
Use macos-13 runners to keep testing on Intel-based Macs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest"]
+        os: [ "ubuntu-latest", "macos-13" ]
         python-version: [ "3.9", "3.10", "3.11" ]
-        include:
-          - os: "macos-latest"
-            python-version: "3.9"
-          - os: "macos-latest"
-            python-version: "3.11"
 
     steps:
     - name: checkout


### PR DESCRIPTION
Changes our CI to use macos-13 runners in order to keep testing on Intel-based Macs until our dependencies support running on Apple silicon (see #604).