### PR TITLE
plt.scatter needs norm argument in Station 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .DS_Store
 .ipynb_checkpoints/
 *.grd.gz
+**/__pycache__/

--- a/Gallery/Station/NCL_station_2.py
+++ b/Gallery/Station/NCL_station_2.py
@@ -57,8 +57,9 @@ colors = [
 
 nbins = len(colors)  # One bin for each color
 
-# Define colormap for plotting based on these colors
+# Define colormap and norm for plotting based on these colors
 cmap = mpl.colors.ListedColormap(colors)
+norm = mpl.colors.BoundaryNorm([-1.2] + bin_bounds + [35], len(colors))
 
 ###################################################
 # Utility Function: Make Shared Plot:
@@ -100,7 +101,7 @@ def make_shared_plot(title):
                    zorder=0)
 
     # Scatter-plot the location data on the map
-    scatter = plt.scatter(lon, lat, c=dummy_data, cmap=cmap, zorder=1)
+    scatter = plt.scatter(lon, lat, c=dummy_data, cmap=cmap, norm=norm, zorder=1)
 
     plt.title(title, fontsize=16, y=1.04)
 
@@ -152,7 +153,6 @@ scatter2 = make_shared_plot(
 
 # Add a horizontal colorbar
 cax = plt.axes((0.225, 0.05, 0.55, 0.025))
-norm = mpl.colors.BoundaryNorm([-1.2] + bin_bounds + [35], len(colors))
 mpl.colorbar.ColorbarBase(cax,
                           cmap=cmap,
                           orientation='horizontal',


### PR DESCRIPTION
Per [a comment](https://github.com/NCAR/geocat-examples/pull/49#issuecomment-2532219356) on the original PR to bring in the station 2 example, the colors weren't actually assigned based on the randomized values.

This will change the images produced by this example; originals are in #49, the updated colors are

![labels with norm](https://github.com/user-attachments/assets/e21adde2-be8c-48ef-94fd-7ed71a8766f5)

![colorbar with norm](https://github.com/user-attachments/assets/ef25b2b2-6a6f-4dfa-9c27-5a606354afd0)

It's been a while since I've contributed to this repo, let me know if I need to update more than just the `.py` script :)
