### PR TITLE
pins micromamba and update the frequency for upstream-dev CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     - name: setup micromamba
       uses: mamba-org/setup-micromamba@v1
       with:
+         micromamba-version: '1.5.10-0'
          environment-name: geocat-examples
          environment-file: conda_environment.yml
          cache-environment: true

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -27,6 +27,7 @@ jobs:
       - name: set up environment
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: conda_environment.yml
           create-args: >-
             python=${{ matrix.python-version }}

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -1,7 +1,7 @@
 name: CI Upstream
 on:
   schedule:
-    - cron: "0 0 * * *" # daily at 00:00 UTC
+    - cron: "0 0 * * 0" # daily at 00:00 UTC
   workflow_dispatch: # allows you to trigger the workflow run manually
 
 concurrency:


### PR DESCRIPTION
Pins micromamba temporarily while upstream issues are addressed: https://github.com/mamba-org/setup-micromamba/issues/225

This should get our CI passing again though upstream-dev will still be failing because of the SciPy changes.

Also, updates the frequency for upstream-dev CI to weekly.  Realistically, I don't think we're addressing issues fast enough to warrant anything more frequent.