### PR TITLE
Better mimic NCL's satellite projection

### DIFF
--- a/Gallery/MapProjections/NCL_sat_1.py
+++ b/Gallery/MapProjections/NCL_sat_1.py
@@ -48,8 +48,9 @@ wrap_pressure = gv.xr_add_cyclic_longitudes(pressure, "lon")
 # Set figure size
 fig = plt.figure(figsize=(8, 8))
 
-# Set global axes with a nearside perspective projection (equivalent to NCL's satellite projection)
-proj = ccrs.NearsidePerspective(central_longitude=270.0, central_latitude=45.0, satellite_height=19134300)
+# Set global axes with a nearside perspective projection (equivalent to NCL's
+# satellite projection)
+proj = ccrs.NearsidePerspective(central_longitude=270.0, central_latitude=45.0, satellite_height=12742000)
 ax = plt.axes(projection=proj)
 ax.set_global()
 

--- a/Gallery/MapProjections/NCL_sat_1.py
+++ b/Gallery/MapProjections/NCL_sat_1.py
@@ -50,7 +50,9 @@ fig = plt.figure(figsize=(8, 8))
 
 # Set global axes with a nearside perspective projection (equivalent to NCL's
 # satellite projection)
-proj = ccrs.NearsidePerspective(central_longitude=270.0, central_latitude=45.0, satellite_height=12742000)
+proj = ccrs.NearsidePerspective(central_longitude=270.0,
+                                central_latitude=45.0,
+                                satellite_height=12742000)
 ax = plt.axes(projection=proj)
 ax.set_global()
 

--- a/Gallery/MapProjections/NCL_sat_1.py
+++ b/Gallery/MapProjections/NCL_sat_1.py
@@ -48,8 +48,8 @@ wrap_pressure = gv.xr_add_cyclic_longitudes(pressure, "lon")
 # Set figure size
 fig = plt.figure(figsize=(8, 8))
 
-# Set global axes with an orthographic projection
-proj = ccrs.Orthographic(central_longitude=270, central_latitude=45)
+# Set global axes with a nearside perspective projection (equivalent to NCL's satellite projection)
+proj = ccrs.NearsidePerspective(central_longitude=270.0, central_latitude=45.0, satellite_height=19134300)
 ax = plt.axes(projection=proj)
 ax.set_global()
 

--- a/Gallery/MapProjections/NCL_sat_2.py
+++ b/Gallery/MapProjections/NCL_sat_2.py
@@ -50,8 +50,9 @@ wrap_pressure = gv.xr_add_cyclic_longitudes(pressure, "lon")
 # Set figure size
 fig = plt.figure(figsize=(8, 8))
 
-# Set global axes with an orthographic projection
-proj = ccrs.Orthographic(central_longitude=270, central_latitude=45)
+# Set global axes with a nearside perspective projection (equivalent to NCL's
+# satellite projection)
+proj = ccrs.NearsidePerspective(central_longitude=270.0, central_latitude=45.0, satellite_height=12742000)
 ax = plt.axes(projection=proj)
 ax.set_global()
 

--- a/Gallery/MapProjections/NCL_sat_2.py
+++ b/Gallery/MapProjections/NCL_sat_2.py
@@ -52,7 +52,9 @@ fig = plt.figure(figsize=(8, 8))
 
 # Set global axes with a nearside perspective projection (equivalent to NCL's
 # satellite projection)
-proj = ccrs.NearsidePerspective(central_longitude=270.0, central_latitude=45.0, satellite_height=12742000)
+proj = ccrs.NearsidePerspective(central_longitude=270.0,
+                                central_latitude=45.0,
+                                satellite_height=12742000)
 ax = plt.axes(projection=proj)
 ax.set_global()
 

--- a/Gallery/MapProjections/NCL_sat_3.py
+++ b/Gallery/MapProjections/NCL_sat_3.py
@@ -41,10 +41,10 @@ t = ds.T.isel(time=0, z_t=0)
 
 plt.figure(figsize=(8, 8))
 
-# Create an axis with an orthographic projection
+# Create an axis with an orthographic projection (equivalent to NCL's satellite
+# projection where mpSatelliteDistF <= 1.0)
 ax = plt.axes(projection=ccrs.Orthographic(central_longitude=-35,
-                                           central_latitude=60),
-              anchor='C')
+                                           central_latitude=60))
 
 # Set extent of map
 ax.set_extent((-80, -10, 30, 80), crs=ccrs.PlateCarree())

--- a/Gallery/MapProjections/NCL_sat_3.py
+++ b/Gallery/MapProjections/NCL_sat_3.py
@@ -43,8 +43,8 @@ plt.figure(figsize=(8, 8))
 
 # Create an axis with an orthographic projection (equivalent to NCL's satellite
 # projection where mpSatelliteDistF <= 1.0)
-ax = plt.axes(projection=ccrs.Orthographic(central_longitude=-35,
-                                           central_latitude=60))
+ax = plt.axes(
+    projection=ccrs.Orthographic(central_longitude=-35, central_latitude=60))
 
 # Set extent of map
 ax.set_extent((-80, -10, 30, 80), crs=ccrs.PlateCarree())


### PR DESCRIPTION
Adjusts the three satellite projection examples to better mimic NCL's satellite projection using Cartopy's [NearsidePerspective](https://scitools.org.uk/cartopy/docs/v0.15/crs/projections.html#cartopy.crs.NearsidePerspective) (which allow for a satellite_height option) and [Orthographic](https://scitools.org.uk/cartopy/docs/v0.15/crs/projections.html#orthographic) (equivalent in certain cases) projections.

Closes #602.