### PR TITLE
codespell pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: codespell
         exclude: >
           (?x)^(
-              .*\.svg|
+              .*\.svg
           )$
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks    # Some common pre-commit hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,16 @@ repos:
 #     - id: docformatter
 #       args: [--in-place]
 #
+
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        exclude: >
+          (?x)^(
+              .*\.svg|
+          )$
+
 -   repo: https://github.com/pre-commit/pre-commit-hooks    # Some common pre-commit hooks
     rev: v5.0.0
     hooks:

--- a/Gallery/Bar/NCL_bar_2.py
+++ b/Gallery/Bar/NCL_bar_2.py
@@ -35,7 +35,7 @@ date = ds.date
 num_months = np.shape(date)[0]
 
 # Dates in the file are represented by year and month (YYYYMM)
-# representing them fractionally will make ploting the data easier
+# representing them fractionally will make plotting the data easier
 # This produces the same results as NCL's yyyymm_to_yyyyfrac() function
 date_frac = np.empty_like(date)
 for n in np.arange(0, num_months, 1):

--- a/Gallery/Bar/NCL_bar_4.py
+++ b/Gallery/Bar/NCL_bar_4.py
@@ -33,7 +33,7 @@ date = ds.date
 num_months = np.shape(date)[0]
 
 # Dates in the file are represented by year and month (YYYYMM)
-# representing them fractionally will make ploting the data easier
+# representing them fractionally will make plotting the data easier
 # This produces the same results as NCL's yyyymm_to_yyyyfrac() function
 date_frac = np.empty_like(date)
 for n in np.arange(0, num_months, 1):

--- a/Gallery/Boxplots/NCL_box_1.py
+++ b/Gallery/Boxplots/NCL_box_1.py
@@ -4,7 +4,7 @@ NCL_box_1.py
 
 This script illustrates the following concepts:
    - Drawing box plots
-   - Manipulating boxplot vizualizations
+   - Manipulating boxplot visualizations
    - Manipulating plot axes
 
 See following URLs to see the reproduced NCL plot & script:

--- a/Gallery/Boxplots/NCL_box_3.py
+++ b/Gallery/Boxplots/NCL_box_3.py
@@ -105,7 +105,7 @@ ax2.patch.set_alpha(0.2)
 ax2.set_xlim(0, 6)
 ax2.set_ylim(-6, 9)
 
-# Turn both major and minor ticks in overlayed axis off
+# Turn both major and minor ticks in overlaid axis off
 ax2.tick_params(which='both',
                 top=False,
                 bottom=False,

--- a/Gallery/Contours/NCL_conLev_1.py
+++ b/Gallery/Contours/NCL_conLev_1.py
@@ -89,7 +89,7 @@ ax.text(1,
 # Specify which contour levels to draw
 contour_lev = np.arange(-5, 35, 5)
 # Specify which contour lines to label. Where the labels appear on the contours
-# is handeled by xarray.plot.contour(). The keyword manual can be used to
+# is handled by xarray.plot.contour(). The keyword manual can be used to
 # set exactly where the labels will be drawn.
 labels = np.linspace(0, 20, 3)
 # Plot contour lines

--- a/Gallery/Contours/NCL_conLev_3.py
+++ b/Gallery/Contours/NCL_conLev_3.py
@@ -16,7 +16,7 @@ Note:
     A different colormap was used in this example than in the NCL example
     because rainbow colormaps do not translate well to black and white formats,
     are not accessible for individuals affected by color blindness, and
-    vary widely in how they are percieved by different people. See this
+    vary widely in how they are perceived by different people. See this
     `example <https://geocat-examples.readthedocs.io/en/latest/gallery/Colors/CB_Temperature.html#sphx-glr-gallery-colors-cb-temperature-py>`_
     for more information on choosing colormaps.
 """

--- a/Gallery/MapProjections/NCL_maponly_6.py
+++ b/Gallery/MapProjections/NCL_maponly_6.py
@@ -16,7 +16,7 @@ Note:
     A different colormap was used in this example than in the NCL example
     because rainbow colormaps do not translate well to black and white formats,
     are not accessible for individuals affected by color blindness, and
-    vary widely in how they are percieved by different people. See this
+    vary widely in how they are perceived by different people. See this
     `example <https://geocat-examples.readthedocs.io/en/latest/gallery/Colors/CB_Temperature.html#sphx-glr-gallery-colors-cb-temperature-py>`_
     for more information on choosing colormaps.
 """

--- a/Gallery/MapProjections/NCL_native_1.py
+++ b/Gallery/MapProjections/NCL_native_1.py
@@ -9,7 +9,7 @@ This script illustrates the following concepts:
    - Turning on map tickmark labels with degree symbols
    - Choosing colors from a pre-existing colormap
    - Making the ends of the colormap white
-   - Using best practices when choosing plot color scheme to accomodate visual impairments
+   - Using best practices when choosing plot color scheme to accommodate visual impairments
 
 See following URLs to see the reproduced NCL plot & script:
     - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/native_1.ncl

--- a/Gallery/MapProjections/NCL_native_2.py
+++ b/Gallery/MapProjections/NCL_native_2.py
@@ -8,7 +8,7 @@ This script illustrates the following concepts:
    - Turning on map tickmark labels with degree symbols
    - Selecting a different color map
    - Zooming in on a particular area on a mercator map
-   - Using best practices when choosing plot color scheme to accomodate visual impairments
+   - Using best practices when choosing plot color scheme to accommodate visual impairments
 
 See following URLs to see the reproduced NCL plot & script:
     - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/native_2.ncl

--- a/Gallery/MapProjections/NCL_sat_1.py
+++ b/Gallery/MapProjections/NCL_sat_1.py
@@ -79,7 +79,7 @@ p = wrap_pressure.plot.contour(ax=ax,
 
 # regular pressure contour levels- These values were found by setting
 # 'manual' argument in ax.clabel call to 'True' and then hovering mouse
-# over desired location of countour label to find coordinate
+# over desired location of contour label to find coordinate
 # (which can be found in bottom left of figure window).
 regularCLabels = [(176.4, 34.63), (-150.46, 42.44), (-142.16, 28.5),
                   (-134.12, 16.32), (-108.9, 17.08), (-98.17, 15.6),

--- a/Gallery/Overlays/NCL_overlay_1.py
+++ b/Gallery/Overlays/NCL_overlay_1.py
@@ -83,7 +83,7 @@ wind = u.plot.contour(ax=ax,
                       linewidths=0.5,
                       add_labels=False)
 
-# Manually specify where contour labels will go using lat and lon coordiantes
+# Manually specify where contour labels will go using lat and lon coordinates
 manual = [(-107, 52), (-79, 57), (-78, 47), (-103, 32), (-86, 23)]
 ax.clabel(wind, u_lev, fmt='%d', inline=True, fontsize=10, manual=manual)
 

--- a/Gallery/Overlays/NCL_overlay_6.py
+++ b/Gallery/Overlays/NCL_overlay_6.py
@@ -197,7 +197,7 @@ t = t.data[0:lat_size:2, 0:lon_size:2]
 
 # Import and modify color map for vectors
 wind_cmap = cmaps.amwg_blueyellowred
-bounds = np.arange(-30, 120, 10)  # Sets where boundarys on color map will be
+bounds = np.arange(-30, 120, 10)  # Sets where boundaries on color map will be
 norm = mcolors.BoundaryNorm(bounds, wind_cmap.N)  # Assigns colors to values
 # Draw wind vectors
 with np.errstate(

--- a/Gallery/Panels/NCL_panel_10.py
+++ b/Gallery/Panels/NCL_panel_10.py
@@ -44,7 +44,7 @@ chi = chi / scale
 
 # Calculate zonal mean
 with warnings.catch_warnings(
-):  # This is not needed but is supressing a warning thrown by numpy checking for NaN values
+):  # This is not needed but is suppressing a warning thrown by numpy checking for NaN values
     warnings.simplefilter("ignore")
     mean = chi.mean(dim='lon')
 

--- a/Gallery/Panels/NCL_panel_6.py
+++ b/Gallery/Panels/NCL_panel_6.py
@@ -12,7 +12,7 @@ Note:
     A different colormap was used in this example than in the NCL example
     because rainbow colormaps do not translate well to black and white formats,
     are not accessible for individuals affected by color blindness, and
-    vary widely in how they are percieved by different people. See this
+    vary widely in how they are perceived by different people. See this
     `example <https://geocat-examples.readthedocs.io/en/latest/gallery/Colors/CB_Temperature.html#sphx-glr-gallery-colors-cb-temperature-py>`_
     for more information on choosing colormaps.
 """

--- a/Gallery/XY/NCL_tm_2.py
+++ b/Gallery/XY/NCL_tm_2.py
@@ -10,7 +10,7 @@ throughout this script.
 This script illustrates the following concepts:
    - Explicitly setting tickmarks and labels on the bottom X axis
    - Setting the spacing for tickmarks
-   - Setting the mininum/maximum value of the Y axis in an XY plot
+   - Setting the minimum/maximum value of the Y axis in an XY plot
    - Changing the width and height of a plot
 
 See following URLs to see the reproduced NCL plot & script:

--- a/Gallery/XY/NCL_xy_12.py
+++ b/Gallery/XY/NCL_xy_12.py
@@ -77,7 +77,7 @@ ax = plt.axes()
 
 bins = [5, 24]
 # Slicing data in Python excludes the last value. To include the last value we
-# can increment it by 1. This ensures that the highlight extends thorugh the
+# can increment it by 1. This ensures that the highlight extends through the
 # last bin value
 highlight = U.data[bins[0]:bins[1] + 1]
 

--- a/Gallery/XY/NCL_xy_16.py
+++ b/Gallery/XY/NCL_xy_16.py
@@ -114,7 +114,7 @@ plt.show()
 plt.figure(figsize=(8, 8))
 ax = plt.axes()
 
-# Note: Currently geocat-viz does not have a utility function for formating
+# Note: Currently geocat-viz does not have a utility function for formatting
 # major and minor ticks on logarithmic axes.
 plt.yscale('log')
 ax.yaxis.set_major_formatter(ScalarFormatter())

--- a/Gallery/XY/NCL_xy_18.py
+++ b/Gallery/XY/NCL_xy_18.py
@@ -71,7 +71,7 @@ import geocat.viz as gv
 # takes the single-file dataset, sets the ``calendar`` attribute of the ``time``
 # coordinate variable to ``noleap``, and returns the *decoded* dataset (using
 # the Xarray function ``decode_cf``).  Work-arounds like this are needed
-# whenever you have "errors" or "inconsistancies" in your data.
+# whenever you have "errors" or "inconsistencies" in your data.
 
 
 # Define the xarray.open_mfdataset pre-processing function

--- a/Gallery/XY/NCL_xy_5.py
+++ b/Gallery/XY/NCL_xy_5.py
@@ -8,7 +8,7 @@ This script illustrates the following concepts:
    - Using named colors to indicate a fill color
    - Converting dates from YYYYMM format to floats
    - Creating a main title
-   - Setting the mininum/maximum value of the Y axis in an XY plot
+   - Setting the minimum/maximum value of the Y axis in an XY plot
 
 See following URLs to see the reproduced NCL plot & script:
     - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/xy_5.ncl
@@ -36,7 +36,7 @@ date = ds.date
 num_months = np.shape(date)[0]
 
 # Dates in the file are represented by year and month (YYYYMM)
-# representing them fractionally will make ploting the data easier
+# representing them fractionally will make plotting the data easier
 # This produces the same results as NCL's yyyymm_to_yyyyfrac() function
 date_frac = np.empty_like(date)
 for n in np.arange(0, num_months, 1):

--- a/Gallery/XY/NCL_xy_7_2.py
+++ b/Gallery/XY/NCL_xy_7_2.py
@@ -8,7 +8,7 @@ This script illustrates the following concepts:
    - Changing the title on the Y axis
    - Changing the line dash pattern in an XY plot
    - Changing the line color for multiple curves in an XY plot
-   - Setting the mininum/maximum value of the Y axis in an XY plot
+   - Setting the minimum/maximum value of the Y axis in an XY plot
 
 See following URLs to see the reproduced NCL plot & script:
     - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/xy_7.ncl

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -18,7 +18,7 @@ Creating a Conda environment
 ----------------------------
 
 This repository provides a `Conda environment file <https://github.com/NCAR/geocat-examples/blob/main/conda_environment.yml>`_
-that can be used to create an evironment to run the examples included in this gallery.
+that can be used to create an environment to run the examples included in this gallery.
 
 To create a Conda environment using the file provided by this repo, from the root directory of
 the cloned geocat-examples repository (or the directory containing the ``conda_environment.yml``

--- a/template_script.py
+++ b/template_script.py
@@ -39,5 +39,5 @@ print("Even more code")
 
 ###############################################################################
 # Note the inline comment in the previous code cell. This was not converted to
-# its own markdown cell because it was not contiguously preceeded with a
+# its own markdown cell because it was not contiguously preceded with a
 # comment line beginning with 20+ '#' characters.


### PR DESCRIPTION
Fix code misspellings with `codespell`, as part of the transition to ruff

Related to #619