### PR TITLE
Avoid Xarray version w/ bug

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - sphinx-book-theme
   - sphinx-design
   - sphinx-gallery
-  - xarray
+  - xarray!=2024.11.0
   - dask
   - wrf-python
   - pre-commit


### PR DESCRIPTION
Exclude xarray version with the seaborn import bug mentioned in #627.  Since there's already a fix, the next release should be fine (i.e. no need to further constrain the version).

Closes #627