### PR TITLE
Remaining changes to support Matplotlib 3.10

### DIFF
--- a/Gallery/Contours/NCL_coneff_11.py
+++ b/Gallery/Contours/NCL_coneff_11.py
@@ -59,9 +59,8 @@ p = v.plot.contourf(ax=ax,
                     cmap='white')  # Use white cmap to have a white background
 
 # Set the colors for the hatches
-for i, collection in enumerate(p.collections):
-    collection.set_edgecolor(colors[i % len(colors)])
-    collection.set_linewidth(0.)
+p.set_edgecolors(colors)
+p.set_linewidth(0.)
 
 # Set linewidth of hatches
 plt.rcParams['hatch.linewidth'] = 2.5

--- a/Gallery/Contours/NCL_hov_3.py
+++ b/Gallery/Contours/NCL_hov_3.py
@@ -67,7 +67,7 @@ cs = ax.contour(lon,
                 levels=np.arange(-6, 12, 2),
                 colors='black',
                 linestyles="-",
-                linewidths=[.2,.2,.2,1,.2,.2,.2,.2,.2])
+                linewidths=[.2, .2, .2, 1, .2, .2, .2, .2, .2])
 
 # Label the contour levels -4, 0, and 4
 cl = ax.clabel(cs, fmt='%d', levels=[-4, 0, 4])

--- a/Gallery/Contours/NCL_hov_3.py
+++ b/Gallery/Contours/NCL_hov_3.py
@@ -67,14 +67,7 @@ cs = ax.contour(lon,
                 levels=np.arange(-6, 12, 2),
                 colors='black',
                 linestyles="-",
-                linewidths=.2)
-
-# Set 0 level contour line to a thicker linewidth
-# If you try to access the "levels" attribute of cs (cs.levels),
-# the list of levels is: [-6, -4, -2, 0, 2, 4, 6, 8, 10]
-# level 0 is at the 3rd index of that list, so those contour lines
-# can be accessed at cs.collections[3]
-cs.collections[3].set_linewidth(1)
+                linewidths=[.2,.2,.2,1,.2,.2,.2,.2,.2])
 
 # Label the contour levels -4, 0, and 4
 cl = ax.clabel(cs, fmt='%d', levels=[-4, 0, 4])


### PR DESCRIPTION
Addresses lingering issues to support Matplotlib 3.10 (after these go in our upstream CI should no longer be failing).

Changes are all related to setting contour plot properties now that ContourSet has moved to a single Collection.

Closes #620