### PR TITLE
Remove NumPy from upstream-dev CI

### DIFF
--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -4,7 +4,6 @@
 # forcibly remove packages to avoid artifacts
 conda remove -y --force \
     metpy \
-    numpy \
     pandas \
     scipy \
     xarray \
@@ -23,7 +22,6 @@ python -m pip install \
     --no-deps \
     --pre \
     --upgrade \
-    numpy \
     pandas \
     scipy \
     xarray \


### PR DESCRIPTION
Removes NumPy from upstream-dev CI since it's pinned by other dependencies anyway and now causing environment issues with upstream-dev CI.

It looks like we are getting the dev versions of the other packages so I'll leave those as is.  

Closes #637