### PR TITLE
GitHub Actions pin updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
     - name: setup micromamba
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc # v2.0.4
       with:
          environment-name: geocat-examples
          environment-file: conda_environment.yml
@@ -39,9 +39,9 @@ jobs:
          create-args: >-
            python=${{matrix.python-version}}
     - name: make html
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
       with:
-         timeout_minutes: 40
+         timeout_minutes: 20
          max_attempts: 3
          command: |
             eval "$(micromamba shell hook --shell bash)"

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history for all branches and tags.
       - name: set up environment
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc # v2.0.4
         with:
           environment-file: conda_environment.yml
           create-args: >-
@@ -38,9 +38,9 @@ jobs:
           conda info
           conda list
       - name: make html
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-           timeout_minutes: 40
+           timeout_minutes: 20
            max_attempts: 3
            command: |
               eval "$(micromamba shell hook --shell bash)"


### PR DESCRIPTION
Pins third party GitHub Actions to commit hashes and drops the retry timeout to 20 mins to save some runtime.

Closes #645