### PR TITLE
Address CI failures from upstream Matplotlib changes

### DIFF
--- a/Gallery/Contours/NCL_hov_3.py
+++ b/Gallery/Contours/NCL_hov_3.py
@@ -49,9 +49,8 @@ cf = ax.contourf(lon,
                  hatches=['....'])
 
 # Make all dot-filled areas light gray so contour lines are still visible
-for i, collection in enumerate(cf.collections):
-    collection.set_edgecolor('lightgray')
-    collection.set_linewidth(0.)
+cf.set_edgecolor('lightgray')
+cf.set_linewidth(0.)
 
 # Fill area at the lowest contour level, -6, with line hatching
 cf = ax.contourf(lon,

--- a/Gallery/Overlays/NCL_overlay_11b.py
+++ b/Gallery/Overlays/NCL_overlay_11b.py
@@ -175,15 +175,7 @@ for path in geos_to_path(country_geos):
     #        another contour plot and clip that contour plot with the patch.  In
     #        other words, every island on this plot corresponds to its own
     #        contour plot!)
-    cf = ax.contourf(lon, lat, T, levels=clevs, cmap=newcmp)
-
-    # Clip each contour of the contour plot
-    # (NOTE: Each contour of the contour plot is actually its own "plot".  There
-    #        is no easy mechanism in matplotlib to clip the entire contour plot
-    #        at once, so we must loop through the "collections" in the contour
-    #        plot and clip each one separately.)
-    for col in cf.collections:
-        col.set_clip_path(patch)
+    cf = ax.contourf(lon, lat, T, levels=clevs, cmap=newcmp, clip_path=patch)
 
 # Add horizontal colorbar
 cax = plt.axes((0.14, 0.08, 0.74, 0.02))

--- a/Gallery/XY/NCL_xy_16.py
+++ b/Gallery/XY/NCL_xy_16.py
@@ -96,15 +96,14 @@ plt.plot(U50.data,
 
 # Add legend
 handles, labels = ax.get_legend_handles_labels()
-# Default order is the order in which the data was plotted
-handles = reversed(handles)  # Reverse order of legend elements
-labels = reversed(labels)
+
 plt.legend(handles,
            labels,
            loc='center right',
            frameon=False,
            fontsize=14,
-           labelspacing=1)
+           labelspacing=1,
+           reverse=True)
 
 plt.show()
 
@@ -183,13 +182,13 @@ plt.plot(U50.data,
 # Add legend
 handles, labels = ax.get_legend_handles_labels()
 # Default order is the order in which the data was plotted
-handles = reversed(handles)  # Reverse order of legend elements
-labels = reversed(labels)
+
 plt.legend(handles,
            labels,
            loc='center right',
            frameon=False,
            fontsize=14,
-           labelspacing=1)
+           labelspacing=1,
+           reverse=True)
 
 plt.show()


### PR DESCRIPTION
Addresses several of the failures we're seeing while testing with a dev version of Matplotlib (3.10.0.dev).   

These stem from deprecations following earlier Matplotlib changes with `ContourSet` and `legend`.

Relates to #620

There will be a lingering problem related to hatch color that this PR does not address so I'm leaving the associated issue open for now.  There's also an open issue (confirmed bug) on Matplotlib.