### PR TITLE
Ruff format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,16 @@
-repos:
--   repo: https://github.com/google/yapf    # To format the code to conform YAPF
-    rev: v0.43.0
-    hooks:
-    - id: yapf
-      args: ['--in-place', '--recursive', '--style', 'google']
-      require_serial: true
+ci:
+    autofix_prs: false
+    autoupdate_schedule: monthly
 
-# -   repo: https://github.com/PyCQA/docformatter    # To format the doc strings to conform PEP257
-#     rev: v1.7.5
-#     hooks:
-#     - id: docformatter
-#       args: [--in-place]
-#
+repos:
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.4
+    hooks:
+     # Run the linter.
+     - id: ruff
+       args: [ --fix ]
+     - id: ruff-format
+
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
@@ -32,7 +31,3 @@ repos:
     - id: trailing-whitespace      # Checks for any tabs or spaces after the last non-whitespace character on the line.
     - id: check-docstring-first    # Checks that code comes after the docstrings.
     - id: check-yaml               # Check valid yml file
-
-ci:
-    autofix_prs: false
-    autoupdate_schedule: monthly

--- a/Gallery/Animations/NCL_animate_1.py
+++ b/Gallery/Animations/NCL_animate_1.py
@@ -45,11 +45,13 @@ ax.coastlines(linewidths=0.5)
 ax.set_extent([-180, 180, -90, 90], ccrs.PlateCarree())
 
 # Use geocat-viz convenience function to set axes limits & tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(-180, 180),
-                             ylim=(-90, 90),
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(-180, 180),
+    ylim=(-90, 90),
+    xticks=np.linspace(-180, 180, 13),
+    yticks=np.linspace(-90, 90, 7),
+)
 
 # Use geocat-viz convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, labelsize=10)
@@ -58,21 +60,25 @@ gv.add_major_minor_ticks(ax, labelsize=10)
 gv.add_lat_lon_ticklabels(ax)
 
 # Create initial plot
-cplot = tas[0, :, :].plot.contourf(ax=ax,
-                                   transform=ccrs.PlateCarree(),
-                                   vmin=195,
-                                   vmax=328,
-                                   levels=53,
-                                   cmap="inferno",
-                                   add_colorbar=False)
+cplot = tas[0, :, :].plot.contourf(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    vmin=195,
+    vmax=328,
+    levels=53,
+    cmap="inferno",
+    add_colorbar=False,
+)
 
 # Create a colorbar
-cbar = fig.colorbar(cplot,
-                    extendrect=True,
-                    orientation="horizontal",
-                    ticks=np.arange(195, 332, 9),
-                    label="",
-                    shrink=0.90)
+cbar = fig.colorbar(
+    cplot,
+    extendrect=True,
+    orientation="horizontal",
+    ticks=np.arange(195, 332, 9),
+    label="",
+    shrink=0.90,
+)
 
 # Remove minor ticks from colorbar that don't work well with other formatting
 cbar.ax.minorticks_off()
@@ -80,24 +86,27 @@ cbar.ax.minorticks_off()
 
 # Animate function for matplotlib FuncAnimation
 def animate(i):
-    tas[i, :, :].plot.contourf(ax=ax,
-                               transform=ccrs.PlateCarree(),
-                               vmin=195,
-                               vmax=328,
-                               levels=53,
-                               cmap="inferno",
-                               add_colorbar=False)
+    tas[i, :, :].plot.contourf(
+        ax=ax,
+        transform=ccrs.PlateCarree(),
+        vmin=195,
+        vmax=328,
+        levels=53,
+        cmap="inferno",
+        add_colorbar=False,
+    )
 
     gv.set_titles_and_labels(
         ax,
-        maintitle="January Global Surface Temperature (K) - Day  " +
-        str(tas.coords['time'].values[i])[:13],
+        maintitle="January Global Surface Temperature (K) - Day  "
+        + str(tas.coords['time'].values[i])[:13],
         xlabel="",
-        ylabel="")
+        ylabel="",
+    )
 
 
 # Run the animation initiated with the frame from init and progressed with the animate function
 anim = animation.FuncAnimation(fig, animate, frames=30, interval=200)
 
 # Uncomment this line to save the animation
-#anim.save('animate_1.gif', writer='pillow', fps=5)
+# anim.save('animate_1.gif', writer='pillow', fps=5)

--- a/Gallery/Bar/NCL_bar_1.py
+++ b/Gallery/Bar/NCL_bar_1.py
@@ -50,26 +50,27 @@ ax = plt.gca()
 baseline = np.nanmin(dsoik[::8])
 
 # Create barplot
-ax.bar(date_frac[::8],
-       dsoik[::8] - baseline,
-       align='center',
-       edgecolor='grey',
-       color='white',
-       width=8 / 12,
-       linewidth=.5,
-       bottom=-1.75)
+ax.bar(
+    date_frac[::8],
+    dsoik[::8] - baseline,
+    align='center',
+    edgecolor='grey',
+    color='white',
+    width=8 / 12,
+    linewidth=0.5,
+    bottom=-1.75,
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=20)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=20)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             yticks=np.arange(-2.0, 2.0, 0.5),
-                             xlim=(date_frac[40], date_frac[-16]),
-                             xticks=np.linspace(1900, 1980, 5))
+gv.set_axes_limits_and_ticks(
+    ax,
+    yticks=np.arange(-2.0, 2.0, 0.5),
+    xlim=(date_frac[40], date_frac[-16]),
+    xticks=np.linspace(1900, 1980, 5),
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
 gv.set_titles_and_labels(ax, maintitle="Bar plot", maintitlefontsize=30)
@@ -106,21 +107,18 @@ ax.plot(xs, ys, color="black", linewidth=0.5)
 ax.fill_between(xs, 0, ys, color='white')
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=20)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=20)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             yticks=np.arange(-2.0, 2.0, 0.5),
-                             xlim=(1880, 2000),
-                             xticks=np.linspace(1880, 2000, 7))
+gv.set_axes_limits_and_ticks(
+    ax,
+    yticks=np.arange(-2.0, 2.0, 0.5),
+    xlim=(1880, 2000),
+    xticks=np.linspace(1880, 2000, 7),
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Bar plot with outlines",
-                         maintitlefontsize=30)
+gv.set_titles_and_labels(ax, maintitle="Bar plot with outlines", maintitlefontsize=30)
 
 # Draw plot on the screen
 plt.tight_layout()
@@ -134,30 +132,31 @@ plt.figure(3, figsize=(10, 5))
 ax = plt.gca()
 
 # Create barplot
-ax.bar(date_frac[::8],
-       dsoik[::8],
-       align='edge',
-       edgecolor='black',
-       color='white',
-       width=8 / 12,
-       linewidth=.5)
+ax.bar(
+    date_frac[::8],
+    dsoik[::8],
+    align='edge',
+    edgecolor='black',
+    color='white',
+    width=8 / 12,
+    linewidth=0.5,
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=20)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=20)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             yticks=np.arange(-2.0, 2.0, 0.5),
-                             xlim=(date_frac[40], date_frac[-16]),
-                             xticks=np.linspace(1900, 1980, 5))
+gv.set_axes_limits_and_ticks(
+    ax,
+    yticks=np.arange(-2.0, 2.0, 0.5),
+    xlim=(date_frac[40], date_frac[-16]),
+    xticks=np.linspace(1900, 1980, 5),
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Bar plot with a reference line",
-                         maintitlefontsize=30)
+gv.set_titles_and_labels(
+    ax, maintitle="Bar plot with a reference line", maintitlefontsize=30
+)
 
 # Show the plot
 plt.tight_layout()

--- a/Gallery/Bar/NCL_bar_11.py
+++ b/Gallery/Bar/NCL_bar_11.py
@@ -29,8 +29,18 @@ panels = 4
 data = np.random.uniform(0.1, 1.15, (panels, bars_per_panel, num_months))
 
 months = [
-    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov',
-    'Dec'
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
 ]
 ###############################################################################
 # Plot:
@@ -43,63 +53,72 @@ panel = 0
 for row in range(0, 2):
     for col in range(0, 2):
         # Use geocat.viz.util convenience function to set axes parameters
-        gv.set_axes_limits_and_ticks(axs[row][col],
-                                     ylim=(0.4, 1.2),
-                                     xticks=x,
-                                     yticks=np.arange(0.4, 1.4, 0.2),
-                                     xticklabels=months)
+        gv.set_axes_limits_and_ticks(
+            axs[row][col],
+            ylim=(0.4, 1.2),
+            xticks=x,
+            yticks=np.arange(0.4, 1.4, 0.2),
+            xticklabels=months,
+        )
         # Use geocat.viz.util convenience function to add minor and major tick lines
-        gv.add_major_minor_ticks(axs[row][col],
-                                 x_minor_per_major=1,
-                                 y_minor_per_major=4,
-                                 labelsize=12)
+        gv.add_major_minor_ticks(
+            axs[row][col], x_minor_per_major=1, y_minor_per_major=4, labelsize=12
+        )
         # Use geocat.viz.util convenience function to set titles and labels
-        gv.set_titles_and_labels(axs[row][col],
-                                 ylabel='(\u00B0C)',
-                                 labelfontsize=14)
+        gv.set_titles_and_labels(axs[row][col], ylabel='(\u00b0C)', labelfontsize=14)
 
         # Add overall figure title
         fig.suptitle('Paneling bar plots, dummy data', size=20, y=0.94)
 
         # Add data to subplot
-        axs[row][col].bar(x - width * 3 / 2,
-                          data[panel][0][:],
-                          width,
-                          edgecolor='black',
-                          linewidth=0.25,
-                          color='red',
-                          label='first')
-        axs[row][col].bar(x - width / 2,
-                          data[panel][1][:],
-                          width,
-                          edgecolor='black',
-                          linewidth=0.25,
-                          color='lightsteelblue',
-                          label='second')
-        axs[row][col].bar(x + width / 2,
-                          data[panel][2][:],
-                          width,
-                          edgecolor='black',
-                          linewidth=0.25,
-                          color='blue',
-                          label='third')
-        axs[row][col].bar(x + width * 3 / 2,
-                          data[panel][3][:],
-                          width,
-                          edgecolor='black',
-                          linewidth=0.25,
-                          color='lime',
-                          label='fourth')
+        axs[row][col].bar(
+            x - width * 3 / 2,
+            data[panel][0][:],
+            width,
+            edgecolor='black',
+            linewidth=0.25,
+            color='red',
+            label='first',
+        )
+        axs[row][col].bar(
+            x - width / 2,
+            data[panel][1][:],
+            width,
+            edgecolor='black',
+            linewidth=0.25,
+            color='lightsteelblue',
+            label='second',
+        )
+        axs[row][col].bar(
+            x + width / 2,
+            data[panel][2][:],
+            width,
+            edgecolor='black',
+            linewidth=0.25,
+            color='blue',
+            label='third',
+        )
+        axs[row][col].bar(
+            x + width * 3 / 2,
+            data[panel][3][:],
+            width,
+            edgecolor='black',
+            linewidth=0.25,
+            color='lime',
+            label='fourth',
+        )
         panel += 1
 
 # Add legend with `figlegend()` to position it relative to figure instead of subplots
 handles, labels = axs[0][0].get_legend_handles_labels()
-fig.legend(handles,
-           labels,
-           ncol=4,
-           loc='lower center',
-           fontsize=14,
-           columnspacing=5,
-           frameon=False)
+fig.legend(
+    handles,
+    labels,
+    ncol=4,
+    loc='lower center',
+    fontsize=14,
+    columnspacing=5,
+    frameon=False,
+)
 
 plt.show()

--- a/Gallery/Bar/NCL_bar_14.py
+++ b/Gallery/Bar/NCL_bar_14.py
@@ -40,35 +40,39 @@ fig = plt.figure(figsize=(6, 5.25))
 ax = plt.axes()
 
 # Plot the bar chart, line chart, and a horizontal line with varying colors and linewidths
-plt.bar(months, y1, color="yellow", edgecolor="k", linewidth=.5)
+plt.bar(months, y1, color="yellow", edgecolor="k", linewidth=0.5)
 plt.plot(months, y2, color="b", linewidth=1)
 plt.hlines(40, 0, 13, color="b", linewidth=1)
 
 # Use geocat.viz.util convenience function to add titles and set their size
-gv.set_titles_and_labels(ax,
-                         maintitle="XY curve over a bar chart",
-                         maintitlefontsize=16,
-                         ylabel="mm",
-                         labelfontsize=14)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="XY curve over a bar chart",
+    maintitlefontsize=16,
+    ylabel="mm",
+    labelfontsize=14,
+)
 
 # Use geocat.viz.util convenience function to set axes tick values and labels
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(0, 12, 5),
-                             xticklabels=np.linspace(0, 12, 5),
-                             xlim=(0, 13),
-                             yticks=np.linspace(0, 100, 6),
-                             ylim=(0, 100))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xticks=np.linspace(0, 12, 5),
+    xticklabels=np.linspace(0, 12, 5),
+    xlim=(0, 13),
+    yticks=np.linspace(0, 100, 6),
+    ylim=(0, 100),
+)
 
 # Create the right axis
 axRHS = ax.twinx()
 
 # Set the right axis title and size while rotating it 270 degrees and adding a whitespace padding
-axRHS.set_ylabel((u"\u00b0" + "C"), size=14, rotation=270, labelpad=25)
+axRHS.set_ylabel(("\u00b0" + "C"), size=14, rotation=270, labelpad=25)
 
 # Use geocat.viz.util convenience function to set axes tick values and labels for the right axis
-gv.set_axes_limits_and_ticks(axRHS,
-                             yticks=np.linspace(0, 100, 6),
-                             yticklabels=np.linspace(0, 50, 6, dtype=int))
+gv.set_axes_limits_and_ticks(
+    axRHS, yticks=np.linspace(0, 100, 6), yticklabels=np.linspace(0, 50, 6, dtype=int)
+)
 
 # Use geocat.viz.util convenience function to add major and minor tick lines
 gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=4)

--- a/Gallery/Bar/NCL_bar_2.py
+++ b/Gallery/Bar/NCL_bar_2.py
@@ -52,33 +52,36 @@ ax = plt.axes()
 
 # Create a list of colors based on the color bar values
 colors = ['red' if (value > 0) else 'blue' for value in dsoik[::8]]
-plt.bar(date_frac[::8],
-        dsoik[::8],
-        align='edge',
-        edgecolor='black',
-        color=colors,
-        width=8 / 12,
-        linewidth=.6)
+plt.bar(
+    date_frac[::8],
+    dsoik[::8],
+    align='edge',
+    edgecolor='black',
+    color=colors,
+    width=8 / 12,
+    linewidth=0.6,
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=20)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=20)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(-3, 3),
-                             yticks=np.linspace(-3, 3, 7),
-                             yticklabels=np.linspace(-3, 3, 7),
-                             xlim=(date_frac[40], date_frac[-16]),
-                             xticks=np.linspace(1900, 1980, 5))
+gv.set_axes_limits_and_ticks(
+    ax,
+    ylim=(-3, 3),
+    yticks=np.linspace(-3, 3, 7),
+    yticklabels=np.linspace(-3, 3, 7),
+    xlim=(date_frac[40], date_frac[-16]),
+    xticks=np.linspace(1900, 1980, 5),
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Darwin Southern Oscillation Index",
-                         ylabel='Anomalies',
-                         maintitlefontsize=28,
-                         labelfontsize=20)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Darwin Southern Oscillation Index",
+    ylabel='Anomalies',
+    maintitlefontsize=28,
+    labelfontsize=20,
+)
 
 plt.show()

--- a/Gallery/Bar/NCL_bar_3.py
+++ b/Gallery/Bar/NCL_bar_3.py
@@ -54,28 +54,29 @@ colors = ['red' if (value > 0) else 'blue' for value in dsoik[::8]]
 plt.bar(date_frac[::8], dsoik[::8], color=colors, width=0.25)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=16)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(-3, 3),
-                             yticks=np.linspace(-3, 3, 7),
-                             yticklabels=np.linspace(-3, 3, 7),
-                             xlim=(date_frac[40], date_frac[-16]),
-                             xticks=np.linspace(1900, 1980, 5))
+gv.set_axes_limits_and_ticks(
+    ax,
+    ylim=(-3, 3),
+    yticks=np.linspace(-3, 3, 7),
+    yticklabels=np.linspace(-3, 3, 7),
+    xlim=(date_frac[40], date_frac[-16]),
+    xticks=np.linspace(1900, 1980, 5),
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Darwin Southern Oscillation Index",
-                         ylabel='Anomalies',
-                         maintitlefontsize=36,
-                         labelfontsize=20)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Darwin Southern Oscillation Index",
+    ylabel='Anomalies',
+    maintitlefontsize=36,
+    labelfontsize=20,
+)
 
 # Plot horizontal line as a reference
-plt.hlines(0, 1880, 2000, colors="black", linewidth=.6)
+plt.hlines(0, 1880, 2000, colors="black", linewidth=0.6)
 
 plt.tight_layout()
 plt.show()

--- a/Gallery/Bar/NCL_bar_4.py
+++ b/Gallery/Bar/NCL_bar_4.py
@@ -52,33 +52,36 @@ ax = plt.axes()
 colors = ['red' if (value > 0) else 'blue' for value in dsoik[::8]]
 
 # Plot bar chart
-plt.bar(date_frac[::8],
-        dsoik[::8],
-        align='edge',
-        edgecolor="none",
-        color=colors,
-        width=8 / 12)
+plt.bar(
+    date_frac[::8],
+    dsoik[::8],
+    align='edge',
+    edgecolor="none",
+    color=colors,
+    width=8 / 12,
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=20)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=20)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(-3, 3),
-                             yticks=np.linspace(-3, 3, 7),
-                             yticklabels=np.linspace(-3, 3, 7),
-                             xlim=(date_frac[40], date_frac[-16]),
-                             xticks=np.linspace(1900, 1980, 5))
+gv.set_axes_limits_and_ticks(
+    ax,
+    ylim=(-3, 3),
+    yticks=np.linspace(-3, 3, 7),
+    yticklabels=np.linspace(-3, 3, 7),
+    xlim=(date_frac[40], date_frac[-16]),
+    xticks=np.linspace(1900, 1980, 5),
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Darwin Southern Oscillation Index",
-                         ylabel='Anomalies',
-                         maintitlefontsize=28,
-                         labelfontsize=20)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Darwin Southern Oscillation Index",
+    ylabel='Anomalies',
+    maintitlefontsize=28,
+    labelfontsize=20,
+)
 
 plt.tight_layout()
 plt.show()

--- a/Gallery/Bar/NCL_bar_5.py
+++ b/Gallery/Bar/NCL_bar_5.py
@@ -30,8 +30,8 @@ ds = xr.open_dataset(gdf.get("netcdf_files/Jsst.nc"))
 sst = ds.SST
 date = ds.date
 
-#scale the sst variable to range from around -1 to 1
-sst = sst * .1
+# scale the sst variable to range from around -1 to 1
+sst = sst * 0.1
 
 # Dates in the file are represented by year and month (YYYYMM)
 # representing them fractionally will make plotting the data easier
@@ -50,12 +50,22 @@ for n in np.arange(0, num_months, 1):
 # in inches of the bottom left corner of year graph
 warm = [1951, 1953, 1957, 1963, 1965, 1969, 1972, 1976, 1982, 1987, 1991]
 heights_list = [
-    0.0585, 0.128, 0.195, .267, .342, .4, 0.482, .541, .636, .686, .763
+    0.0585,
+    0.128,
+    0.195,
+    0.267,
+    0.342,
+    0.4,
+    0.482,
+    0.541,
+    0.636,
+    0.686,
+    0.763,
 ]
 
 # Set the number of subplots
 num_subplots = 11
-fig_height = (num_subplots)
+fig_height = num_subplots
 
 # Create figure and default axis which will be visible
 fig, ax0 = plt.subplots(figsize=(8, fig_height + 2), constrained_layout=True)
@@ -79,16 +89,17 @@ for ax, year in zip(ax_dict, warm):
     year_iend = int(np.where(np.round(date_frac, 3) == year_end)[0])
 
     # Create each bar chart where it is red if it is above 0 and blue if below
-    ax_dict[ax].bar(date_frac[year_istart:year_iend],
-                    sst[year_istart:year_iend],
-                    align='edge',
-                    edgecolor='black',
-                    color=[
-                        'red' if (value > 0) else 'blue'
-                        for value in sst[year_istart:year_iend]
-                    ],
-                    width=.08,
-                    linewidth=1)
+    ax_dict[ax].bar(
+        date_frac[year_istart:year_iend],
+        sst[year_istart:year_iend],
+        align='edge',
+        edgecolor='black',
+        color=[
+            'red' if (value > 0) else 'blue' for value in sst[year_istart:year_iend]
+        ],
+        width=0.08,
+        linewidth=1,
+    )
     # Turn off axis so it is not visible
     ax_dict[ax].axis("off")
 
@@ -96,14 +107,16 @@ for ax, year in zip(ax_dict, warm):
 axRHS = ax0.twinx()
 
 # Make a variable for the degree symbol
-degree = u"\u00b0"
+degree = "\u00b0"
 
 # Use geocat.viz.util convenience function to add titles to the center and right of the plot axis
-gv.set_titles_and_labels(ax0,
-                         maintitle="Monthly SST Anomalies for Nino-3",
-                         maintitlefontsize=25,
-                         righttitle=("(" + degree + "C)"),
-                         righttitlefontsize=18)
+gv.set_titles_and_labels(
+    ax0,
+    maintitle="Monthly SST Anomalies for Nino-3",
+    maintitlefontsize=25,
+    righttitle=("(" + degree + "C)"),
+    righttitlefontsize=18,
+)
 # Add center title
 ax0.text(0.38, 1.05, 'Warm Events', fontsize=18, transform=ax0.transAxes)
 
@@ -139,13 +152,13 @@ gv.set_axes_limits_and_ticks(
     xticks=np.linspace(-3, 3, 7),
     xticklabels=["Jan₋₁", "Jul₋₁", "Jan₀", "Jul₀", "Jan₊₁", "Jul₊₁", "Jan₊₂"],
     yticks=np.linspace(0, 46, 46),
-    yticklabels=left_y_ticks)
+    yticklabels=left_y_ticks,
+)
 
 ax0.spines['right'].set_visible(False)
-gv.set_axes_limits_and_ticks(axRHS,
-                             ylim=(0, 45),
-                             yticks=np.linspace(0, 45, 46),
-                             yticklabels=right_y_ticks)
+gv.set_axes_limits_and_ticks(
+    axRHS, ylim=(0, 45), yticks=np.linspace(0, 45, 46), yticklabels=right_y_ticks
+)
 
 # Set tick parameters for all axes
 ax0.tick_params(axis="x", length=9, labelsize=12)
@@ -180,23 +193,26 @@ for year in warm:
     year_iend = int(np.where(np.round(date_frac, 3) == year_end)[0])
 
     # Create each bar chart where it is red if it is above 0 and blue if below
-    ax2[i].bar(date_frac[year_istart:year_iend],
-               sst[year_istart:year_iend],
-               align='edge',
-               edgecolor='black',
-               color=[
-                   'red' if (value > 0) else 'blue'
-                   for value in sst[year_istart:year_iend]
-               ],
-               width=.08,
-               linewidth=1)
+    ax2[i].bar(
+        date_frac[year_istart:year_iend],
+        sst[year_istart:year_iend],
+        align='edge',
+        edgecolor='black',
+        color=[
+            'red' if (value > 0) else 'blue' for value in sst[year_istart:year_iend]
+        ],
+        width=0.08,
+        linewidth=1,
+    )
 
     # Set ticks and limits for axes using convenience function
-    gv.set_axes_limits_and_ticks(ax2[i],
-                                 xlim=((year_start), year_end),
-                                 xticks=np.linspace(year_start, year_end, 5),
-                                 ylim=(-3, 3.5),
-                                 yticks=np.linspace(-2, 2, 3))
+    gv.set_axes_limits_and_ticks(
+        ax2[i],
+        xlim=((year_start), year_end),
+        xticks=np.linspace(year_start, year_end, 5),
+        ylim=(-3, 3.5),
+        yticks=np.linspace(-2, 2, 3),
+    )
 
     # Use geocat.viz.util convenience function to add major tick lines
     gv.add_major_minor_ticks(ax2[i], x_minor_per_major=4, y_minor_per_major=2)
@@ -216,17 +232,19 @@ for year in warm:
 plt.subplots_adjust(hspace=1)
 
 # Make a variable for the degree symbol
-degree = u"\u00b0"
+degree = "\u00b0"
 
 # Add title to entire figure
-fig2.suptitle("Monthly SST Anomalies for Nino-3",
-              horizontalalignment='center',
-              y=0.93,
-              fontsize=15,
-              fontweight='bold')
+fig2.suptitle(
+    "Monthly SST Anomalies for Nino-3",
+    horizontalalignment='center',
+    y=0.93,
+    fontsize=15,
+    fontweight='bold',
+)
 
 # Add subtitles
-fig2.text(0.42, .895, 'Warm Events', fontsize=9)
-fig2.text(0.12, .895, "(" + degree + "C)", fontsize=9)
+fig2.text(0.42, 0.895, 'Warm Events', fontsize=9)
+fig2.text(0.12, 0.895, "(" + degree + "C)", fontsize=9)
 
 plt.show()

--- a/Gallery/Bar/NCL_bar_7.py
+++ b/Gallery/Bar/NCL_bar_7.py
@@ -27,15 +27,27 @@ import geocat.viz as gv
 x = [1, 2, 3, 4, 5, 6, 7, 8]
 data = [154900, 56600, 40000, 30200, 29700, 24400, 21700, 13900]
 labels = [
-    'Lung', 'Colon/rectum', 'Breast', 'Prostate', 'Pancreas',
-    'Non-Hodgkin\'s Lymphoma', 'Leukemias', 'Ovary'
+    'Lung',
+    'Colon/rectum',
+    'Breast',
+    'Prostate',
+    'Pancreas',
+    'Non-Hodgkin\'s Lymphoma',
+    'Leukemias',
+    'Ovary',
 ]
 
 ###############################################################################
 # Create the custom color list.
 color_list = [
-    'firebrick', 'red', 'orange', 'green', 'navy', 'blue', 'skyblue',
-    'slateblue'
+    'firebrick',
+    'red',
+    'orange',
+    'green',
+    'navy',
+    'blue',
+    'skyblue',
+    'slateblue',
 ]
 
 ###############################################################################
@@ -64,16 +76,12 @@ for k, label in enumerate(labels):
     plt.text(x[k], data[k] + 2000, label, rotation=45)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(0, plot_y_max),
-                             xticks=[],
-                             yticks=np.linspace(0, plot_y_max, 7))
+gv.set_axes_limits_and_ticks(
+    ax, ylim=(0, plot_y_max), xticks=[], yticks=np.linspace(0, plot_y_max, 7)
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=0,
-                         y_minor_per_major=3,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=0, y_minor_per_major=3, labelsize=12)
 
 # Draw plot on the screen.
 plt.show()
@@ -96,22 +104,17 @@ labels_reversed = labels[::-1]
 plt.legend(bars_reversed, labels_reversed)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(0, plot_y_max),
-                             xticks=[],
-                             yticks=np.linspace(0, plot_y_max, 7))
+gv.set_axes_limits_and_ticks(
+    ax, ylim=(0, plot_y_max), xticks=[], yticks=np.linspace(0, plot_y_max, 7)
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=0,
-                         y_minor_per_major=3,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=0, y_minor_per_major=3, labelsize=12)
 
 # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-gv.set_titles_and_labels(ax,
-                         maintitle=title,
-                         maintitlefontsize=title_fontsize,
-                         ylabel="Number of Deaths")
+gv.set_titles_and_labels(
+    ax, maintitle=title, maintitlefontsize=title_fontsize, ylabel="Number of Deaths"
+)
 
 # Show the plot
 plt.tight_layout()

--- a/Gallery/Bar/NCL_unique_5.py
+++ b/Gallery/Bar/NCL_unique_5.py
@@ -24,8 +24,18 @@ import geocat.viz as gv
 # Generate labels:
 x = np.arange(1, 13)
 labels = [
-    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov',
-    'Dec'
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
 ]
 
 # Generate random data:
@@ -59,59 +69,70 @@ w = 0.15
 
 # Create subplots for each category
 sub = plt.subplot(111)
-sub.bar(x + w,
-        obs,
-        width=0.15,
-        color=color_list[0],
-        edgecolor='black',
-        linewidth=0.25,
-        align='center')
-sub.bar((x + (2 * w)),
-        ccsm2_t42,
-        width=0.15,
-        color=color_list[1],
-        edgecolor='black',
-        linewidth=0.25,
-        align='center')
-sub.bar(x + 3 * w,
-        ccsm3_t42,
-        width=0.15,
-        color=color_list[2],
-        edgecolor='black',
-        linewidth=0.25,
-        align='center')
-sub.bar(x + 4 * w,
-        ccsm3_t85,
-        width=0.15,
-        color=color_list[3],
-        edgecolor='black',
-        linewidth=0.25,
-        align='center')
+sub.bar(
+    x + w,
+    obs,
+    width=0.15,
+    color=color_list[0],
+    edgecolor='black',
+    linewidth=0.25,
+    align='center',
+)
+sub.bar(
+    (x + (2 * w)),
+    ccsm2_t42,
+    width=0.15,
+    color=color_list[1],
+    edgecolor='black',
+    linewidth=0.25,
+    align='center',
+)
+sub.bar(
+    x + 3 * w,
+    ccsm3_t42,
+    width=0.15,
+    color=color_list[2],
+    edgecolor='black',
+    linewidth=0.25,
+    align='center',
+)
+sub.bar(
+    x + 4 * w,
+    ccsm3_t85,
+    width=0.15,
+    color=color_list[3],
+    edgecolor='black',
+    linewidth=0.25,
+    align='center',
+)
 
 # Add the legend
-plt.legend(['OBS', 'CCSM2 (T42)', 'CCSM3 (T42)', 'CCSM3 (T85)'],
-           loc='lower center',
-           bbox_to_anchor=(0.5, -0.30),
-           ncol=2)
+plt.legend(
+    ['OBS', 'CCSM2 (T42)', 'CCSM3 (T42)', 'CCSM3 (T85)'],
+    loc='lower center',
+    bbox_to_anchor=(0.5, -0.30),
+    ncol=2,
+)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(0.4, plot_y_max),
-                             xticks=x,
-                             xticklabels=labels,
-                             yticks=np.linspace(0.4, plot_y_max, 5))
+gv.set_axes_limits_and_ticks(
+    ax,
+    ylim=(0.4, plot_y_max),
+    xticks=x,
+    xticklabels=labels,
+    yticks=np.linspace(0.4, plot_y_max, 5),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=1,
-                         y_minor_per_major=4,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=1, y_minor_per_major=4, labelsize=12)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle='Nino3.4 Monthly Standard Deviation',
-                         maintitlefontsize=16,
-                         ylabel="(" + u'\N{DEGREE SIGN}' + "C)")
+gv.set_titles_and_labels(
+    ax,
+    maintitle='Nino3.4 Monthly Standard Deviation',
+    maintitlefontsize=16,
+    ylabel="(" + '\N{DEGREE SIGN}' + "C)",
+)
 
 # Show the plot
 plt.tight_layout()

--- a/Gallery/Boxplots/NCL_box_1.py
+++ b/Gallery/Boxplots/NCL_box_1.py
@@ -26,7 +26,7 @@ import geocat.viz as gv
 seed = 200
 np.random.seed(seed)
 
-data = np.random.lognormal(size=(40, 3), mean=1, sigma=.7)
+data = np.random.lognormal(size=(40, 3), mean=1, sigma=0.7)
 for a in range(len(data)):
     data[a] = [x - 4 for x in data[a]]
 
@@ -36,10 +36,9 @@ for a in range(len(data)):
 # Create figure and axis
 w = 0.25
 fig, ax = plt.subplots(figsize=(6, 6))
-boxplots = ax.boxplot(data,
-                      labels=['Control', '-2Xna', '2Xna'],
-                      widths=[w, w, w],
-                      showfliers=False)
+boxplots = ax.boxplot(
+    data, labels=['Control', '-2Xna', '2Xna'], widths=[w, w, w], showfliers=False
+)
 
 # Set whiskers style to dashed
 plt.setp(boxplots['whiskers'], linestyle='--')
@@ -55,10 +54,7 @@ ax.spines['top'].set_visible(False)
 gv.set_axes_limits_and_ticks(ax, ylim=(-6.0, 9.0), yticks=[-3.0, 0.0, 3.0, 6.0])
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         y_minor_per_major=3,
-                         x_minor_per_major=1,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, y_minor_per_major=3, x_minor_per_major=1, labelsize=14)
 
 # Use geocat.viz.util convenience function to add title to the plot axis.
 gv.set_titles_and_labels(ax, maintitle='Default Box Plot')

--- a/Gallery/Boxplots/NCL_box_2.py
+++ b/Gallery/Boxplots/NCL_box_2.py
@@ -27,7 +27,7 @@ import geocat.viz as gv
 seed = 200
 np.random.seed(seed)
 
-data = np.random.lognormal(size=(40, 3), mean=1, sigma=.7)
+data = np.random.lognormal(size=(40, 3), mean=1, sigma=0.7)
 for a in range(len(data)):
     data[a] = [x - 4 for x in data[a]]
 
@@ -36,7 +36,6 @@ for a in range(len(data)):
 
 
 def setBoxColor(boxplot, colors):
-
     # Set edge color of the outside and median lines of the boxes
     for element in ['boxes', 'medians']:
         for box, color in zip(boxplot[element], colors):
@@ -45,7 +44,8 @@ def setBoxColor(boxplot, colors):
     # Set the color of the whiskers and caps of the boxes
     for element in ['whiskers', 'caps']:
         for box, color in zip(
-                zip(boxplot[element][::2], boxplot[element][1::2]), colors):
+            zip(boxplot[element][::2], boxplot[element][1::2]), colors
+        ):
             plt.setp(box, color=color)
 
 
@@ -55,10 +55,9 @@ def setBoxColor(boxplot, colors):
 # Create figure and axis
 w = 0.1
 fig, ax = plt.subplots(figsize=(6, 6))
-boxplots = ax.boxplot(data,
-                      labels=['Control', '-2Xna', '2Xna'],
-                      widths=[w, w, w],
-                      showfliers=False)
+boxplots = ax.boxplot(
+    data, labels=['Control', '-2Xna', '2Xna'], widths=[w, w, w], showfliers=False
+)
 
 # Set whiskers style to dashed
 plt.setp(boxplots['whiskers'], linestyle='--')
@@ -73,21 +72,15 @@ gv.set_axes_limits_and_ticks(ax, ylim=(-6.0, 8.5), yticks=[-3.0, 0.0, 3.0, 6.0])
 ax.yaxis.set_major_formatter(FormatStrFormatter('%.1f'))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         y_minor_per_major=3,
-                         x_minor_per_major=1,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, y_minor_per_major=3, x_minor_per_major=1, labelsize=16)
 
 # Use geocat.viz.util convenience function to set spines visibility
-gv.set_tick_direction_spine_visibility(ax,
-                                       tick_direction='in',
-                                       top_spine_visible=False,
-                                       right_spine_visible=False)
+gv.set_tick_direction_spine_visibility(
+    ax, tick_direction='in', top_spine_visible=False, right_spine_visible=False
+)
 
 # Use geocat.viz.util convenience function to add title to the plot axis.
-gv.set_titles_and_labels(ax,
-                         maintitle='Tailored Box Plot',
-                         maintitlefontsize=22)
+gv.set_titles_and_labels(ax, maintitle='Tailored Box Plot', maintitlefontsize=22)
 
 # Set padding between ticks and tick labels
 ax.tick_params(pad=9)

--- a/Gallery/Boxplots/NCL_box_3.py
+++ b/Gallery/Boxplots/NCL_box_3.py
@@ -25,7 +25,7 @@ import geocat.viz as gv
 # Generate fake data
 
 np.random.seed(200)
-data = np.random.lognormal(size=(40, 3), mean=1, sigma=.7)
+data = np.random.lognormal(size=(40, 3), mean=1, sigma=0.7)
 for a in range(len(data)):
     data[a] = [x - 4 for x in data[a]]
 
@@ -34,7 +34,6 @@ for a in range(len(data)):
 
 
 def setBoxColor(boxplot, colors):
-
     # Set edge color of the outside and median lines of the boxes
     for element in ['boxes', 'medians']:
         for box, color in zip(boxplot[element], colors):
@@ -43,7 +42,8 @@ def setBoxColor(boxplot, colors):
     # Set the color of the whiskers and caps of the boxes
     for element in ['whiskers', 'caps']:
         for box, color in zip(
-                zip(boxplot[element][::2], boxplot[element][1::2]), colors):
+            zip(boxplot[element][::2], boxplot[element][1::2]), colors
+        ):
             plt.setp(box, color=color)
 
 
@@ -52,7 +52,6 @@ def setBoxColor(boxplot, colors):
 
 
 def removeSpines(ax):
-
     ax.spines['right'].set_visible(False)
     ax.spines['top'].set_visible(False)
 
@@ -64,10 +63,9 @@ def removeSpines(ax):
 fig, ax = plt.subplots(figsize=(6, 6))
 
 # Plot each boxplot, set tick labels, and determine box widths
-boxplots = ax.boxplot(data,
-                      labels=['Control', '-2Xna', '2Xna'],
-                      widths=[0.4, 0.4, 0.4],
-                      showfliers=False)
+boxplots = ax.boxplot(
+    data, labels=['Control', '-2Xna', '2Xna'], widths=[0.4, 0.4, 0.4], showfliers=False
+)
 
 # Set whisker style to dashed
 plt.setp(boxplots['whiskers'], linestyle='--')
@@ -79,10 +77,7 @@ setBoxColor(boxplots, ['blue', 'red', 'green'])
 gv.set_axes_limits_and_ticks(ax, ylim=(-6.0, 9.0), yticks=[-3.0, 0.0, 3.0, 6.0])
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         y_minor_per_major=3,
-                         x_minor_per_major=1,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, y_minor_per_major=3, x_minor_per_major=1, labelsize=14)
 
 # Use geocat.viz.util convenience function to add title to the plot axis.
 gv.set_titles_and_labels(ax, maintitle='Box Plot with Polymarkers')
@@ -106,21 +101,23 @@ ax2.set_xlim(0, 6)
 ax2.set_ylim(-6, 9)
 
 # Turn both major and minor ticks in overlaid axis off
-ax2.tick_params(which='both',
-                top=False,
-                bottom=False,
-                left=False,
-                right=False,
-                labelleft=False,
-                labelbottom=False)
+ax2.tick_params(
+    which='both',
+    top=False,
+    bottom=False,
+    left=False,
+    right=False,
+    labelleft=False,
+    labelbottom=False,
+)
 
 # Get rid of right and top axis spines
 removeSpines(ax2)
 
 # Plot red x markers
-ax2.scatter(1, 7.7, marker='x', color='red', linewidth=.5, s=100)
-ax2.scatter(3, 2.5, marker='x', color='red', linewidth=.5, s=100)
-ax2.scatter(5, 2, marker='x', color='red', linewidth=.5, s=100)
+ax2.scatter(1, 7.7, marker='x', color='red', linewidth=0.5, s=100)
+ax2.scatter(3, 2.5, marker='x', color='red', linewidth=0.5, s=100)
+ax2.scatter(5, 2, marker='x', color='red', linewidth=0.5, s=100)
 
 # Plot blue o markers
 ax2.scatter(1, 2, marker='o', color='darkblue')

--- a/Gallery/Colors/CB_Height.py
+++ b/Gallery/Colors/CB_Height.py
@@ -60,13 +60,12 @@ v = ds.PBLH.isel(time=0)
 t = gv.xr_add_cyclic_longitudes(v, "lon")
 
 ###############################################################################
-#Plot:
+# Plot:
 
 fig = plt.figure(figsize=(12, 12))
 
 
 def Plot(color, row, col, pos, title):
-
     # Generate axes, using Cartopy, drawing coastlines, and adding features
     projection = ccrs.PlateCarree()
     ax1 = plt.subplot(row, col, pos, projection=projection)
@@ -77,32 +76,38 @@ def Plot(color, row, col, pos, title):
     newcmp = color
 
     # Contourf-plot data
-    hgt = t.plot.contourf(ax=ax1,
-                          transform=projection,
-                          levels=31,
-                          vmin=100,
-                          vmax=1600,
-                          cmap=newcmp,
-                          add_colorbar=False)
+    hgt = t.plot.contourf(
+        ax=ax1,
+        transform=projection,
+        levels=31,
+        vmin=100,
+        vmax=1600,
+        cmap=newcmp,
+        add_colorbar=False,
+    )
 
     # Add color bar
     cbar_ticks = np.arange(100, 1600, 100)
-    cbar = plt.colorbar(hgt,
-                        orientation='vertical',
-                        shrink=0.8,
-                        pad=0.05,
-                        extendrect=True,
-                        ticks=cbar_ticks)
+    cbar = plt.colorbar(
+        hgt,
+        orientation='vertical',
+        shrink=0.8,
+        pad=0.05,
+        extendrect=True,
+        ticks=cbar_ticks,
+    )
 
     cbar.ax.tick_params(labelsize=10)
 
     # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
     # Set axes limits, and tick values
-    gv.set_axes_limits_and_ticks(ax1,
-                                 xlim=(0, 90),
-                                 ylim=(0, 90),
-                                 xticks=np.linspace(-180, 180, 13),
-                                 yticks=np.linspace(-90, 90, 7))
+    gv.set_axes_limits_and_ticks(
+        ax1,
+        xlim=(0, 90),
+        ylim=(0, 90),
+        xticks=np.linspace(-180, 180, 13),
+        yticks=np.linspace(-90, 90, 7),
+    )
 
     # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
     gv.add_lat_lon_ticklabels(ax1)
@@ -111,27 +116,28 @@ def Plot(color, row, col, pos, title):
     gv.add_major_minor_ticks(ax1, labelsize=12)
 
     # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-    gv.set_titles_and_labels(ax1,
-                             maintitle=title,
-                             maintitlefontsize=16,
-                             righttitlefontsize=14,
-                             xlabel="",
-                             ylabel="")
+    gv.set_titles_and_labels(
+        ax1,
+        maintitle=title,
+        maintitlefontsize=16,
+        righttitlefontsize=14,
+        xlabel="",
+        ylabel="",
+    )
 
 
-#Plot first color map
+# Plot first color map
 Plot(cmaps.BlAqGrYeOrRe, 2, 2, 1, "Rainbow Color Projection")
 
-#plot second color map
+# plot second color map
 Plot('magma', 2, 2, 2, "Magma Color Projection")
 
-#plot third color map
+# plot third color map
 Plot('coolwarm', 2, 2, 3, "Coolwarm Color Projection")
 
-#Plot fourth color map
+# Plot fourth color map
 Plot('Reds', 2, 2, 4, "Reds Color Projection")
 
-fig.suptitle("Projections of Planetary Boundary Layer Height",
-             x=.5,
-             y=.93,
-             fontsize=18)
+fig.suptitle(
+    "Projections of Planetary Boundary Layer Height", x=0.5, y=0.93, fontsize=18
+)

--- a/Gallery/Colors/CB_Rain.py
+++ b/Gallery/Colors/CB_Rain.py
@@ -60,13 +60,12 @@ ds = xr.open_dataset(gdf.get("netcdf_files/pre.8912.mon.nc"))
 t = ds.pre[0, :]
 
 ###############################################################################
-#Plot:
+# Plot:
 
 fig = plt.figure(figsize=(12, 12))
 
 
 def Plot(color, row, col, pos, title):
-
     # Generate axes, using Cartopy, drawing coastlines, and adding features
     projection = ccrs.PlateCarree()
     ax1 = plt.subplot(row, col, pos, projection=projection)
@@ -77,32 +76,38 @@ def Plot(color, row, col, pos, title):
     newcmp = color
 
     # Contourf-plot data
-    pre = t.plot.contourf(ax=ax1,
-                          transform=projection,
-                          levels=13,
-                          vmin=0,
-                          vmax=240,
-                          cmap=newcmp,
-                          add_colorbar=False)
+    pre = t.plot.contourf(
+        ax=ax1,
+        transform=projection,
+        levels=13,
+        vmin=0,
+        vmax=240,
+        cmap=newcmp,
+        add_colorbar=False,
+    )
 
     # Add color bar
     cbar_ticks = np.arange(0, 240, 20)
-    cbar = plt.colorbar(pre,
-                        orientation='vertical',
-                        shrink=0.8,
-                        pad=0.05,
-                        extendrect=True,
-                        ticks=cbar_ticks)
+    cbar = plt.colorbar(
+        pre,
+        orientation='vertical',
+        shrink=0.8,
+        pad=0.05,
+        extendrect=True,
+        ticks=cbar_ticks,
+    )
 
     cbar.ax.tick_params(labelsize=10)
 
     # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
     # Set axes limits, and tick values
-    gv.set_axes_limits_and_ticks(ax1,
-                                 xlim=(30, 55),
-                                 ylim=(20, 45),
-                                 xticks=np.linspace(30, 55, 6),
-                                 yticks=np.linspace(20, 45, 6))
+    gv.set_axes_limits_and_ticks(
+        ax1,
+        xlim=(30, 55),
+        ylim=(20, 45),
+        xticks=np.linspace(30, 55, 6),
+        yticks=np.linspace(20, 45, 6),
+    )
 
     # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
     gv.add_lat_lon_ticklabels(ax1)
@@ -111,24 +116,26 @@ def Plot(color, row, col, pos, title):
     gv.add_major_minor_ticks(ax1, labelsize=12)
 
     # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-    gv.set_titles_and_labels(ax1,
-                             maintitle=title,
-                             maintitlefontsize=16,
-                             righttitlefontsize=14,
-                             xlabel="",
-                             ylabel="")
+    gv.set_titles_and_labels(
+        ax1,
+        maintitle=title,
+        maintitlefontsize=16,
+        righttitlefontsize=14,
+        xlabel="",
+        ylabel="",
+    )
 
 
-#Plot first color map
+# Plot first color map
 Plot(cmaps.BlAqGrYeOrRe, 2, 2, 1, "Rainbow Color Projection")
 
-#plot second color map
+# plot second color map
 Plot('coolwarm', 2, 2, 2, "Coolwarm Color Projection")
 
-#plot third color map
+# plot third color map
 Plot('viridis', 2, 2, 3, "Viridis Color Projection")
 
-#Plot fourth color map
+# Plot fourth color map
 Plot('Blues_r', 2, 2, 4, "Blues_r Color Projection")
 
-fig.suptitle("Projections of Rain Fall Total", x=.5, y=.93, fontsize=18)
+fig.suptitle("Projections of Rain Fall Total", x=0.5, y=0.93, fontsize=18)

--- a/Gallery/Colors/CB_Temperature.py
+++ b/Gallery/Colors/CB_Temperature.py
@@ -55,8 +55,7 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/h_avg_Y0191_D000.00.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/h_avg_Y0191_D000.00.nc"), decode_times=False)
 
 # Extract a slice of the data
 t = ds.T.isel(time=0, z_t=0).sel(lat_t=slice(-60, 30), lon_t=slice(30, 120))
@@ -68,7 +67,6 @@ fig = plt.figure(figsize=(12, 12))
 
 
 def Plot(color, row, col, pos, title):
-
     # Generate axes, using Cartopy, drawing coastlines, and adding features
     projection = ccrs.PlateCarree()
     ax1 = plt.subplot(row, col, pos, projection=projection)
@@ -79,22 +77,26 @@ def Plot(color, row, col, pos, title):
     newcmp = color
 
     # Contourf-plot data
-    temp = t.plot.contourf(ax=ax1,
-                           transform=projection,
-                           levels=33,
-                           vmin=0,
-                           vmax=32,
-                           cmap=newcmp,
-                           add_colorbar=False)
+    temp = t.plot.contourf(
+        ax=ax1,
+        transform=projection,
+        levels=33,
+        vmin=0,
+        vmax=32,
+        cmap=newcmp,
+        add_colorbar=False,
+    )
 
     # Add color bar
     cbar_ticks = np.arange(0, 32, 2)
-    cbar = plt.colorbar(temp,
-                        orientation='vertical',
-                        shrink=0.8,
-                        pad=0.05,
-                        extendrect=True,
-                        ticks=cbar_ticks)
+    cbar = plt.colorbar(
+        temp,
+        orientation='vertical',
+        shrink=0.8,
+        pad=0.05,
+        extendrect=True,
+        ticks=cbar_ticks,
+    )
 
     cbar.ax.tick_params(labelsize=10)
 
@@ -103,11 +105,9 @@ def Plot(color, row, col, pos, title):
     gv.set_axes_limits_and_ticks(ax1, xlim=(30, 120), ylim=(-60, 30))
 
     # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-    gv.set_titles_and_labels(ax1,
-                             maintitle=title,
-                             maintitlefontsize=14,
-                             xlabel="",
-                             ylabel="")
+    gv.set_titles_and_labels(
+        ax1, maintitle=title, maintitlefontsize=14, xlabel="", ylabel=""
+    )
 
 
 # Plot first color map
@@ -122,4 +122,4 @@ Plot("viridis", 2, 2, 3, "Figure 3: \n Viridis Color Projection")
 # Plot fourth color map
 Plot("magma", 2, 2, 4, "Figure 4: \n Magma Color Projection")
 
-fig.suptitle("Projections of Temperature", x=.5, y=.95, fontsize=18)
+fig.suptitle("Projections of Temperature", x=0.5, y=0.95, fontsize=18)

--- a/Gallery/Contours/NCL_ce_1.py
+++ b/Gallery/Contours/NCL_ce_1.py
@@ -54,21 +54,22 @@ contour = ds.U.plot.contour(
     add_labels=False,  # turn off xarray's automatic Lat, lon labels
     colors="black",  # note plurals in this and following kwargs
     linestyles="-",
-    linewidths=0.5)
+    linewidths=0.5,
+)
 
 # Label the contours and set axes title
 ax.clabel(contour, [-8, 0, 8, 16, 24, 32], fontsize=12, fmt="%.0f")
 
 # Add lower text box
-ax.text(0.995,
-        -0.13,
-        "CONTOUR FROM -12 TO 40 BY 4",
-        horizontalalignment='right',
-        transform=ax.transAxes,
-        fontsize=14,
-        bbox=dict(boxstyle='square, pad=0.25',
-                  facecolor='white',
-                  edgecolor='black'))
+ax.text(
+    0.995,
+    -0.13,
+    "CONTOUR FROM -12 TO 40 BY 4",
+    horizontalalignment='right',
+    transform=ax.transAxes,
+    fontsize=14,
+    bbox=dict(boxstyle='square, pad=0.25', facecolor='white', edgecolor='black'),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax)
@@ -81,11 +82,13 @@ ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use geocat.viz.util convenience function to add left and right title to the plot axes.
-gv.set_titles_and_labels(ax,
-                         lefttitle="Zonal Wind",
-                         lefttitlefontsize=16,
-                         righttitle=ds.U.units,
-                         righttitlefontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle="Zonal Wind",
+    lefttitlefontsize=16,
+    righttitle=ds.U.units,
+    righttitlefontsize=16,
+)
 
 # Set ticklabel fontsize
 plt.xticks(fontsize=14)

--- a/Gallery/Contours/NCL_ce_3_1.py
+++ b/Gallery/Contours/NCL_ce_3_1.py
@@ -33,8 +33,7 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarray
-ds = xr.open_dataset(gdf.get('netcdf_files/h_avg_Y0191_D000.00.nc'),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get('netcdf_files/h_avg_Y0191_D000.00.nc'), decode_times=False)
 # Extract a slice of the data
 t = ds.T.isel(time=0, z_t=0).sel(lat_t=slice(-60, 30), lon_t=slice(30, 120))
 
@@ -54,30 +53,36 @@ ax.add_feature(cfeature.LAND, facecolor='lightgray')
 newcmp = cmaps.BlAqGrYeOrRe
 
 # Contourf-plot data
-heatmap = t.plot.contourf(ax=ax,
-                          transform=projection,
-                          levels=np.arange(0, 32, .5),
-                          vmin=0,
-                          vmax=32,
-                          cmap=newcmp,
-                          add_colorbar=False)
+heatmap = t.plot.contourf(
+    ax=ax,
+    transform=projection,
+    levels=np.arange(0, 32, 0.5),
+    vmin=0,
+    vmax=32,
+    cmap=newcmp,
+    add_colorbar=False,
+)
 
 # Add colorbar
-cbar = plt.colorbar(heatmap,
-                    shrink=0.8,
-                    drawedges=True,
-                    ticks=np.arange(0, 32, 2),
-                    extendrect=True,
-                    extendfrac='auto')
+cbar = plt.colorbar(
+    heatmap,
+    shrink=0.8,
+    drawedges=True,
+    ticks=np.arange(0, 32, 2),
+    extendrect=True,
+    extendfrac='auto',
+)
 cbar.ax.set_yticklabels([str(i) for i in np.arange(0, 32, 2)])
 
 # Usa geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, and tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(30, 120),
-                             ylim=(-60, 30),
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(30, 120),
+    ylim=(-60, 30),
+    xticks=np.linspace(-180, 180, 13),
+    yticks=np.linspace(-90, 90, 7),
+)
 
 # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
@@ -86,15 +91,17 @@ gv.add_lat_lon_ticklabels(ax)
 gv.add_major_minor_ticks(ax, labelsize=12)
 
 # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-gv.set_titles_and_labels(ax,
-                         maintitle="30-degree major and 10-degree minor ticks",
-                         maintitlefontsize=16,
-                         lefttitle="Potential Temperature",
-                         lefttitlefontsize=14,
-                         righttitle="Celsius",
-                         righttitlefontsize=14,
-                         xlabel="",
-                         ylabel="")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="30-degree major and 10-degree minor ticks",
+    maintitlefontsize=16,
+    lefttitle="Potential Temperature",
+    lefttitlefontsize=14,
+    righttitle="Celsius",
+    righttitlefontsize=14,
+    xlabel="",
+    ylabel="",
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_ce_3_2.py
+++ b/Gallery/Contours/NCL_ce_3_2.py
@@ -33,8 +33,7 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get('netcdf_files/h_avg_Y0191_D000.00.nc'),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get('netcdf_files/h_avg_Y0191_D000.00.nc'), decode_times=False)
 # Extract a slice of the data
 t = ds.T.isel(time=0, z_t=0).sel(lat_t=slice(-60, 30), lon_t=slice(30, 120))
 
@@ -54,21 +53,25 @@ ax.add_feature(cfeature.LAND, facecolor='lightgray')
 newcmp = cmaps.BlAqGrYeOrRe
 
 # Contourf-plot data
-heatmap = t.plot.contourf(ax=ax,
-                          transform=projection,
-                          levels=np.arange(0, 32, .5),
-                          vmin=0,
-                          vmax=32,
-                          cmap=newcmp,
-                          add_colorbar=False)
+heatmap = t.plot.contourf(
+    ax=ax,
+    transform=projection,
+    levels=np.arange(0, 32, 0.5),
+    vmin=0,
+    vmax=32,
+    cmap=newcmp,
+    add_colorbar=False,
+)
 
 # Add colorbar
-cbar = plt.colorbar(heatmap,
-                    shrink=0.8,
-                    drawedges=True,
-                    ticks=np.arange(0, 32, 2),
-                    extendrect=True,
-                    extendfrac='auto')
+cbar = plt.colorbar(
+    heatmap,
+    shrink=0.8,
+    drawedges=True,
+    ticks=np.arange(0, 32, 2),
+    extendrect=True,
+    extendfrac='auto',
+)
 cbar.ax.set_yticklabels([str(i) for i in np.arange(0, 32, 2)])
 
 # Adjust tick label size
@@ -76,25 +79,29 @@ ax.tick_params(labelsize=12)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, and tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(30, 120),
-                             ylim=(-60, 30),
-                             xticks=np.linspace(-180, 180, 25),
-                             yticks=np.linspace(-90, 90, 13))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(30, 120),
+    ylim=(-60, 30),
+    xticks=np.linspace(-180, 180, 25),
+    yticks=np.linspace(-90, 90, 13),
+)
 
 # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-gv.set_titles_and_labels(ax,
-                         maintitle="15-degree major but no minor ticks",
-                         maintitlefontsize=16,
-                         lefttitle="Potential Temperature",
-                         lefttitlefontsize=14,
-                         righttitle="Celsius",
-                         righttitlefontsize=14,
-                         xlabel="",
-                         ylabel="")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="15-degree major but no minor ticks",
+    maintitlefontsize=16,
+    lefttitle="Potential Temperature",
+    lefttitlefontsize=14,
+    righttitle="Celsius",
+    righttitlefontsize=14,
+    xlabel="",
+    ylabel="",
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_color_1.py
+++ b/Gallery/Contours/NCL_color_1.py
@@ -54,39 +54,40 @@ newcmp = cmaps.ncl_default
 
 # Contourf-plot data (for filled contours)
 # Note, min-max contour levels are hard-coded. contourf's automatic contour value selector produces fractional values.
-p = U.plot.contourf(ax=ax,
-                    vmin=-16.0,
-                    vmax=44,
-                    levels=16,
-                    cmap=newcmp,
-                    add_colorbar=False,
-                    transform=projection,
-                    extend='neither')
+p = U.plot.contourf(
+    ax=ax,
+    vmin=-16.0,
+    vmax=44,
+    levels=16,
+    cmap=newcmp,
+    add_colorbar=False,
+    transform=projection,
+    extend='neither',
+)
 
 # Contour-plot data (for contour lines)
 # Note, min-max contour levels are hard-coded. contourf's automatic contour value selector produces fractional values.
-U.plot.contour(ax=ax,
-               vmin=-16.0,
-               vmax=44,
-               levels=16,
-               colors='black',
-               linewidths=0.5,
-               transform=projection)
+U.plot.contour(
+    ax=ax,
+    vmin=-16.0,
+    vmax=44,
+    levels=16,
+    colors='black',
+    linewidths=0.5,
+    transform=projection,
+)
 
 # Add horizontal colorbar
-cbar = plt.colorbar(p,
-                    orientation='horizontal',
-                    shrink=0.75,
-                    drawedges=True,
-                    aspect=16,
-                    pad=0.075)
+cbar = plt.colorbar(
+    p, orientation='horizontal', shrink=0.75, drawedges=True, aspect=16, pad=0.075
+)
 cbar.ax.tick_params(labelsize=14)
 cbar.set_ticks(np.linspace(-12, 40, 14))
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.linspace(-180, 180, 13), yticks=np.linspace(-90, 90, 7)
+)
 
 # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
@@ -95,14 +96,16 @@ gv.add_lat_lon_ticklabels(ax)
 gv.add_major_minor_ticks(ax, labelsize=14)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         maintitle="NCL Default Colors",
-                         lefttitle=U.long_name,
-                         lefttitlefontsize=16,
-                         righttitle=U.units,
-                         righttitlefontsize=16,
-                         xlabel="",
-                         ylabel="")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="NCL Default Colors",
+    lefttitle=U.long_name,
+    lefttitlefontsize=16,
+    righttitle=U.units,
+    righttitlefontsize=16,
+    xlabel="",
+    ylabel="",
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_conLab_4.py
+++ b/Gallery/Contours/NCL_conLab_4.py
@@ -50,19 +50,16 @@ plt.figure(figsize=(8, 8))
 ax = plt.axes(projection=ccrs.PlateCarree())
 
 # Draw map features
-ax.add_feature(cfeature.LAKES,
-               linewidth=0.5,
-               edgecolor='black',
-               facecolor='None')
+ax.add_feature(cfeature.LAKES, linewidth=0.5, edgecolor='black', facecolor='None')
 ax.add_feature(cfeature.COASTLINE, linewidth=0.5)
 
 # Zoom in on region bounded by the prime meridian, 70N, 25S, and 25N
 ax.set_extent([0, 70, -30, 30], crs=ccrs.PlateCarree())
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             yticks=np.linspace(-20, 20, 3),
-                             xticks=np.linspace(0, 60, 3))
+gv.set_axes_limits_and_ticks(
+    ax, yticks=np.linspace(-20, 20, 3), xticks=np.linspace(0, 60, 3)
+)
 
 # Use geocat.viz.util convenience function to make plots look like NCL plots
 # by using latitude, longitude tick labels
@@ -73,10 +70,7 @@ ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=4,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=4, labelsize=14)
 
 # Use geocat.viz.util convenience function to add titles to left and right of
 # the plot axis
@@ -86,32 +80,42 @@ gv.set_titles_and_labels(ax, lefttitle=U.long_name, righttitle=U.units)
 cmap = cmaps.gui_default
 
 # Draw filled contours
-colors = U.plot.contourf(ax=ax,
-                         cmap=cmap,
-                         levels=np.arange(-16, 48, 4),
-                         add_colorbar=False,
-                         add_labels=False)
+colors = U.plot.contourf(
+    ax=ax, cmap=cmap, levels=np.arange(-16, 48, 4), add_colorbar=False, add_labels=False
+)
 # Draw contour lines
-lines = U.plot.contour(ax=ax,
-                       colors='black',
-                       levels=np.arange(-16, 48, 4),
-                       linewidths=0.5,
-                       linestyles='solid',
-                       add_labels=False)
+lines = U.plot.contour(
+    ax=ax,
+    colors='black',
+    levels=np.arange(-16, 48, 4),
+    linewidths=0.5,
+    linestyles='solid',
+    add_labels=False,
+)
 
 # Create horizontal colorbar
-cbar = plt.colorbar(colors,
-                    ticks=np.arange(-12, 44, 4),
-                    orientation='horizontal',
-                    drawedges=True,
-                    aspect=12,
-                    shrink=0.8,
-                    pad=0.075)
+cbar = plt.colorbar(
+    colors,
+    ticks=np.arange(-12, 44, 4),
+    orientation='horizontal',
+    drawedges=True,
+    aspect=12,
+    shrink=0.8,
+    pad=0.075,
+)
 cbar.ax.tick_params(labelsize=14)  # Make the labels larger
 
 # Specify coordinates for contour labels in (longitude, latitude) format
-manual = [(25, 28), (30, -17), (40, -21), (40, -5), (42, -13), (10, 50),
-          (62, -15), (65, -2)]
+manual = [
+    (25, 28),
+    (30, -17),
+    (40, -21),
+    (40, -5),
+    (42, -13),
+    (10, 50),
+    (62, -15),
+    (65, -2),
+]
 
 # Draw contour labels and pass in coordinates using `manual` argument
 ax.clabel(lines, fontsize=12, fmt='%d', inline=True, manual=manual)

--- a/Gallery/Contours/NCL_conLev_1.py
+++ b/Gallery/Contours/NCL_conLev_1.py
@@ -29,8 +29,7 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/b003_TS_200-299.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/b003_TS_200-299.nc"), decode_times=False)
 # Extract slice of the data
 temp = ds.TS.isel(time=43, drop=True)
 
@@ -56,9 +55,9 @@ ax.set_extent([-180, 180, -70, 70], crs=projection)
 ax.add_feature(cfeature.LAND, color='silver')
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-60, 60, 5))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.linspace(-180, 180, 13), yticks=np.linspace(-60, 60, 5)
+)
 
 # Use geocat.viz.util convenience function to make latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
@@ -70,21 +69,23 @@ ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 gv.add_major_minor_ticks(ax, labelsize=12)
 
 # Use geocat.viz.util convenience function to add titles
-gv.set_titles_and_labels(ax,
-                         lefttitle=temp.long_name,
-                         righttitle=temp.units,
-                         lefttitlefontsize=14,
-                         righttitlefontsize=14)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle=temp.long_name,
+    righttitle=temp.units,
+    lefttitlefontsize=14,
+    righttitlefontsize=14,
+)
 
 # Add lower text box
-ax.text(1,
-        -0.15,
-        "CONTOUR FROM -5 TO 30 BY 5",
-        horizontalalignment='right',
-        transform=ax.transAxes,
-        bbox=dict(boxstyle='square, pad=0.25',
-                  facecolor='white',
-                  edgecolor='black'))
+ax.text(
+    1,
+    -0.15,
+    "CONTOUR FROM -5 TO 30 BY 5",
+    horizontalalignment='right',
+    transform=ax.transAxes,
+    bbox=dict(boxstyle='square, pad=0.25', facecolor='white', edgecolor='black'),
+)
 
 # Specify which contour levels to draw
 contour_lev = np.arange(-5, 35, 5)
@@ -93,14 +94,16 @@ contour_lev = np.arange(-5, 35, 5)
 # set exactly where the labels will be drawn.
 labels = np.linspace(0, 20, 3)
 # Plot contour lines
-contour = temp.plot.contour(ax=ax,
-                            transform=ccrs.PlateCarree(),
-                            vmin=-5,
-                            vmax=30,
-                            levels=contour_lev,
-                            colors='black',
-                            linestyles='solid',
-                            linewidths=0.5,
-                            add_labels=False)
+contour = temp.plot.contour(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    vmin=-5,
+    vmax=30,
+    levels=contour_lev,
+    colors='black',
+    linestyles='solid',
+    linewidths=0.5,
+    add_labels=False,
+)
 ax.clabel(contour, labels, fmt='%d', inline=True, fontsize=10)
 plt.show()

--- a/Gallery/Contours/NCL_conLev_3.py
+++ b/Gallery/Contours/NCL_conLev_3.py
@@ -53,22 +53,26 @@ newcmp = 'plasma'
 
 # Contourf-plot data (for filled contours)
 num_lev = 16  # Number of levels
-temp = T.plot.contourf(ax=ax,
-                       vmin=244,
-                       vmax=308,
-                       levels=np.linspace(244, 308, num_lev + 1),
-                       cmap=newcmp,
-                       add_colorbar=False,
-                       add_labels=False)
+temp = T.plot.contourf(
+    ax=ax,
+    vmin=244,
+    vmax=308,
+    levels=np.linspace(244, 308, num_lev + 1),
+    cmap=newcmp,
+    add_colorbar=False,
+    add_labels=False,
+)
 
 # Contour-plot data (for line contours)
-T.plot.contour(ax=ax,
-               vmin=244,
-               vmax=308,
-               levels=np.linspace(244, 308, num_lev + 1),
-               colors='black',
-               linewidths=0.5,
-               add_labels=False)
+T.plot.contour(
+    ax=ax,
+    vmin=244,
+    vmax=308,
+    levels=np.linspace(244, 308, num_lev + 1),
+    colors='black',
+    linewidths=0.5,
+    add_labels=False,
+)
 
 # Add horizontal colorbar
 cbar_ticks = np.arange(248, 308, 4)
@@ -77,11 +81,13 @@ cbar.ax.tick_params(labelsize=11)
 cbar.set_ticks(cbar_ticks)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(-140, -50),
-                             ylim=(20, 60),
-                             xticks=[-135, -90],
-                             yticks=np.arange(20, 70, 10))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(-140, -50),
+    ylim=(20, 60),
+    xticks=[-135, -90],
+    yticks=np.arange(20, 70, 10),
+)
 
 # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
@@ -91,10 +97,7 @@ ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=5,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=5, labelsize=12)
 
 # Remove ticks on right side
 ax.tick_params(which='both', right=False)
@@ -105,41 +108,47 @@ gv.set_titles_and_labels(ax, maintitle="Explanation of Python contour levels")
 # Create labels by colorbar
 size = 8
 y = 1 / num_lev / 2  # Offset from x axis in axes coordinates
-ax.text(0.949,
-        y,
-        'T < 248',
-        fontsize=size,
-        horizontalalignment='center',
-        verticalalignment='center',
-        transform=ax.transAxes,
-        bbox=dict(boxstyle='square, pad=0.25',
-                  facecolor='papayawhip',
-                  edgecolor='papayawhip'))
+ax.text(
+    0.949,
+    y,
+    'T < 248',
+    fontsize=size,
+    horizontalalignment='center',
+    verticalalignment='center',
+    transform=ax.transAxes,
+    bbox=dict(
+        boxstyle='square, pad=0.25', facecolor='papayawhip', edgecolor='papayawhip'
+    ),
+)
 text = '{} <= T < {}'
 for i in range(0, 14):
     y = y + 1 / num_lev  # Vertical spacing between the labels
-    ax.text(0.904,
-            y,
-            text.format(cbar_ticks[i], cbar_ticks[i + 1]),
-            fontsize=size,
-            horizontalalignment='center',
-            verticalalignment='center',
-            transform=ax.transAxes,
-            bbox=dict(boxstyle='square, pad=0.25',
-                      facecolor='papayawhip',
-                      edgecolor='papayawhip'))
-
-y = y + 1 / num_lev  # Increment height once more for top label
-ax.text(0.94,
+    ax.text(
+        0.904,
         y,
-        'T >= 304',
+        text.format(cbar_ticks[i], cbar_ticks[i + 1]),
         fontsize=size,
         horizontalalignment='center',
         verticalalignment='center',
         transform=ax.transAxes,
-        bbox=dict(boxstyle='square, pad=0.25',
-                  facecolor='papayawhip',
-                  edgecolor='papayawhip'))
+        bbox=dict(
+            boxstyle='square, pad=0.25', facecolor='papayawhip', edgecolor='papayawhip'
+        ),
+    )
+
+y = y + 1 / num_lev  # Increment height once more for top label
+ax.text(
+    0.94,
+    y,
+    'T >= 304',
+    fontsize=size,
+    horizontalalignment='center',
+    verticalalignment='center',
+    transform=ax.transAxes,
+    bbox=dict(
+        boxstyle='square, pad=0.25', facecolor='papayawhip', edgecolor='papayawhip'
+    ),
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_conLev_4.py
+++ b/Gallery/Contours/NCL_conLev_4.py
@@ -32,8 +32,7 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/b003_TS_200-299.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/b003_TS_200-299.nc"), decode_times=False)
 x = ds.TS
 
 # Apply mean reduction from coordinates as performed in NCL's dim_rmvmean_n_Wrap(x,0)
@@ -60,8 +59,11 @@ ax.coastlines(linewidth=0.5, resolution="110m")
 
 # Import an NCL colormap
 newcmp = cmaps.BlRe
-newcmp.colors[len(newcmp.colors) //
-              2] = [1, 1, 1]  # Set middle value to white to match NCL
+newcmp.colors[len(newcmp.colors) // 2] = [
+    1,
+    1,
+    1,
+]  # Set middle value to white to match NCL
 
 # Contourf-plot data (for filled contours)
 p = newx.plot.contourf(
@@ -72,24 +74,27 @@ p = newx.plot.contourf(
     cmap=newcmp,
     add_colorbar=False,
     transform=projection,
-    add_labels=False)
+    add_labels=False,
+)
 
 # Add horizontal colorbar
-cbar = plt.colorbar(p,
-                    orientation='horizontal',
-                    shrink=0.6,
-                    extendrect=True,
-                    extendfrac='auto',
-                    pad=0.075,
-                    aspect=15,
-                    drawedges=True)
+cbar = plt.colorbar(
+    p,
+    orientation='horizontal',
+    shrink=0.6,
+    extendrect=True,
+    extendfrac='auto',
+    pad=0.075,
+    aspect=15,
+    drawedges=True,
+)
 cbar.ax.tick_params(labelsize=11)
 cbar.set_ticks([-12, -10, -8, -6, -4, -2, -1, 1, 2, 4, 6, 8, 10, 12])
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.linspace(-180, 180, 13), yticks=np.linspace(-90, 90, 7)
+)
 
 # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
@@ -98,9 +103,7 @@ gv.add_lat_lon_ticklabels(ax)
 gv.add_major_minor_ticks(ax, labelsize=12)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         lefttitle='Anomalies: Surface Temperature',
-                         righttitle='K')
+gv.set_titles_and_labels(ax, lefttitle='Anomalies: Surface Temperature', righttitle='K')
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_conOncon_1.py
+++ b/Gallery/Contours/NCL_conOncon_1.py
@@ -56,11 +56,13 @@ gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=0)
 
 # Use geocat.viz.util convenience function to set axes tick values
 # Set y-lim inorder for y-axis to have descending values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-60, 60, 5),
-                             xticklabels=['60S', '30S', '0', '30N', '60N'],
-                             ylim=ax.get_ylim()[::-1],
-                             yticks=U["lev"])
+gv.set_axes_limits_and_ticks(
+    ax,
+    xticks=np.linspace(-60, 60, 5),
+    xticklabels=['60S', '30S', '0', '30N', '60N'],
+    ylim=ax.get_ylim()[::-1],
+    yticks=U["lev"],
+)
 
 # Change formatter or else we tick values formatted in exponential form
 ax.yaxis.set_major_formatter(ScalarFormatter())
@@ -73,28 +75,31 @@ ax.tick_params('both', length=15, width=1, which='major', labelsize=18)
 ax.tick_params('x', length=7, width=0.6, which='minor')
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         maintitle="Ensemble Average 1987-89",
-                         maintitlefontsize=25,
-                         lefttitle=U.long_name,
-                         lefttitlefontsize=22,
-                         righttitle=U.units,
-                         righttitlefontsize=22,
-                         xlabel="")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Ensemble Average 1987-89",
+    maintitlefontsize=25,
+    lefttitle=U.long_name,
+    lefttitlefontsize=22,
+    righttitle=U.units,
+    righttitlefontsize=22,
+    xlabel="",
+)
 
 # Create second y-axis to show geo-potential height.
-axRHS = gv.add_height_from_pressure_axis(ax,
-                                         heights=np.arange(4, 28, 4),
-                                         ticklabelsize=18,
-                                         axislabelsize=22)
+axRHS = gv.add_height_from_pressure_axis(
+    ax, heights=np.arange(4, 28, 4), ticklabelsize=18, axislabelsize=22
+)
 
 # Add figure label
-fig.text(0.7,
-         0.03,
-         "CONTOUR FROM -3.2 TO 2.8 BY 4",
-         horizontalalignment='center',
-         fontsize=15,
-         bbox=dict(facecolor='none', edgecolor='k'))
+fig.text(
+    0.7,
+    0.03,
+    "CONTOUR FROM -3.2 TO 2.8 BY 4",
+    horizontalalignment='center',
+    fontsize=15,
+    bbox=dict(facecolor='none', edgecolor='k'),
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_conOncon_2.py
+++ b/Gallery/Contours/NCL_conOncon_2.py
@@ -11,6 +11,7 @@ See following URLs to see the reproduced NCL plot & script:
     - Original NCL script: https://www.ncl.ucar.edu/Applications/Scripts/conOncon_2.ncl
     - Original NCL plot: https://www.ncl.ucar.edu/Applications/Images/conOncon_2_lg.png
 """
+
 ################################################################################
 # Import packages:
 import numpy as np
@@ -53,21 +54,25 @@ ax.set_extent([100, 300, -60, 60], crs=ccrs.PlateCarree())
 cmap = cmaps.BlWhRe
 sst_levels = np.arange(-5.5, 6, 0.5)
 # Draw SST contour
-temp = sst.plot.contourf(ax=ax,
-                         transform=ccrs.PlateCarree(),
-                         cmap=cmap,
-                         levels=sst_levels,
-                         extend='neither',
-                         add_colorbar=False,
-                         add_labels=False,
-                         zorder=0)
-plt.colorbar(temp,
-             ax=ax,
-             orientation='vertical',
-             ticks=np.arange(-5, 6, 1),
-             drawedges=True,
-             shrink=0.5,
-             aspect=10)
+temp = sst.plot.contourf(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    cmap=cmap,
+    levels=sst_levels,
+    extend='neither',
+    add_colorbar=False,
+    add_labels=False,
+    zorder=0,
+)
+plt.colorbar(
+    temp,
+    ax=ax,
+    orientation='vertical',
+    ticks=np.arange(-5, 6, 1),
+    drawedges=True,
+    shrink=0.5,
+    aspect=10,
+)
 
 # Draw map features on top of filled contour
 ax.add_feature(cfeature.LAND, facecolor='lightgray', zorder=1)
@@ -78,28 +83,31 @@ ax.add_feature(cfeature.COASTLINE, edgecolor='gray', linewidth=0.5, zorder=1)
 olr_levels = np.arange(-80, 0, 10)
 olr_levels = np.append(olr_levels, np.arange(10, 50, 10))
 
-rad = olr.plot.contour(ax=ax,
-                       transform=ccrs.PlateCarree(),
-                       levels=olr_levels,
-                       colors='gray',
-                       linewidths=0.5,
-                       add_labels=False)
+rad = olr.plot.contour(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    levels=olr_levels,
+    colors='gray',
+    linewidths=0.5,
+    add_labels=False,
+)
 ax.clabel(rad, [-40, -20, 20], fmt='%d', inline=True, colors='black')
 
 # Plot the zero contour with a black color
-rad = olr.plot.contour(ax=ax,
-                       transform=ccrs.PlateCarree(),
-                       levels=[0],
-                       colors='black',
-                       linewidths=0.5,
-                       add_labels=False)
+rad = olr.plot.contour(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    levels=[0],
+    colors='black',
+    linewidths=0.5,
+    add_labels=False,
+)
 ax.clabel(rad, [0], fmt='%d', inline=True, colors='black')
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(-60, 60),
-                             yticks=np.arange(-60, 90, 30),
-                             xticks=np.arange(-80, 120, 30))
+gv.set_axes_limits_and_ticks(
+    ax, ylim=(-60, 60), yticks=np.arange(-60, 90, 30), xticks=np.arange(-80, 120, 30)
+)
 
 # Use geocat.viz.util convenience function to make plots look like NCL plots by
 # using latitude, longitude tick labels
@@ -110,29 +118,28 @@ ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=3,
-                         labelsize=10)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=3, labelsize=10)
 
-gv.set_titles_and_labels(ax,
-                         maintitle=olr.long_name,
-                         maintitlefontsize=14,
-                         lefttitle='degC',
-                         lefttitlefontsize=12,
-                         righttitle='(W m s$^{-2}$)',
-                         righttitlefontsize=12)
+gv.set_titles_and_labels(
+    ax,
+    maintitle=olr.long_name,
+    maintitlefontsize=14,
+    lefttitle='degC',
+    lefttitlefontsize=12,
+    righttitle='(W m s$^{-2}$)',
+    righttitlefontsize=12,
+)
 # Add center title
 ax.text(0.35, 1.06, 'December 1982', fontsize=12, transform=ax.transAxes)
 
 # Add lower text box
-ax.text(1,
-        -0.2,
-        "CONTOUR FROM -80 TO 40 BY 10",
-        horizontalalignment='right',
-        transform=ax.transAxes,
-        bbox=dict(boxstyle='square, pad=0.25',
-                  facecolor='white',
-                  edgecolor='black'))
+ax.text(
+    1,
+    -0.2,
+    "CONTOUR FROM -80 TO 40 BY 10",
+    horizontalalignment='right',
+    transform=ax.transAxes,
+    bbox=dict(boxstyle='square, pad=0.25', facecolor='white', edgecolor='black'),
+)
 
 plt.show()

--- a/Gallery/Contours/NCL_conOncon_5.py
+++ b/Gallery/Contours/NCL_conOncon_5.py
@@ -31,8 +31,9 @@ import geocat.viz as gv
 
 # Open a netCDF data file using xarray default engine and
 # load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/HGT500_MON_1958-1997.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(
+    gdf.get("netcdf_files/HGT500_MON_1958-1997.nc"), decode_times=False
+)
 
 ###############################################################################
 # Plot:
@@ -51,12 +52,14 @@ ax.add_feature(cfeature.LAND, facecolor='lightgray')
 gv.set_map_boundary(ax, [-180, 180], [0, 40], south_pad=1)
 
 # Set draw_labels to False so that you can manually manipulate it later
-gl = ax.gridlines(ccrs.PlateCarree(),
-                  draw_labels=False,
-                  linestyle="--",
-                  linewidth=1,
-                  color='darkgray',
-                  zorder=2)
+gl = ax.gridlines(
+    ccrs.PlateCarree(),
+    draw_labels=False,
+    linestyle="--",
+    linewidth=1,
+    color='darkgray',
+    zorder=2,
+)
 
 # Manipulate latitude and longitude gridline numbers and spacing
 gl.ylocator = mticker.FixedLocator(np.arange(0, 90, 15))
@@ -64,38 +67,44 @@ gl.xlocator = mticker.FixedLocator(np.arange(-180, 180, 30))
 
 # Manipulate longitude labels (0, 30 E, 60 E, ..., 30 W, etc.)
 ticks = np.arange(0, 210, 30)
-etick = ['0'] + [
-    r'%dE' % tick for tick in ticks if (tick != 0) & (tick != 180)
-] + ['180']
+etick = (
+    ['0'] + [r'%dE' % tick for tick in ticks if (tick != 0) & (tick != 180)] + ['180']
+)
 wtick = [r'%dW' % tick for tick in ticks if (tick != 0) & (tick != 180)]
 labels = etick + wtick
 xticks = np.arange(0, 360, 30)
 yticks = np.full_like(xticks, -5)  # Latitude where the labels will be drawn
 for xtick, ytick, label in zip(xticks, yticks, labels):
     if label == '180':
-        ax.text(xtick,
-                ytick,
-                label,
-                fontsize=14,
-                horizontalalignment='center',
-                verticalalignment='top',
-                transform=ccrs.Geodetic())
+        ax.text(
+            xtick,
+            ytick,
+            label,
+            fontsize=14,
+            horizontalalignment='center',
+            verticalalignment='top',
+            transform=ccrs.Geodetic(),
+        )
     elif label == '0':
-        ax.text(xtick,
-                ytick,
-                label,
-                fontsize=14,
-                horizontalalignment='center',
-                verticalalignment='bottom',
-                transform=ccrs.Geodetic())
+        ax.text(
+            xtick,
+            ytick,
+            label,
+            fontsize=14,
+            horizontalalignment='center',
+            verticalalignment='bottom',
+            transform=ccrs.Geodetic(),
+        )
     else:
-        ax.text(xtick,
-                ytick,
-                label,
-                fontsize=14,
-                horizontalalignment='center',
-                verticalalignment='center',
-                transform=ccrs.Geodetic())
+        ax.text(
+            xtick,
+            ytick,
+            label,
+            fontsize=14,
+            horizontalalignment='center',
+            verticalalignment='center',
+            transform=ccrs.Geodetic(),
+        )
 
 # Get slice of data at the 0th timestep - plot this contour line separately
 # because it will be thicker than the other contour lines
@@ -106,23 +115,40 @@ p = ds.HGT.isel(time=0)
 slon = gv.xr_add_cyclic_longitudes(p, "lon")
 
 # Plot contour data at pressure level 5500 at the first timestep
-p = slon.plot.contour(ax=ax,
-                      transform=ccrs.PlateCarree(),
-                      linewidths=1.5,
-                      levels=[5500],
-                      colors='black',
-                      add_labels=False)
+p = slon.plot.contour(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    linewidths=1.5,
+    levels=[5500],
+    colors='black',
+    add_labels=False,
+)
 
 # Create a color list for each of the next 18 contours
 colorlist = [
-    "crimson", "green", "blue", "yellow", "cyan", "hotpink", "crimson",
-    "skyblue", "navy", "lightyellow", "mediumorchid", "orange", "slateblue",
-    "palegreen", "magenta", "springgreen", "pink", "forestgreen", "violet"
+    "crimson",
+    "green",
+    "blue",
+    "yellow",
+    "cyan",
+    "hotpink",
+    "crimson",
+    "skyblue",
+    "navy",
+    "lightyellow",
+    "mediumorchid",
+    "orange",
+    "slateblue",
+    "palegreen",
+    "magenta",
+    "springgreen",
+    "pink",
+    "forestgreen",
+    "violet",
 ]
 
 # Iterate through 18 different timesteps
 for x in range(18):
-
     # Get a slice of data at the 12*x+1 timestep
     p = ds.HGT.isel(time=12 * x + 1)
 
@@ -131,18 +157,22 @@ for x in range(18):
     slon = gv.xr_add_cyclic_longitudes(p, "lon")
 
     # Plot contour data at pressure level 5500 for the 12*x+1 timestep
-    p = slon.plot.contour(ax=ax,
-                          transform=ccrs.PlateCarree(),
-                          linewidths=0.5,
-                          levels=[5500],
-                          colors=colorlist[x],
-                          add_labels=False)
+    p = slon.plot.contour(
+        ax=ax,
+        transform=ccrs.PlateCarree(),
+        linewidths=0.5,
+        levels=[5500],
+        colors=colorlist[x],
+        add_labels=False,
+    )
 
 # Use geocat.viz.util convenience function to add titles
-gv.set_titles_and_labels(ax,
-                         maintitle=r"$\bf{Spaghetti}$" + " " + r"$\bf{Plot}$",
-                         lefttitle=slon.long_name,
-                         righttitle=slon.units)
+gv.set_titles_and_labels(
+    ax,
+    maintitle=r"$\bf{Spaghetti}$" + " " + r"$\bf{Plot}$",
+    lefttitle=slon.long_name,
+    righttitle=slon.units,
+)
 
 # Make tight layout
 plt.tight_layout()

--- a/Gallery/Contours/NCL_coneff_11.py
+++ b/Gallery/Contours/NCL_coneff_11.py
@@ -45,43 +45,51 @@ hatches = ['/////', '/////', '/////', '/////', None, '..', '.', '.', '.']
 
 # Choose colors for the hatches
 colors = [
-    'coral', 'palegreen', 'royalblue', 'lemonchiffon', 'white', 'fuchsia',
-    'brown', 'cyan', 'mediumblue'
+    'coral',
+    'palegreen',
+    'royalblue',
+    'lemonchiffon',
+    'white',
+    'fuchsia',
+    'brown',
+    'cyan',
+    'mediumblue',
 ]
 
 # Create a filled contour plot
-p = v.plot.contourf(ax=ax,
-                    vmin=-45.0,
-                    vmax=45,
-                    levels=10,
-                    add_colorbar=False,
-                    hatches=hatches,
-                    cmap='white')  # Use white cmap to have a white background
+p = v.plot.contourf(
+    ax=ax,
+    vmin=-45.0,
+    vmax=45,
+    levels=10,
+    add_colorbar=False,
+    hatches=hatches,
+    cmap='white',
+)  # Use white cmap to have a white background
 
 # Set the colors for the hatches
 p.set_edgecolors(colors)
-p.set_linewidth(0.)
+p.set_linewidth(0.0)
 
 # Set linewidth of hatches
 plt.rcParams['hatch.linewidth'] = 2.5
 
 # Plot the contour lines
-c = v.plot.contour(ax=ax,
-                   vmin=-45.0,
-                   vmax=45,
-                   levels=10,
-                   colors='k',
-                   linewidths=1,
-                   add_colorbar=False,
-                   linestyles='solid')
+c = v.plot.contour(
+    ax=ax,
+    vmin=-45.0,
+    vmax=45,
+    levels=10,
+    colors='k',
+    linewidths=1,
+    add_colorbar=False,
+    linestyles='solid',
+)
 
 # Add horizontal colorbar
-cbar = plt.colorbar(p,
-                    orientation='horizontal',
-                    shrink=0.97,
-                    aspect=10,
-                    pad=0.09,
-                    drawedges=True)
+cbar = plt.colorbar(
+    p, orientation='horizontal', shrink=0.97, aspect=10, pad=0.09, drawedges=True
+)
 cbar.ax.tick_params(labelsize=16)
 cbar.set_ticks(np.arange(-35, 40, 10))
 
@@ -95,19 +103,18 @@ for i, patch in enumerate(cbar.solids_patches):
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat-viz utility function to format major and minor ticks
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=2,
-                         y_minor_per_major=3,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=2, y_minor_per_major=3, labelsize=16)
 
 # Use geocat-viz utility function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Patterned Contour Plot",
-                         maintitlefontsize=18,
-                         lefttitle="meridional wind component",
-                         lefttitlefontsize=16,
-                         righttitle="m/s",
-                         righttitlefontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Patterned Contour Plot",
+    maintitlefontsize=18,
+    lefttitle="meridional wind component",
+    lefttitlefontsize=16,
+    righttitle="m/s",
+    righttitlefontsize=16,
+)
 
 # Remove default x and y labels
 ax.set_xlabel(None)
@@ -119,6 +126,7 @@ gv.set_axes_limits_and_ticks(
     xticks=np.arange(0, 360, 60),
     yticks=np.arange(-60, 90, 30),
     xticklabels=['0', '60E', '120E', '180', '120W', '60W'],
-    yticklabels=['60S', '30S', '0', '30N', '60N'])
+    yticklabels=['60S', '30S', '0', '30N', '60N'],
+)
 
 plt.show()

--- a/Gallery/Contours/NCL_coneff_16.py
+++ b/Gallery/Contours/NCL_coneff_16.py
@@ -49,14 +49,16 @@ newcmp = cmaps.BlueYellowRed
 
 # Contourf-plot data (for filled contours)
 # Note, min-max contour levels are hard-coded. contourf's automatic contour value selector produces fractional values.
-p = U.plot.contourf(ax=ax,
-                    vmin=-16.0,
-                    vmax=44,
-                    levels=16,
-                    cmap=newcmp,
-                    add_colorbar=False,
-                    transform=projection,
-                    extend='neither')
+p = U.plot.contourf(
+    ax=ax,
+    vmin=-16.0,
+    vmax=44,
+    levels=16,
+    cmap=newcmp,
+    add_colorbar=False,
+    transform=projection,
+    extend='neither',
+)
 
 # Add horizontal colorbar
 cbar = plt.colorbar(p, orientation='horizontal', shrink=0.5)
@@ -64,9 +66,9 @@ cbar.ax.tick_params(labelsize=14)
 cbar.set_ticks(np.linspace(-12, 40, 14))
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.linspace(-180, 180, 13), yticks=np.linspace(-90, 90, 7)
+)
 
 # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
@@ -75,14 +77,16 @@ gv.add_lat_lon_ticklabels(ax)
 gv.add_major_minor_ticks(ax, labelsize=12)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         maintitle="Color contours mask filled land",
-                         lefttitle=U.long_name,
-                         lefttitlefontsize=16,
-                         righttitle=U.units,
-                         righttitlefontsize=16,
-                         xlabel="",
-                         ylabel="")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Color contours mask filled land",
+    lefttitle=U.long_name,
+    lefttitlefontsize=16,
+    righttitle=U.units,
+    righttitlefontsize=16,
+    xlabel="",
+    ylabel="",
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_coneff_8.py
+++ b/Gallery/Contours/NCL_coneff_8.py
@@ -41,20 +41,14 @@ new_levels = np.array([1000, 850, 700, 500, 400, 300, 250, 200])
 new_levels = new_levels * 100  # convert to Pascals
 
 # Interpolate pressure coordinates from hybrid sigma coord
-u_int = interp_hybrid_to_pressure(u,
-                                  ps,
-                                  hyam,
-                                  hybm,
-                                  p0=p0,
-                                  new_levels=new_levels,
-                                  method='log')
+u_int = interp_hybrid_to_pressure(
+    u, ps, hyam, hybm, p0=p0, new_levels=new_levels, method='log'
+)
 # Calculate zonal mean
 uzon = u_int.mean(dim='lon')
 
 # interpolate nan values
-uzon = uzon.interpolate_na(dim='lat',
-                           method='nearest',
-                           fill_value='extrapolate')
+uzon = uzon.interpolate_na(dim='lat', method='nearest', fill_value='extrapolate')
 
 ###############################################################################
 # Plot:
@@ -72,39 +66,52 @@ newcmp = mpl.colors.ListedColormap(colors)
 
 # Plot filled contours
 levels = np.arange(0, 36, 4)
-p = uzon.plot.contourf(ax=ax1,
-                       levels=levels,
-                       vmin=-8,
-                       vmax=40,
-                       cmap=newcmp,
-                       add_colorbar=False,
-                       add_labels=False)
+p = uzon.plot.contourf(
+    ax=ax1,
+    levels=levels,
+    vmin=-8,
+    vmax=40,
+    cmap=newcmp,
+    add_colorbar=False,
+    add_labels=False,
+)
 
 # Plot contour lines
-contours = uzon.plot.contour(ax=ax1,
-                             levels=13,
-                             vmin=-8,
-                             vmax=40,
-                             colors='black',
-                             linewidths=0.5,
-                             linestyles='solid',
-                             add_labels=False)
+contours = uzon.plot.contour(
+    ax=ax1,
+    levels=13,
+    vmin=-8,
+    vmax=40,
+    colors='black',
+    linewidths=0.5,
+    linestyles='solid',
+    add_labels=False,
+)
 
 # Label the contours
-manual = [(-70, 55000), (-80, 26000), (-72, 22500), (-62, 40000), (-58, 30000),
-          (-45, 69500), (-40, 34000), (-12, 39000), (-37, 75000), (40, 50000),
-          (-25, 42000), (18, 23000), (30, 40000), (45, 40000), (57, 41000),
-          (63, 39000), (55, 80000), (65, 85000)]
-clabels = ax1.clabel(contours,
-                     fontsize=12,
-                     colors="black",
-                     fmt="%.0f",
-                     manual=manual)
-# Set background color to white for contour labels
-[
-    txt.set_bbox(dict(facecolor='white', edgecolor='none', pad=2))
-    for txt in clabels
+manual = [
+    (-70, 55000),
+    (-80, 26000),
+    (-72, 22500),
+    (-62, 40000),
+    (-58, 30000),
+    (-45, 69500),
+    (-40, 34000),
+    (-12, 39000),
+    (-37, 75000),
+    (40, 50000),
+    (-25, 42000),
+    (18, 23000),
+    (30, 40000),
+    (45, 40000),
+    (57, 41000),
+    (63, 39000),
+    (55, 80000),
+    (65, 85000),
 ]
+clabels = ax1.clabel(contours, fontsize=12, colors="black", fmt="%.0f", manual=manual)
+# Set background color to white for contour labels
+[txt.set_bbox(dict(facecolor='white', edgecolor='none', pad=2)) for txt in clabels]
 
 # Use geocat-viz utility function to configure labels
 gv.set_titles_and_labels(ax1, lefttitle="Zonal Wind", lefttitlefontsize=16)
@@ -117,18 +124,17 @@ lat_formatter = LatitudeFormatter(degree_symbol='')
 ax1.xaxis.set_major_formatter(lat_formatter)
 
 # Use geocat-viz utility function to add minor ticks on x-axis
-gv.add_major_minor_ticks(ax1,
-                         x_minor_per_major=3,
-                         y_minor_per_major=0,
-                         labelsize=15)
+gv.add_major_minor_ticks(ax1, x_minor_per_major=3, y_minor_per_major=0, labelsize=15)
 
 # Add second axis to plot heights (heights chosen arbitrarily)
-gv.add_right_hand_axis(ax1,
-                       label="Height (km)",
-                       ylim=(0, 13),
-                       yticks=np.array([4, 8]),
-                       ticklabelsize=15,
-                       axislabelsize=21)
+gv.add_right_hand_axis(
+    ax1,
+    label="Height (km)",
+    ylim=(0, 13),
+    yticks=np.array([4, 8]),
+    ticklabelsize=15,
+    axislabelsize=21,
+)
 
 # Turn off tick marks on y-axis, set length and width parameters for x-axis
 ax1.tick_params(axis='y', which='minor', left=False, right=False)
@@ -136,12 +142,13 @@ ax1.tick_params(axis='x', which='minor', length=4, width=0.6, pad=9)
 ax1.tick_params(axis='x', which='major', length=9, width=1, pad=9)
 
 # Use geocat-viz utility function to configure ticks and labels
-gv.set_axes_limits_and_ticks(ax1,
-                             ylim=(100000, 20000),
-                             xticks=np.linspace(-60, 60, 5),
-                             yticks=np.flip(new_levels),
-                             xticklabels=None,
-                             yticklabels=np.flip(
-                                 (new_levels / 100).astype(int)))
+gv.set_axes_limits_and_ticks(
+    ax1,
+    ylim=(100000, 20000),
+    xticks=np.linspace(-60, 60, 5),
+    yticks=np.flip(new_levels),
+    xticklabels=None,
+    yticklabels=np.flip((new_levels / 100).astype(int)),
+)
 
 plt.show()

--- a/Gallery/Contours/NCL_conwomap_1.py
+++ b/Gallery/Contours/NCL_conwomap_1.py
@@ -31,46 +31,42 @@ u = ds.u.isel(time=4)
 ###############################################################################
 # Plot Without Enhancements:
 
-#create figure
+# create figure
 plt.figure(figsize=(10, 10))
 
-#create axes
+# create axes
 ax = plt.axes()
 ax.set_aspect(1.5)
 
-#contour plot data
-p = u.plot.contour(ax=ax,
-                   vmin=0,
-                   vmax=10,
-                   levels=11,
-                   add_labels=False,
-                   colors="black")
+# contour plot data
+p = u.plot.contour(ax=ax, vmin=0, vmax=10, levels=11, add_labels=False, colors="black")
 
-#label contours
+# label contours
 ax.clabel(p, np.arange(0, 9, 2), colors='black', fmt="%.0f")
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(0, 49),
-                             ylim=(0, 29),
-                             xticks=np.linspace(0, 40, 5),
-                             yticks=np.linspace(0, 25, 6))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(0, 49),
+    ylim=(0, 29),
+    xticks=np.linspace(0, 40, 5),
+    yticks=np.linspace(0, 25, 6),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=5,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=5, labelsize=16)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         lefttitle="Cone amplitude",
-                         lefttitlefontsize=18,
-                         righttitle="ndim",
-                         righttitlefontsize=18,
-                         xlabel="X",
-                         ylabel="Y",
-                         labelfontsize=18)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle="Cone amplitude",
+    lefttitlefontsize=18,
+    righttitle="ndim",
+    righttitlefontsize=18,
+    xlabel="X",
+    ylabel="Y",
+    labelfontsize=18,
+)
 
 plt.show()
 
@@ -80,49 +76,46 @@ plt.show()
 # Make this figure the thumbnail image on the HTML page.
 # sphinx_gallery_thumbnail_number = 2
 
-#create figure
+# create figure
 plt.figure(figsize=(10, 10))
 
-#create axes
+# create axes
 ax = plt.axes()
 ax.set_aspect(1.5)
 
-#import colormap
+# import colormap
 newcmp = cmaps.NCV_jet
 
-#contour plot data
-p = u.plot.contour(ax=ax,
-                   vmin=0,
-                   vmax=10,
-                   levels=11,
-                   cmap=newcmp,
-                   add_labels=False,
-                   linewidths=2.3)
+# contour plot data
+p = u.plot.contour(
+    ax=ax, vmin=0, vmax=10, levels=11, cmap=newcmp, add_labels=False, linewidths=2.3
+)
 
 # label contours
 ax.clabel(p, np.arange(0, 9, 2), colors='black', fmt="%.0f")
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(0, 49),
-                             ylim=(0, 29),
-                             xticks=np.linspace(0, 40, 5),
-                             yticks=np.linspace(0, 25, 6))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(0, 49),
+    ylim=(0, 29),
+    xticks=np.linspace(0, 40, 5),
+    yticks=np.linspace(0, 25, 6),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=5,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=5, labelsize=16)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         lefttitle="Cone amplitude",
-                         lefttitlefontsize=18,
-                         righttitle="ndim",
-                         righttitlefontsize=18,
-                         xlabel="X",
-                         ylabel="Y",
-                         labelfontsize=18)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle="Cone amplitude",
+    lefttitlefontsize=18,
+    righttitle="ndim",
+    righttitlefontsize=18,
+    xlabel="X",
+    ylabel="Y",
+    labelfontsize=18,
+)
 
 plt.show()

--- a/Gallery/Contours/NCL_conwomap_2.py
+++ b/Gallery/Contours/NCL_conwomap_2.py
@@ -43,26 +43,30 @@ ax = plt.axes(projection=projection)
 newcmp = cmaps.gui_default
 
 # Contourf-plot data (for filled contours)
-p = u.plot.contourf(ax=ax,
-                    vmin=-1,
-                    vmax=10,
-                    levels=12,
-                    cmap=newcmp,
-                    add_colorbar=False,
-                    transform=projection,
-                    extend='neither',
-                    add_labels=False)
+p = u.plot.contourf(
+    ax=ax,
+    vmin=-1,
+    vmax=10,
+    levels=12,
+    cmap=newcmp,
+    add_colorbar=False,
+    transform=projection,
+    extend='neither',
+    add_labels=False,
+)
 # Contour-plot data (for borderlines)
-u.plot.contour(ax=ax,
-               vmin=-1,
-               vmax=10,
-               levels=12,
-               linewidths=0.5,
-               colors='black',
-               add_colorbar=False,
-               transform=projection,
-               extend='neither',
-               add_labels=False)
+u.plot.contour(
+    ax=ax,
+    vmin=-1,
+    vmax=10,
+    levels=12,
+    linewidths=0.5,
+    colors='black',
+    add_colorbar=False,
+    transform=projection,
+    extend='neither',
+    add_labels=False,
+)
 
 # Add horizontal colorbar
 cbar = plt.colorbar(p, orientation='horizontal', shrink=0.5, drawedges=True)
@@ -70,27 +74,28 @@ cbar.ax.tick_params(labelsize=16)
 cbar.set_ticks(np.linspace(0, 9, 10))
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(0, 49),
-                             ylim=(0, 29),
-                             xticks=np.linspace(0, 40, 5),
-                             yticks=np.linspace(0, 25, 6))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(0, 49),
+    ylim=(0, 29),
+    xticks=np.linspace(0, 40, 5),
+    yticks=np.linspace(0, 25, 6),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=5,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=5, labelsize=16)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         lefttitle="Cone amplitude",
-                         lefttitlefontsize=18,
-                         righttitle="ndim",
-                         righttitlefontsize=18,
-                         xlabel="X",
-                         ylabel="Y",
-                         labelfontsize=18)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle="Cone amplitude",
+    lefttitlefontsize=18,
+    righttitle="ndim",
+    righttitlefontsize=18,
+    xlabel="X",
+    ylabel="Y",
+    labelfontsize=18,
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_conwomap_3.py
+++ b/Gallery/Contours/NCL_conwomap_3.py
@@ -41,19 +41,18 @@ plt.figure(figsize=(10, 10))
 ax = plt.axes()
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(0, 30),
-                             ylim=(0, 30),
-                             xticks=None,
-                             yticks=None,
-                             xticklabels=None,
-                             yticklabels=None)
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(0, 30),
+    ylim=(0, 30),
+    xticks=None,
+    yticks=None,
+    xticklabels=None,
+    yticklabels=None,
+)
 
 # Use geocat.viz.util to add major and minor tics
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=5,
-                         labelsize=18)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=5, labelsize=18)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
 gv.set_titles_and_labels(ax, ylabel="wave number", labelfontsize=24)
@@ -81,35 +80,34 @@ ax.clabel(cp, inline=True, fontsize=10, colors='black', fmt="%.0f")
 # Ignore second half of the graph
 y1 = np.full(shape=len(xlist), fill_value=0, dtype=np.int32)
 y2 = x
-ax.fill_between(x,
-                y1,
-                y2,
-                where=y2 >= y1,
-                color='white',
-                step='pre',
-                alpha=1.0,
-                zorder=4)
+ax.fill_between(
+    x, y1, y2, where=y2 >= y1, color='white', step='pre', alpha=1.0, zorder=4
+)
 
 # Set properties for the text boxes
 props1 = dict(facecolor='white', edgecolor='white', alpha=0.5)
 props2 = dict(facecolor='white', edgecolor='black', alpha=0.5)
 
 # Place first text box
-ax.text(0.70,
-        0.35,
-        'J(${\u03B1}$)',
-        transform=ax.transAxes,
-        fontsize=25,
-        bbox=props1,
-        zorder=5)
+ax.text(
+    0.70,
+    0.35,
+    'J(${\u03b1}$)',
+    transform=ax.transAxes,
+    fontsize=25,
+    bbox=props1,
+    zorder=5,
+)
 
 # Place second text box
-ax.text(0.70,
-        0.05,
-        'CONTOUR FROM -8 TO 6 BY 1',
-        transform=ax.transAxes,
-        fontsize=10,
-        bbox=props2,
-        zorder=5)
+ax.text(
+    0.70,
+    0.05,
+    'CONTOUR FROM -8 TO 6 BY 1',
+    transform=ax.transAxes,
+    fontsize=10,
+    bbox=props2,
+    zorder=5,
+)
 
 plt.show()

--- a/Gallery/Contours/NCL_conwomap_5.py
+++ b/Gallery/Contours/NCL_conwomap_5.py
@@ -40,18 +40,13 @@ ps = ds.PS  # surface pressures in Pascals
 p0 = 100000  # surface reference pressure in Pascals
 
 # Specify output pressure levels
-new_levels = np.array([1000, 950, 800, 700, 600, 500, 400, 300,
-                       200])  # in millibars
+new_levels = np.array([1000, 950, 800, 700, 600, 500, 400, 300, 200])  # in millibars
 new_levels = new_levels * 100  # convert to Pascals
 
 # Interpolate pressure coordinates form hybrid sigma coord
-u_int = interp_hybrid_to_pressure(u,
-                                  ps[0, :, :],
-                                  hyam,
-                                  hybm,
-                                  p0=p0,
-                                  new_levels=new_levels,
-                                  method='log')
+u_int = interp_hybrid_to_pressure(
+    u, ps[0, :, :], hyam, hybm, p0=p0, new_levels=new_levels, method='log'
+)
 
 # Calculate zonal mean of u component of wind
 uzon = u_int.mean(dim='lon')
@@ -68,61 +63,68 @@ plt.yscale('log')
 ax.yaxis.set_major_formatter(ScalarFormatter())
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(20000, 100000),
-                             yticks=[100000, 70000, 50000, 30000],
-                             yticklabels=['1000', '700', '500', '300'],
-                             xticks=np.arange(-60, 90, 30),
-                             xticklabels=['60S', '30S', '0', '30N', '60N'])
+gv.set_axes_limits_and_ticks(
+    ax,
+    ylim=(20000, 100000),
+    yticks=[100000, 70000, 50000, 30000],
+    yticklabels=['1000', '700', '500', '300'],
+    xticks=np.arange(-60, 90, 30),
+    xticklabels=['60S', '30S', '0', '30N', '60N'],
+)
 
 # Us geocat.viz.util convenience function to add minor and major ticks
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=0,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=0, labelsize=16)
 
 # Specify colormap
 newcmap = cmaps.ncl_default
 
 # Plot filed contours
-p = uzon.plot.contourf(ax=ax,
-                       levels=13,
-                       vmin=-8,
-                       vmax=40,
-                       cmap=newcmap,
-                       add_colorbar=False,
-                       add_labels=False)
+p = uzon.plot.contourf(
+    ax=ax,
+    levels=13,
+    vmin=-8,
+    vmax=40,
+    cmap=newcmap,
+    add_colorbar=False,
+    add_labels=False,
+)
 
 # Plot contour lines
-uzon.plot.contour(ax=ax,
-                  levels=13,
-                  vmin=-8,
-                  vmax=40,
-                  colors='black',
-                  linewidths=0.5,
-                  linestyles='solid',
-                  add_labels=False)
+uzon.plot.contour(
+    ax=ax,
+    levels=13,
+    vmin=-8,
+    vmax=40,
+    colors='black',
+    linewidths=0.5,
+    linestyles='solid',
+    add_labels=False,
+)
 
 # Create colorbar
-cbar = plt.colorbar(p,
-                    ax=ax,
-                    drawedges=True,
-                    extendrect=True,
-                    extendfrac='auto',
-                    ticks=np.arange(-8, 44, 4),
-                    orientation='horizontal',
-                    pad=0.075,
-                    aspect=11)
+cbar = plt.colorbar(
+    p,
+    ax=ax,
+    drawedges=True,
+    extendrect=True,
+    extendfrac='auto',
+    ticks=np.arange(-8, 44, 4),
+    orientation='horizontal',
+    pad=0.075,
+    aspect=11,
+)
 
 # Set colorbar tick label size
 cbar.ax.tick_params(labelsize=14)
 
 # Use geocat.vix convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Logarithmic axis",
-                         maintitlefontsize=18,
-                         lefttitle="Zonal Wind",
-                         lefttitlefontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Logarithmic axis",
+    maintitlefontsize=18,
+    lefttitle="Zonal Wind",
+    lefttitlefontsize=16,
+)
 
 # Show plot
 plt.show()

--- a/Gallery/Contours/NCL_eof_1_1.py
+++ b/Gallery/Contours/NCL_eof_1_1.py
@@ -43,10 +43,10 @@ from geocat.comp import eofunc_eofs, eofunc_pcs, month_to_season
 # User defined parameters and a convenience function:
 
 # In order to specify region of the globe, time span, etc.
-latS = 25.
-latN = 80.
-lonL = -70.
-lonR = 40.
+latS = 25.0
+latN = 80.0
+lonL = -70.0
+lonR = 40.0
 
 yearStart = 1979
 yearEnd = 2003
@@ -161,20 +161,19 @@ def make_contour_plot(ax, dataset):
     v = np.linspace(-0.08, 0.08, 9, endpoint=True)
 
     # The function contourf() produces fill colors, and contour() calculates contour label locations.
-    cplot = ax.contourf(lon,
-                        lat,
-                        values,
-                        levels=v,
-                        cmap=cmap,
-                        extend="both",
-                        transform=ccrs.PlateCarree())
+    cplot = ax.contourf(
+        lon,
+        lat,
+        values,
+        levels=v,
+        cmap=cmap,
+        extend="both",
+        transform=ccrs.PlateCarree(),
+    )
 
-    p = ax.contour(lon,
-                   lat,
-                   values,
-                   levels=v,
-                   linewidths=0.0,
-                   transform=ccrs.PlateCarree())
+    p = ax.contour(
+        lon, lat, values, levels=v, linewidths=0.0, transform=ccrs.PlateCarree()
+    )
 
     # Label the contours
     ax.clabel(p, fontsize=8, fmt="%0.2f", colors="black")
@@ -183,15 +182,10 @@ def make_contour_plot(ax, dataset):
     ax.coastlines(linewidth=0.5)
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
-    gv.add_major_minor_ticks(ax,
-                             x_minor_per_major=3,
-                             y_minor_per_major=4,
-                             labelsize=10)
+    gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=4, labelsize=10)
 
     # Use geocat.viz.util convenience function to set axes tick values
-    gv.set_axes_limits_and_ticks(ax,
-                                 xticks=[-60, -30, 0, 30],
-                                 yticks=[40, 60, 80])
+    gv.set_axes_limits_and_ticks(ax, xticks=[-60, -30, 0, 30], yticks=[40, 60, 80])
 
     # Use geocat.viz.util convenience function to make plots look like NCL plots, using latitude & longitude tick labels
     gv.add_lat_lon_ticklabels(ax)
@@ -203,10 +197,9 @@ def make_contour_plot(ax, dataset):
 # Plot (1): Draw a contour plot for each EOF
 
 # Generate figure and axes using Cartopy projection  and set figure size (width, height) in inches
-fig, axs = plt.subplots(neof,
-                        1,
-                        subplot_kw={"projection": ccrs.PlateCarree()},
-                        figsize=(6, 10.6))
+fig, axs = plt.subplots(
+    neof, 1, subplot_kw={"projection": ccrs.PlateCarree()}, figsize=(6, 10.6)
+)
 
 # Add multiple axes to the figure as contour and contourf plots
 for i in range(neof):
@@ -217,24 +210,28 @@ for i in range(neof):
 
     # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
     pct = eofs.attrs['varianceFraction'].values[i] * 100
-    gv.set_titles_and_labels(axs[i],
-                             lefttitle=f'EOF {i + 1}',
-                             lefttitlefontsize=10,
-                             righttitle=f'{pct:.1f}%',
-                             righttitlefontsize=10)
+    gv.set_titles_and_labels(
+        axs[i],
+        lefttitle=f'EOF {i + 1}',
+        lefttitlefontsize=10,
+        righttitle=f'{pct:.1f}%',
+        righttitlefontsize=10,
+    )
 
 # Adjust subplot spacings and locations
 plt.subplots_adjust(bottom=0.07, top=0.95, hspace=0.15)
 
 # Add horizontal colorbar
-cbar = plt.colorbar(cplot,
-                    ax=axs,
-                    orientation='horizontal',
-                    shrink=0.9,
-                    pad=0.05,
-                    fraction=.02,
-                    extendrect=True,
-                    extendfrac='auto')
+cbar = plt.colorbar(
+    cplot,
+    ax=axs,
+    orientation='horizontal',
+    shrink=0.9,
+    pad=0.05,
+    fraction=0.02,
+    extendrect=True,
+    extendfrac='auto',
+)
 cbar.ax.tick_params(labelsize=8)
 
 # Set a common title
@@ -254,24 +251,16 @@ def make_bar_plot(ax, dataset):
     values = list(dataset.values)
     colors = ['blue' if val < 0 else 'red' for val in values]
 
-    ax.bar(years,
-           values,
-           color=colors,
-           width=1.0,
-           edgecolor='black',
-           linewidth=0.5)
+    ax.bar(years, values, color=colors, width=1.0, edgecolor='black', linewidth=0.5)
     ax.set_ylabel('Pa')
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
-    gv.add_major_minor_ticks(ax,
-                             x_minor_per_major=4,
-                             y_minor_per_major=5,
-                             labelsize=8)
+    gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=8)
 
     # Use geocat.viz.util convenience function to set axes tick values
-    gv.set_axes_limits_and_ticks(ax,
-                                 xticks=np.linspace(1980, 2000, 6),
-                                 xlim=[1978.5, 2003.5])
+    gv.set_axes_limits_and_ticks(
+        ax, xticks=np.linspace(1980, 2000, 6), xlim=[1978.5, 2003.5]
+    )
 
     return ax
 
@@ -288,11 +277,13 @@ for i in range(neof):
 
     axs[i] = make_bar_plot(axs[i], eof_single)
     pct = eofs.attrs['varianceFraction'].values[i] * 100
-    gv.set_titles_and_labels(axs[i],
-                             lefttitle=f'EOF {i + 1}',
-                             lefttitlefontsize=10,
-                             righttitle=f'{pct:.1f}%',
-                             righttitlefontsize=10)
+    gv.set_titles_and_labels(
+        axs[i],
+        lefttitle=f'EOF {i + 1}',
+        lefttitlefontsize=10,
+        righttitle=f'{pct:.1f}%',
+        righttitlefontsize=10,
+    )
 
 # Set a common title
 axs[0].set_title(f'SLP: DJF: {yearStart}-{yearEnd}', fontsize=14, y=1.12)

--- a/Gallery/Contours/NCL_h_lat_6.py
+++ b/Gallery/Contours/NCL_h_lat_6.py
@@ -20,10 +20,7 @@ import xarray as xr
 import matplotlib.pyplot as plt
 from matplotlib.ticker import ScalarFormatter
 import cmaps
-import metpy.calc as mpcalc
-from metpy.units import units
 
-import scipy
 
 import geocat.datafiles as gdf
 import geocat.viz as gv
@@ -50,12 +47,14 @@ plt.yscale('log')
 levels = np.linspace(-55, 55, 23)
 
 # Plot contour lines
-lines = U.plot.contour(ax=ax,
-                       levels=levels,
-                       colors='black',
-                       linewidths=0.5,
-                       linestyles='solid',
-                       add_labels=False)
+lines = U.plot.contour(
+    ax=ax,
+    levels=levels,
+    colors='black',
+    linewidths=0.5,
+    linestyles='solid',
+    add_labels=False,
+)
 
 # Draw contour labels and set their backgrounds to be white
 ax.clabel(lines, fmt='%d', levels=levels)
@@ -65,47 +64,48 @@ ax.clabel(lines, fmt='%d', levels=levels)
 ]
 
 # Plot filled contours
-colors = U.plot.contourf(ax=ax,
-                         levels=levels,
-                         cmap=cmaps.BlWhRe,
-                         add_labels=False,
-                         add_colorbar=False)
+colors = U.plot.contourf(
+    ax=ax, levels=levels, cmap=cmaps.BlWhRe, add_labels=False, add_colorbar=False
+)
 # Add colorbar
-plt.colorbar(colors,
-             ax=ax,
-             orientation='horizontal',
-             ticks=levels[1::2],
-             drawedges=True,
-             aspect=12,
-             shrink=0.7,
-             pad=0.1)
+plt.colorbar(
+    colors,
+    ax=ax,
+    orientation='horizontal',
+    ticks=levels[1::2],
+    drawedges=True,
+    aspect=12,
+    shrink=0.7,
+    pad=0.1,
+)
 
 # Use geocat.viz.util convenience function to set axes tick values
 # Set y-lim inorder for y-axis to have descending values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-60, 60, 5),
-                             xticklabels=['60S', '30S', '0', '30N', '60N'],
-                             ylim=ax.get_ylim()[::-1],
-                             yticks=U["lev"])
+gv.set_axes_limits_and_ticks(
+    ax,
+    xticks=np.linspace(-60, 60, 5),
+    xticklabels=['60S', '30S', '0', '30N', '60N'],
+    ylim=ax.get_ylim()[::-1],
+    yticks=U["lev"],
+)
 
 # Change formatter or else tick values will be in exponential form
 ax.yaxis.set_major_formatter(ScalarFormatter())
 
 # Use geocat.viz.util convenience function to add major tick lines with no
 # minor ticks on lefthand side y axis and some minor ticks on the x axis
-gv.add_major_minor_ticks(ax=ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=1,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax=ax, x_minor_per_major=3, y_minor_per_major=1, labelsize=12)
 
 # Use geocat.viz.util convenience function to add titles and the pressure label
-gv.set_titles_and_labels(ax,
-                         lefttitle=U.long_name,
-                         lefttitlefontsize=14,
-                         righttitle=U.units,
-                         righttitlefontsize=14,
-                         ylabel=U.lev.long_name + " (" + U.lev.units + ")",
-                         labelfontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle=U.long_name,
+    lefttitlefontsize=14,
+    righttitle=U.units,
+    righttitlefontsize=14,
+    ylabel=U.lev.long_name + " (" + U.lev.units + ")",
+    labelfontsize=16,
+)
 
 # Create second y-axis to show geo-potential height.
 axRHS = gv.add_height_from_pressure_axis(ax, heights=[4, 8])

--- a/Gallery/Contours/NCL_h_lat_7.py
+++ b/Gallery/Contours/NCL_h_lat_7.py
@@ -19,8 +19,6 @@ See following URLs to see the reproduced NCL plot & script:
 import xarray as xr
 from matplotlib import pyplot as plt
 import numpy as np
-import metpy.calc as mpcalc
-from metpy.units import units
 
 import geocat.datafiles as gdf
 import geocat.viz as gv
@@ -59,31 +57,19 @@ ps = ps / 100  # Convert from pascal to millibar
 lev_p = np.array([300, 400, 500, 600, 700, 800, 900, 1000])
 
 # interp_hybrid_to_pressure is the Python version of vinth2p in NCL script
-hp = interp_hybrid_to_pressure(data=h,
-                               ps=ps,
-                               hyam=hyam,
-                               hybm=hybm,
-                               p0=P0mb,
-                               new_levels=lev_p,
-                               method='log')
+hp = interp_hybrid_to_pressure(
+    data=h, ps=ps, hyam=hyam, hybm=hybm, p0=P0mb, new_levels=lev_p, method='log'
+)
 # Assign attribute values
 hp.attrs['units'] = "kJ/kg"
 hp.attrs['long_name'] = "Moist Static Energy"
 
-op = interp_hybrid_to_pressure(data=omega,
-                               ps=ps,
-                               hyam=hyam,
-                               hybm=hybm,
-                               p0=P0mb,
-                               new_levels=lev_p,
-                               method='log')
-vp = interp_hybrid_to_pressure(data=V,
-                               ps=ps,
-                               hyam=hyam,
-                               hybm=hybm,
-                               p0=P0mb,
-                               new_levels=lev_p,
-                               method='log')
+op = interp_hybrid_to_pressure(
+    data=omega, ps=ps, hyam=hyam, hybm=hybm, p0=P0mb, new_levels=lev_p, method='log'
+)
+vp = interp_hybrid_to_pressure(
+    data=V, ps=ps, hyam=hyam, hybm=hybm, p0=P0mb, new_levels=lev_p, method='log'
+)
 
 # Extract slices of the data
 hp = hp.isel(time=0).sel(lat=slice(-30, 30)).sel(lon=210, method='nearest')
@@ -108,19 +94,19 @@ levels = np.arange(300, 335, 2)
 levels = np.append(levels, 335)
 
 # Plot contour lines
-hp.plot.contour(ax=ax,
-                colors='black',
-                levels=levels,
-                linewidths=0.5,
-                linestyles='solid',
-                add_labels=False)
+hp.plot.contour(
+    ax=ax,
+    colors='black',
+    levels=levels,
+    linewidths=0.5,
+    linestyles='solid',
+    add_labels=False,
+)
 
 # Plot filled contours
-colors = hp.plot.contourf(ax=ax,
-                          levels=levels,
-                          cmap='viridis',
-                          add_labels=False,
-                          add_colorbar=False)
+colors = hp.plot.contourf(
+    ax=ax, levels=levels, cmap='viridis', add_labels=False, add_colorbar=False
+)
 
 # Draw vector plot
 # (there is no matplotlib equivalent to "CurlyVector" yet)
@@ -133,18 +119,20 @@ Q = ax.quiver(
     pivot="middle",
     width=0.001,
     headwidth=15,
-    zorder=1)
+    zorder=1,
+)
 
 # Draw legend for vector plot
 ax.add_patch(
     plt.Rectangle(
-        (17.3,
-         944),  # location of the SW corner of box in the same units as the data
+        (17.3, 944),  # location of the SW corner of box in the same units as the data
         12,  # the width of the box in the same units as the x axis
         55,  # the height of the box in the same units as the y axis
         facecolor='white',
         edgecolor='black',
-        clip_on=False))
+        clip_on=False,
+    )
+)
 # Call quiver key twice to draw the text above and below the key arrow
 qk = ax.quiverkey(
     Q,
@@ -155,7 +143,8 @@ qk = ax.quiverkey(
     labelpos='S',
     coordinates='figure',
     color='black',
-    fontproperties={'size': 13})
+    fontproperties={'size': 13},
+)
 qk = ax.quiverkey(
     Q,
     0.828,  # x coordinate of the center of the arrow as a percent of the plot width
@@ -165,31 +154,33 @@ qk = ax.quiverkey(
     labelpos='N',
     coordinates='figure',
     color='black',
-    fontproperties={'size': 13})
+    fontproperties={'size': 13},
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=1,
-                         labelsize=18)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=1, labelsize=18)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=ax.get_ylim()[::-1],
-                             xticks=np.array([-20, 0, 20]),
-                             yticks=np.array([300, 400, 500, 700, 850, 1000]),
-                             xticklabels=['20S', '0', '20N'])
+gv.set_axes_limits_and_ticks(
+    ax,
+    ylim=ax.get_ylim()[::-1],
+    xticks=np.array([-20, 0, 20]),
+    yticks=np.array([300, 400, 500, 700, 850, 1000]),
+    xticklabels=['20S', '0', '20N'],
+)
 
 # Use geocat.viz.util convenience function to add titles and the pressure label
-gv.set_titles_and_labels(ax,
-                         maintitle="Pressure/Height Vector Example",
-                         maintitlefontsize=24,
-                         lefttitle=hp.long_name,
-                         lefttitlefontsize=22,
-                         righttitle=hp.units,
-                         righttitlefontsize=22,
-                         ylabel='Pressure (mb)',
-                         labelfontsize=24)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Pressure/Height Vector Example",
+    maintitlefontsize=24,
+    lefttitle=hp.long_name,
+    lefttitlefontsize=22,
+    righttitle=hp.units,
+    righttitlefontsize=22,
+    ylabel='Pressure (mb)',
+    labelfontsize=24,
+)
 
 # Create second y-axis to show geo-potential height.
 axRHS = gv.add_height_from_pressure_axis(ax, heights=np.arange(4, 28, 4))
@@ -205,14 +196,16 @@ ax.tick_params(axis='y', which='minor', left=False, right=False)
 plt.tight_layout()
 
 cax = plt.axes((0.15, 0.03, 0.75, 0.06))
-cab = fig.colorbar(colors,
-                   ax=ax,
-                   cax=cax,
-                   orientation='horizontal',
-                   ticks=levels[::2],
-                   extendrect=True,
-                   drawedges=True,
-                   spacing='uniform')
+cab = fig.colorbar(
+    colors,
+    ax=ax,
+    cax=cax,
+    orientation='horizontal',
+    ticks=levels[::2],
+    extendrect=True,
+    drawedges=True,
+    spacing='uniform',
+)
 
 # Set colorbar ticklabel font size
 cab.ax.xaxis.set_tick_params(length=0, labelsize=18)

--- a/Gallery/Contours/NCL_h_long_5.py
+++ b/Gallery/Contours/NCL_h_long_5.py
@@ -19,8 +19,6 @@ import xarray as xr
 import matplotlib.pyplot as plt
 from matplotlib.ticker import ScalarFormatter
 import cmaps
-import metpy.calc as mpcalc
-from metpy.units import units
 
 import geocat.datafiles as gdf
 import geocat.viz as gv
@@ -49,12 +47,14 @@ plt.yscale('log')
 levels = np.linspace(-55, 55, 23)
 
 # Plot contour lines
-lines = U.plot.contour(ax=ax,
-                       levels=levels,
-                       colors='black',
-                       linewidths=0.5,
-                       linestyles='solid',
-                       add_labels=False)
+lines = U.plot.contour(
+    ax=ax,
+    levels=levels,
+    colors='black',
+    linewidths=0.5,
+    linestyles='solid',
+    add_labels=False,
+)
 
 # Label contour levels at -10, 0, and 10 and set their backgrounds to be white
 ax.clabel(lines, fmt='%d', levels=[-10, 0, 10])
@@ -64,20 +64,20 @@ ax.clabel(lines, fmt='%d', levels=[-10, 0, 10])
 ]
 
 # Plot filled contours
-colors = U.plot.contourf(ax=ax,
-                         levels=levels,
-                         cmap=cmaps.BlWhRe,
-                         add_labels=False,
-                         add_colorbar=False)
+colors = U.plot.contourf(
+    ax=ax, levels=levels, cmap=cmaps.BlWhRe, add_labels=False, add_colorbar=False
+)
 # Add colorbar
-plt.colorbar(colors,
-             ax=ax,
-             orientation='horizontal',
-             ticks=levels[1::2],
-             drawedges=True,
-             aspect=12,
-             shrink=0.65,
-             pad=0.1)
+plt.colorbar(
+    colors,
+    ax=ax,
+    orientation='horizontal',
+    ticks=levels[1::2],
+    drawedges=True,
+    aspect=12,
+    shrink=0.65,
+    pad=0.1,
+)
 
 # Use geocat.viz.util convenience function to set axes tick values
 # Set y-lim inorder for y-axis to have descending values
@@ -86,28 +86,28 @@ gv.set_axes_limits_and_ticks(
     xticks=np.linspace(-180, 178, 7),
     xticklabels=['180', '120W', '60W', '0', '60E', "120E", ""],
     ylim=ax.get_ylim()[::-1],
-    yticks=U["lev"])
+    yticks=U["lev"],
+)
 
 # Change formatter or else tick values will be in exponential form
 ax.yaxis.set_major_formatter(ScalarFormatter())
 
 # Use geocat.viz.util convenience function to add major tick lines with no
 # minor ticks on left hand side y axis and some minor ticks on the x axis
-gv.add_major_minor_ticks(ax=ax,
-                         x_minor_per_major=2,
-                         y_minor_per_major=1,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax=ax, x_minor_per_major=2, y_minor_per_major=1, labelsize=12)
 
 # Use geocat.viz.util convenience function to add titles and the pressure label
-gv.set_titles_and_labels(ax,
-                         maintitle="January 1988",
-                         maintitlefontsize=18,
-                         lefttitle=U.long_name,
-                         lefttitlefontsize=14,
-                         righttitle=U.units,
-                         righttitlefontsize=14,
-                         ylabel=U.lev.long_name,
-                         labelfontsize=18)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="January 1988",
+    maintitlefontsize=18,
+    lefttitle=U.long_name,
+    lefttitlefontsize=14,
+    righttitle=U.units,
+    righttitlefontsize=14,
+    ylabel=U.lev.long_name,
+    labelfontsize=18,
+)
 
 # Create second y-axis to show geo-potential height.
 axRHS = gv.add_height_from_pressure_axis(ax, heights=np.arange(4, 28, 4))

--- a/Gallery/Contours/NCL_hov_3.py
+++ b/Gallery/Contours/NCL_hov_3.py
@@ -41,72 +41,65 @@ chi = chi / scale
 fig, ax = plt.subplots(figsize=(7, 7.5))
 
 # Fill area between level 4 contours and level 10 contours with dot hatching
-cf = ax.contourf(lon,
-                 times,
-                 chi,
-                 levels=[4, 12],
-                 colors='None',
-                 hatches=['....'])
+cf = ax.contourf(lon, times, chi, levels=[4, 12], colors='None', hatches=['....'])
 
 # Make all dot-filled areas light gray so contour lines are still visible
 cf.set_edgecolor('lightgray')
-cf.set_linewidth(0.)
+cf.set_linewidth(0.0)
 
 # Fill area at the lowest contour level, -6, with line hatching
-cf = ax.contourf(lon,
-                 times,
-                 chi,
-                 levels=[-7, -6],
-                 colors='None',
-                 hatches=['///'])
+cf = ax.contourf(lon, times, chi, levels=[-7, -6], colors='None', hatches=['///'])
 
 # Draw contour lines at levels [-6, -4, -2, 0, 2, 4, 6, 8, 10]
-cs = ax.contour(lon,
-                times,
-                chi,
-                levels=np.arange(-6, 12, 2),
-                colors='black',
-                linestyles="-",
-                linewidths=[.2, .2, .2, 1, .2, .2, .2, .2, .2])
+cs = ax.contour(
+    lon,
+    times,
+    chi,
+    levels=np.arange(-6, 12, 2),
+    colors='black',
+    linestyles="-",
+    linewidths=[0.2, 0.2, 0.2, 1, 0.2, 0.2, 0.2, 0.2, 0.2],
+)
 
 # Label the contour levels -4, 0, and 4
 cl = ax.clabel(cs, fmt='%d', levels=[-4, 0, 4])
 
 # Use geocat.viz.util convenience function to set axes limits & tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=[100, 220],
-                             ylim=[0, 1.55 * 1e16],
-                             xticks=[135, 180],
-                             yticks=np.linspace(0, 1.55 * 1e16, 7),
-                             xticklabels=['135E', '180'],
-                             yticklabels=np.linspace(0, 180, 7, dtype='int'))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=[100, 220],
+    ylim=[0, 1.55 * 1e16],
+    xticks=[135, 180],
+    yticks=np.linspace(0, 1.55 * 1e16, 7),
+    xticklabels=['135E', '180'],
+    yticklabels=np.linspace(0, 180, 7, dtype='int'),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=3,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=3, labelsize=16)
 
 # Use geocat.viz.util convenience function to add titles
-gv.set_titles_and_labels(ax,
-                         maintitle="Pacific Region",
-                         maintitlefontsize=20,
-                         lefttitle="Velocity Potential",
-                         lefttitlefontsize=18,
-                         righttitle="m2/s",
-                         righttitlefontsize=18,
-                         ylabel="elapsed time",
-                         labelfontsize=18)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Pacific Region",
+    maintitlefontsize=20,
+    lefttitle="Velocity Potential",
+    lefttitlefontsize=18,
+    righttitle="m2/s",
+    righttitlefontsize=18,
+    ylabel="elapsed time",
+    labelfontsize=18,
+)
 
 # Add lower text box
-ax.text(1,
-        -0.12,
-        "CONTOUR FROM -6 TO 10 BY 2",
-        horizontalalignment='right',
-        transform=ax.transAxes,
-        bbox=dict(boxstyle='square, pad=0.25',
-                  facecolor='white',
-                  edgecolor='black'))
+ax.text(
+    1,
+    -0.12,
+    "CONTOUR FROM -6 TO 10 BY 2",
+    horizontalalignment='right',
+    transform=ax.transAxes,
+    bbox=dict(boxstyle='square, pad=0.25', facecolor='white', edgecolor='black'),
+)
 
 plt.tight_layout()
 plt.show()

--- a/Gallery/Contours/NCL_lb_1.py
+++ b/Gallery/Contours/NCL_lb_1.py
@@ -48,31 +48,33 @@ ax.coastlines(linewidths=0.5)
 newcmp = cmaps.wgne15
 
 # Contourf-plot data (for filled contours)
-a = wrap_v.plot.contourf(levels=np.arange(-24, 32, 4),
-                         cmap=newcmp,
-                         add_colorbar=False,
-                         add_labels=False)
+a = wrap_v.plot.contourf(
+    levels=np.arange(-24, 32, 4), cmap=newcmp, add_colorbar=False, add_labels=False
+)
 # Contour-plot data (for borderlines)
-wrap_v.plot.contour(levels=np.arange(-24, 32, 4),
-                    linewidths=0.5,
-                    cmap='black',
-                    add_labels=False)
+wrap_v.plot.contour(
+    levels=np.arange(-24, 32, 4), linewidths=0.5, cmap='black', add_labels=False
+)
 
 # Add vertical colorbar
-cbar = fig.colorbar(a,
-                    label='',
-                    ticks=np.arange(-20, 28, 4),
-                    shrink=0.8,
-                    orientation="horizontal",
-                    extendrect=True,
-                    pad=0.11,
-                    drawedges=True)
+cbar = fig.colorbar(
+    a,
+    label='',
+    ticks=np.arange(-20, 28, 4),
+    shrink=0.8,
+    orientation="horizontal",
+    extendrect=True,
+    pad=0.11,
+    drawedges=True,
+)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(-90, 90),
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax,
+    ylim=(-90, 90),
+    xticks=np.linspace(-180, 180, 13),
+    yticks=np.linspace(-90, 90, 7),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, labelsize=10)
@@ -81,13 +83,15 @@ gv.add_major_minor_ticks(ax, labelsize=10)
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         lefttitle="meridional wind component",
-                         lefttitlefontsize=14,
-                         righttitle="m/s",
-                         righttitlefontsize=14,
-                         xlabel="",
-                         ylabel="")
+gv.set_titles_and_labels(
+    ax,
+    lefttitle="meridional wind component",
+    lefttitlefontsize=14,
+    righttitle="m/s",
+    righttitlefontsize=14,
+    xlabel="",
+    ylabel="",
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_lb_2.py
+++ b/Gallery/Contours/NCL_lb_2.py
@@ -48,33 +48,35 @@ ax.coastlines(linewidths=0.5)
 newcmp = cmaps.wgne15
 
 # Contourf-plot data (for filled contours)
-a = wrap_v.plot.contourf(levels=np.arange(-24, 25, 4),
-                         cmap=newcmp,
-                         add_colorbar=False,
-                         add_labels=False)
+a = wrap_v.plot.contourf(
+    levels=np.arange(-24, 25, 4), cmap=newcmp, add_colorbar=False, add_labels=False
+)
 # Contour-plot data (for borderlines)
-wrap_v.plot.contour(levels=np.arange(-24, 25, 4),
-                    linewidths=0.5,
-                    cmap='black',
-                    add_labels=False)
+wrap_v.plot.contour(
+    levels=np.arange(-24, 25, 4), linewidths=0.5, cmap='black', add_labels=False
+)
 
 # Add vertical colorbar
-cbar = plt.colorbar(a,
-                    ticks=np.arange(-20, 25, 4),
-                    shrink=0.8,
-                    aspect=10,
-                    extendrect=True,
-                    extendfrac='auto')
+cbar = plt.colorbar(
+    a,
+    ticks=np.arange(-20, 25, 4),
+    shrink=0.8,
+    aspect=10,
+    extendrect=True,
+    extendfrac='auto',
+)
 
 # Change the colorbar tick labels
 clabels = np.arange(-70, 151, 20)
 cbar.ax.set_yticklabels(clabels)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(-90, 90),
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax,
+    ylim=(-90, 90),
+    xticks=np.linspace(-180, 180, 13),
+    yticks=np.linspace(-90, 90, 7),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, labelsize=10)
@@ -83,13 +85,15 @@ gv.add_major_minor_ticks(ax, labelsize=10)
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         lefttitle="meridional wind component",
-                         lefttitlefontsize=14,
-                         righttitle="m/s",
-                         righttitlefontsize=14,
-                         xlabel="",
-                         ylabel="")
+gv.set_titles_and_labels(
+    ax,
+    lefttitle="meridional wind component",
+    lefttitlefontsize=14,
+    righttitle="m/s",
+    righttitlefontsize=14,
+    xlabel="",
+    ylabel="",
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_lb_3.py
+++ b/Gallery/Contours/NCL_lb_3.py
@@ -50,11 +50,13 @@ ax = plt.axes(projection=ccrs.PlateCarree())
 ax.coastlines(linewidths=0.5, alpha=0.6)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(-180, 180),
-                             ylim=(-90, 90),
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(-180, 180),
+    ylim=(-90, 90),
+    xticks=np.linspace(-180, 180, 13),
+    yticks=np.linspace(-90, 90, 7),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, labelsize=10)
@@ -66,11 +68,13 @@ ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use geocat.viz.util convenience function to add titles
-gv.set_titles_and_labels(ax,
-                         lefttitle=V.long_name,
-                         righttitle=V.units,
-                         lefttitlefontsize=12,
-                         righttitlefontsize=12)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle=V.long_name,
+    righttitle=V.units,
+    lefttitlefontsize=12,
+    righttitlefontsize=12,
+)
 
 # Import an NCL colormap
 cmap = cmaps.wgne15
@@ -78,21 +82,25 @@ cmap = cmaps.wgne15
 # Specify which contour levels to draw
 contour_lev = np.arange(-20, 28, 4)
 # Plot filled contour
-contour = V.plot.contourf(ax=ax,
-                          transform=ccrs.PlateCarree(),
-                          cmap=cmap,
-                          levels=contour_lev,
-                          add_colorbar=False,
-                          add_labels=False)
+contour = V.plot.contourf(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    cmap=cmap,
+    levels=contour_lev,
+    add_colorbar=False,
+    add_labels=False,
+)
 # Plot line contour
-V.plot.contour(ax=ax,
-               transform=ccrs.PlateCarree(),
-               colors='black',
-               linewidths=0.5,
-               linestyles='solid',
-               levels=contour_lev,
-               add_colorbar=False,
-               add_labels=False)
+V.plot.contour(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    colors='black',
+    linewidths=0.5,
+    linestyles='solid',
+    levels=contour_lev,
+    add_colorbar=False,
+    add_labels=False,
+)
 
 # Create horizontal colorbar
 # By changing the kwarg `pad`, the colorbar can be moved closer to or farther away from
@@ -100,13 +108,15 @@ V.plot.contour(ax=ax,
 # `pad` defaults to 0.15 for horizontal colorbars
 # `extendrect` and `extendfrac` format the ends of the colorbar, default is
 # pointed ends to show there are values beyond the given contour levels
-cbar = plt.colorbar(contour,
-                    ax=ax,
-                    orientation='horizontal',
-                    shrink=0.75,
-                    pad=0.11,
-                    extendrect=True,
-                    extendfrac='auto')
+cbar = plt.colorbar(
+    contour,
+    ax=ax,
+    orientation='horizontal',
+    shrink=0.75,
+    pad=0.11,
+    extendrect=True,
+    extendfrac='auto',
+)
 # Make colorbar tick labels larger and rotate them
 cbar.ax.tick_params(labelsize=14, rotation=45)
 # Format colorbar title, this will make the title appear above the colorbar

--- a/Gallery/Contours/NCL_lb_4.py
+++ b/Gallery/Contours/NCL_lb_4.py
@@ -51,11 +51,13 @@ ax = plt.axes(projection=ccrs.PlateCarree())
 ax.coastlines(linewidths=0.5, alpha=0.6)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(-180, 180),
-                             ylim=(-90, 90),
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(-180, 180),
+    ylim=(-90, 90),
+    xticks=np.linspace(-180, 180, 13),
+    yticks=np.linspace(-90, 90, 7),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, labelsize=10)
@@ -67,11 +69,13 @@ ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use geocat.viz.util convenience function to add titles
-gv.set_titles_and_labels(ax,
-                         lefttitle=V.long_name,
-                         righttitle=V.units,
-                         lefttitlefontsize=12,
-                         righttitlefontsize=12)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle=V.long_name,
+    righttitle=V.units,
+    lefttitlefontsize=12,
+    righttitlefontsize=12,
+)
 
 # Import an NCL colormap
 cmap = cmaps.wgne15
@@ -79,21 +83,25 @@ cmap = cmaps.wgne15
 # Specify which contour levels to draw
 contour_lev = np.arange(-20, 28, 4)
 # Plot filled contour
-contour = V.plot.contourf(ax=ax,
-                          transform=ccrs.PlateCarree(),
-                          cmap=cmap,
-                          levels=contour_lev,
-                          add_colorbar=False,
-                          add_labels=False)
+contour = V.plot.contourf(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    cmap=cmap,
+    levels=contour_lev,
+    add_colorbar=False,
+    add_labels=False,
+)
 # Plot line contour
-V.plot.contour(ax=ax,
-               transform=ccrs.PlateCarree(),
-               colors='black',
-               linewidths=0.5,
-               linestyles='solid',
-               levels=contour_lev,
-               add_colorbar=False,
-               add_labels=False)
+V.plot.contour(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    colors='black',
+    linewidths=0.5,
+    linestyles='solid',
+    levels=contour_lev,
+    add_colorbar=False,
+    add_labels=False,
+)
 
 # Create horizontal colorbar
 # By changing the kwarg `pad`, the colorbar can be moved closer to or farther
@@ -101,15 +109,17 @@ V.plot.contour(ax=ax,
 # colorbars. `extendrect` and `extendfrac` format the ends of the colorbar,
 # default is pointed ends to show there are values beyond the given contour
 # levels
-cbar = plt.colorbar(contour,
-                    ax=ax,
-                    orientation='horizontal',
-                    shrink=0.5,
-                    pad=0.11,
-                    extendrect=True,
-                    extendfrac='auto',
-                    aspect=11,
-                    drawedges=True)
+cbar = plt.colorbar(
+    contour,
+    ax=ax,
+    orientation='horizontal',
+    shrink=0.5,
+    pad=0.11,
+    extendrect=True,
+    extendfrac='auto',
+    aspect=11,
+    drawedges=True,
+)
 
 # Turn off automatically created ticks and tick labels
 cbar.ax.set_xticklabels([])
@@ -122,21 +132,25 @@ cbar.ax.get_xaxis().set_ticks([])
 # end are the extensions for values that fall outside the colorbar rand
 offset = 3 / 22
 for i in range(1, 14):
-    cbar.ax.text(i / 11 - offset,
-                 0.45,
-                 i,
-                 horizontalalignment='center',
-                 verticalalignment='center',
-                 fontweight='bold',
-                 transform=cbar.ax.transAxes)
+    cbar.ax.text(
+        i / 11 - offset,
+        0.45,
+        i,
+        horizontalalignment='center',
+        verticalalignment='center',
+        fontweight='bold',
+        transform=cbar.ax.transAxes,
+    )
 
 # Draw the colorbar units
-cbar.ax.text(1.15,
-             0.5,
-             V.units,
-             horizontalalignment='center',
-             verticalalignment='center',
-             transform=cbar.ax.transAxes)
+cbar.ax.text(
+    1.15,
+    0.5,
+    V.units,
+    horizontalalignment='center',
+    verticalalignment='center',
+    transform=cbar.ax.transAxes,
+)
 
 plt.tight_layout()
 plt.show()

--- a/Gallery/Contours/NCL_lb_5.py
+++ b/Gallery/Contours/NCL_lb_5.py
@@ -51,18 +51,19 @@ lines = u.plot.contour(ax=ax, levels=levels, linewidths=0.5, add_labels=False)
 # Draw contour labels and set bounding boxes for the labels
 ax.clabel(lines, np.array([0]), colors='black', fmt="%.0f", fontsize=18)
 [
-    txt.set_bbox(
-        dict(mutation_aspect=0.8, facecolor='white', edgecolor='none', pad=2))
+    txt.set_bbox(dict(mutation_aspect=0.8, facecolor='white', edgecolor='none', pad=2))
     for txt in lines.labelTexts
 ]
 
 # Plot filled contour
-colors = u.plot.contourf(ax=ax,
-                         cmap='viridis_r',
-                         levels=levels,
-                         transform=ccrs.PlateCarree(),
-                         add_colorbar=False,
-                         add_labels=False)
+colors = u.plot.contourf(
+    ax=ax,
+    cmap='viridis_r',
+    levels=levels,
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    add_labels=False,
+)
 
 # Add colorbar
 cbar = plt.colorbar(
@@ -75,17 +76,20 @@ cbar = plt.colorbar(
     extendfrac='auto',
     aspect=11,  # aspect ratio
     drawedges=True,
-    ticks=levels[:-1:2])  # set colorbar levels
+    ticks=levels[:-1:2],
+)  # set colorbar levels
 
 # Set colorbar label size
 cbar.ax.xaxis.set_tick_params(length=0, labelsize=24, pad=12)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(0, 49),
-                             ylim=(0, 29),
-                             xticks=np.linspace(0, 40, 5),
-                             yticks=np.linspace(0, 25, 6))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(0, 49),
+    ylim=(0, 29),
+    xticks=np.linspace(0, 40, 5),
+    yticks=np.linspace(0, 25, 6),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=5)

--- a/Gallery/Contours/NCL_minmax_3.py
+++ b/Gallery/Contours/NCL_minmax_3.py
@@ -29,15 +29,106 @@ import cmaps
 #  Globals for random number generator for generate_2d_array
 dfran_iseq = 0
 dfran_rseq = [
-    .749, .973, .666, .804, .081, .483, .919, .903, .951, .960, .039, .269,
-    .270, .756, .222, .478, .621, .063, .550, .798, .027, .569, .149, .697,
-    .451, .738, .508, .041, .266, .249, .019, .191, .266, .625, .492, .940,
-    .508, .406, .972, .311, .757, .378, .299, .536, .619, .844, .342, .295,
-    .447, .499, .688, .193, .225, .520, .954, .749, .997, .693, .217, .273,
-    .961, .948, .902, .104, .495, .257, .524, .100, .492, .347, .981, .019,
-    .225, .806, .678, .710, .235, .600, .994, .758, .682, .373, .009, .469,
-    .203, .730, .588, .603, .213, .495, .884, .032, .185, .127, .010, .180,
-    .689, .354, .372, .429
+    0.749,
+    0.973,
+    0.666,
+    0.804,
+    0.081,
+    0.483,
+    0.919,
+    0.903,
+    0.951,
+    0.960,
+    0.039,
+    0.269,
+    0.270,
+    0.756,
+    0.222,
+    0.478,
+    0.621,
+    0.063,
+    0.550,
+    0.798,
+    0.027,
+    0.569,
+    0.149,
+    0.697,
+    0.451,
+    0.738,
+    0.508,
+    0.041,
+    0.266,
+    0.249,
+    0.019,
+    0.191,
+    0.266,
+    0.625,
+    0.492,
+    0.940,
+    0.508,
+    0.406,
+    0.972,
+    0.311,
+    0.757,
+    0.378,
+    0.299,
+    0.536,
+    0.619,
+    0.844,
+    0.342,
+    0.295,
+    0.447,
+    0.499,
+    0.688,
+    0.193,
+    0.225,
+    0.520,
+    0.954,
+    0.749,
+    0.997,
+    0.693,
+    0.217,
+    0.273,
+    0.961,
+    0.948,
+    0.902,
+    0.104,
+    0.495,
+    0.257,
+    0.524,
+    0.100,
+    0.492,
+    0.347,
+    0.981,
+    0.019,
+    0.225,
+    0.806,
+    0.678,
+    0.710,
+    0.235,
+    0.600,
+    0.994,
+    0.758,
+    0.682,
+    0.373,
+    0.009,
+    0.469,
+    0.203,
+    0.730,
+    0.588,
+    0.603,
+    0.213,
+    0.495,
+    0.884,
+    0.032,
+    0.185,
+    0.127,
+    0.010,
+    0.180,
+    0.689,
+    0.354,
+    0.372,
+    0.429,
 ]
 
 
@@ -87,8 +178,8 @@ def generate_2d_array(dims, num_low, num_high, minv, maxv, seed=0):
     # Column-major (Fortran-style) order in memory
     out_array = np.zeros([nx, ny], 'f')
     tmp_array = np.zeros([3, 25], 'f')
-    fovm = 9. / float(nx)
-    fovn = 9. / float(ny)
+    fovm = 9.0 / float(nx)
+    fovn = 9.0 / float(ny)
     # Make sure that num_low and num_high are between 1 to 25 inclusive
     nlow = max(1, min(25, num_low))
     nhgh = max(1, min(25, num_high))
@@ -97,14 +188,14 @@ def generate_2d_array(dims, num_low, num_high, minv, maxv, seed=0):
     # Fill up the temporary array
     for k in range(num_low):
         # lows at random locations.
-        tmp_array[0, k] = 1. + (float(nx) - 1.) * _dfran()
-        tmp_array[1, k] = 1. + (float(ny) - 1.) * _dfran()
-        tmp_array[2, k] = -1.
+        tmp_array[0, k] = 1.0 + (float(nx) - 1.0) * _dfran()
+        tmp_array[1, k] = 1.0 + (float(ny) - 1.0) * _dfran()
+        tmp_array[2, k] = -1.0
     for k in range(num_low, num_low + num_high):
         # highs at random locations.
-        tmp_array[0, k] = 1. + (float(nx) - 1.) * _dfran()
-        tmp_array[1, k] = 1. + (float(ny) - 1.) * _dfran()
-        tmp_array[2, k] = 1.
+        tmp_array[0, k] = 1.0 + (float(nx) - 1.0) * _dfran()
+        tmp_array[1, k] = 1.0 + (float(ny) - 1.0) * _dfran()
+        tmp_array[2, k] = 1.0
 
     # Initialize dmin and dmax to positive and negative infinity
     dmin = np.inf
@@ -120,9 +211,10 @@ def generate_2d_array(dims, num_low, num_high, minv, maxv, seed=0):
                 tempi = fovm * (float(i + 1) - tmp_array[0, k])
                 tempj = fovn * (float(j + 1) - tmp_array[1, k])
                 temp = -(np.square(tempi) + np.square(tempj))
-                if (temp >= -20.):
-                    out_array[i,j] = out_array[i,j] + \
-                       0.5*(maxv - minv)*tmp_array[2,k]*np.exp(temp)
+                if temp >= -20.0:
+                    out_array[i, j] = out_array[i, j] + 0.5 * (maxv - minv) * tmp_array[
+                        2, k
+                    ] * np.exp(temp)
             dmin = min(dmin, out_array[i, j])
             dmax = max(dmax, out_array[i, j])
 
@@ -145,12 +237,14 @@ def plotLabels(coord_locations, label):
         # and first item of coord (lon) access the index for the column number
         value = round(data.data[coord[1], coord[0]], 1)
 
-        txt = ax.text(coord[0],
-                      coord[1],
-                      label + str(value),
-                      fontsize=14,
-                      horizontalalignment='center',
-                      verticalalignment='center')
+        txt = ax.text(
+            coord[0],
+            coord[1],
+            label + str(value),
+            fontsize=14,
+            horizontalalignment='center',
+            verticalalignment='center',
+        )
         txt.set_bbox(dict(facecolor='w', edgecolor='gray', pad=2))
 
 
@@ -160,12 +254,12 @@ def plotLabels(coord_locations, label):
 nx = 100
 ny = 100
 
-data = generate_2d_array((nx, ny), 10, 10, -19., 16., 0)
+data = generate_2d_array((nx, ny), 10, 10, -19.0, 16.0, 0)
 
 # Convert data into type xarray.DataArray
-data = xr.DataArray(data,
-                    dims=["lat", "lon"],
-                    coords=dict(lat=np.arange(nx), lon=np.arange(ny)))
+data = xr.DataArray(
+    data, dims=["lat", "lon"], coords=dict(lat=np.arange(nx), lon=np.arange(ny))
+)
 
 ###############################################################################
 # Plot:
@@ -195,45 +289,43 @@ plotLabels(lmin, 'L')
 plotLabels(lmax, 'H')
 
 # Add colorbar
-cbar = plt.colorbar(contours,
-                    ax=ax,
-                    orientation='vertical',
-                    shrink=0.96,
-                    pad=0.06,
-                    extendrect=True,
-                    extendfrac='auto',
-                    aspect=15,
-                    drawedges=True,
-                    ticks=levels[1:-1:])  # set colorbar levels
+cbar = plt.colorbar(
+    contours,
+    ax=ax,
+    orientation='vertical',
+    shrink=0.96,
+    pad=0.06,
+    extendrect=True,
+    extendfrac='auto',
+    aspect=15,
+    drawedges=True,
+    ticks=levels[1:-1:],
+)  # set colorbar levels
 
 # Set every other tick labels to be integers
 ticklabs = cbar.ax.get_yticklabels()
-[
-    ticklabs[i].set_text(ticklabs[i].get_text()[:-2])
-    for i in range(1, len(ticklabs), 2)
-]
+[ticklabs[i].set_text(ticklabs[i].get_text()[:-2]) for i in range(1, len(ticklabs), 2)]
 
 # Center align colorbar tick labels
 cbar.ax.set_yticklabels(ticklabs, ha='center')
 cbar.ax.yaxis.set_tick_params(pad=26, length=0, labelsize=16)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(0, 99),
-                             ylim=(0, 99),
-                             xticks=np.arange(0, 100, 20),
-                             yticks=np.arange(0, 100, 20))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(0, 99),
+    ylim=(0, 99),
+    xticks=np.arange(0, 100, 20),
+    yticks=np.arange(0, 100, 20),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=4,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=4, labelsize=16)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         maintitle='Adding your own minima/maxima text strings',
-                         maintitlefontsize=24)
+gv.set_titles_and_labels(
+    ax, maintitle='Adding your own minima/maxima text strings', maintitlefontsize=24
+)
 
 # Set different tick font sizes and padding for X and Y axis
 ax.tick_params(axis='both', pad=10)

--- a/Gallery/Contours/NCL_polar_1.py
+++ b/Gallery/Contours/NCL_polar_1.py
@@ -47,10 +47,7 @@ ax.add_feature(cfeature.LAND, facecolor='lightgray')
 gv.set_map_boundary(ax, [-180, 180], [0, 40], south_pad=1)
 
 # Set draw_labels to False so that you can manually manipulate it later
-gl = ax.gridlines(ccrs.PlateCarree(),
-                  draw_labels=False,
-                  linestyle="--",
-                  color='black')
+gl = ax.gridlines(ccrs.PlateCarree(), draw_labels=False, linestyle="--", color='black')
 
 # Manipulate latitude and longitude gridline numbers and spacing
 gl.ylocator = mticker.FixedLocator(np.arange(0, 90, 15))
@@ -58,9 +55,9 @@ gl.xlocator = mticker.FixedLocator(np.arange(-180, 180, 30))
 
 # Manipulate longitude labels (0, 30 E, 60 E, ..., 30 W, etc.)
 ticks = np.arange(0, 210, 30)
-etick = ['0'] + [
-    r'%dE' % tick for tick in ticks if (tick != 0) & (tick != 180)
-] + ['180']
+etick = (
+    ['0'] + [r'%dE' % tick for tick in ticks if (tick != 0) & (tick != 180)] + ['180']
+)
 wtick = [r'%dW' % tick for tick in ticks[::-1] if (tick != 0) & (tick != 180)]
 labels = etick + wtick
 xticks = np.arange(0, 360, 30)
@@ -68,39 +65,47 @@ yticks = np.full_like(xticks, -5)  # Latitude where the labels will be drawn
 
 for xtick, ytick, label in zip(xticks, yticks, labels):
     if label == '180':
-        ax.text(xtick,
-                ytick,
-                label,
-                fontsize=14,
-                horizontalalignment='center',
-                verticalalignment='top',
-                transform=ccrs.Geodetic())
+        ax.text(
+            xtick,
+            ytick,
+            label,
+            fontsize=14,
+            horizontalalignment='center',
+            verticalalignment='top',
+            transform=ccrs.Geodetic(),
+        )
     elif label == '0':
-        ax.text(xtick,
-                ytick,
-                label,
-                fontsize=14,
-                horizontalalignment='center',
-                verticalalignment='bottom',
-                transform=ccrs.Geodetic())
+        ax.text(
+            xtick,
+            ytick,
+            label,
+            fontsize=14,
+            horizontalalignment='center',
+            verticalalignment='bottom',
+            transform=ccrs.Geodetic(),
+        )
     else:
-        ax.text(xtick,
-                ytick,
-                label,
-                fontsize=14,
-                horizontalalignment='center',
-                verticalalignment='center',
-                transform=ccrs.Geodetic())
+        ax.text(
+            xtick,
+            ytick,
+            label,
+            fontsize=14,
+            horizontalalignment='center',
+            verticalalignment='center',
+            transform=ccrs.Geodetic(),
+        )
 
 # Contour-plot U-data
-p = wrap_U.plot.contour(ax=ax,
-                        vmin=-8,
-                        vmax=16,
-                        transform=ccrs.PlateCarree(),
-                        levels=np.arange(-12, 44, 4),
-                        linewidths=0.5,
-                        cmap='black',
-                        add_labels=False)
+p = wrap_U.plot.contour(
+    ax=ax,
+    vmin=-8,
+    vmax=16,
+    transform=ccrs.PlateCarree(),
+    levels=np.arange(-12, 44, 4),
+    linewidths=0.5,
+    cmap='black',
+    add_labels=False,
+)
 
 ax.clabel(p, np.arange(-8, 17, 8), fmt='%d', inline=1, fontsize=14)
 
@@ -108,14 +113,14 @@ ax.clabel(p, np.arange(-8, 17, 8), fmt='%d', inline=1, fontsize=14)
 gv.set_titles_and_labels(ax, lefttitle="Zonal Wind", righttitle="m/s")
 
 # Add lower text box
-ax.text(1.0,
-        -.10,
-        "CONTOUR FROM -12 TO 40 BY 4",
-        horizontalalignment='right',
-        transform=ax.transAxes,
-        bbox=dict(boxstyle='square, pad=0.25',
-                  facecolor='white',
-                  edgecolor='black'))
+ax.text(
+    1.0,
+    -0.10,
+    "CONTOUR FROM -12 TO 40 BY 4",
+    horizontalalignment='right',
+    transform=ax.transAxes,
+    bbox=dict(boxstyle='square, pad=0.25', facecolor='white', edgecolor='black'),
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Contours/NCL_polar_8.py
+++ b/Gallery/Contours/NCL_polar_8.py
@@ -32,7 +32,7 @@ V = ds.V[0, 1, :, :].sel(lat=slice(60, 90))
 T = ds.TS[0, :, :].sel(lat=slice(60, 90))
 
 # Rotate and rescale the wind vectors following recommendations from SciTools/cartopy#1179
-U_source_crs = U / np.cos(U["lat"] / 180. * np.pi)
+U_source_crs = U / np.cos(U["lat"] / 180.0 * np.pi)
 V_source_crs = V
 magnitude = np.sqrt(U**2 + V**2)
 magnitude_source_crs = np.sqrt(U_source_crs**2 + V_source_crs**2)
@@ -63,10 +63,9 @@ ax.add_feature(land_110m, facecolor='none', edgecolor='gray')
 gv.set_map_boundary(ax, [-180, 180], [60, 90], south_pad=1)
 
 # Set draw_labels to False to manually set labels later
-gl = ax.gridlines(ccrs.PlateCarree(),
-                  draw_labels=False,
-                  linestyle=(0, (4, 10)),
-                  color='black')
+gl = ax.gridlines(
+    ccrs.PlateCarree(), draw_labels=False, linestyle=(0, (4, 10)), color='black'
+)
 
 # Manipulate latitude and longitude gridline numbers and spacing
 gl.ylocator = mticker.FixedLocator(np.arange(60, 90, 15))
@@ -82,86 +81,102 @@ yticks = np.full_like(xticks, 58)  # Latitude of the labels
 
 for xtick, ytick, label in zip(xticks, yticks, labels):
     if label == '180':
-        ax.text(xtick,
-                ytick,
-                label,
-                fontsize=13,
-                horizontalalignment='center',
-                verticalalignment='top',
-                transform=ccrs.PlateCarree())
+        ax.text(
+            xtick,
+            ytick,
+            label,
+            fontsize=13,
+            horizontalalignment='center',
+            verticalalignment='top',
+            transform=ccrs.PlateCarree(),
+        )
     elif label == '0':
-        ax.text(xtick,
-                ytick,
-                label,
-                fontsize=13,
-                horizontalalignment='center',
-                verticalalignment='bottom',
-                transform=ccrs.PlateCarree())
+        ax.text(
+            xtick,
+            ytick,
+            label,
+            fontsize=13,
+            horizontalalignment='center',
+            verticalalignment='bottom',
+            transform=ccrs.PlateCarree(),
+        )
     else:
-        ax.text(xtick,
-                ytick,
-                label,
-                fontsize=13,
-                horizontalalignment='center',
-                verticalalignment='center',
-                transform=ccrs.PlateCarree())
+        ax.text(
+            xtick,
+            ytick,
+            label,
+            fontsize=13,
+            horizontalalignment='center',
+            verticalalignment='center',
+            transform=ccrs.PlateCarree(),
+        )
 
 # Set contour levels
 levels = np.arange(249, 283, 3)
 
 # Contourf-plot T-data
-p = wrap_T.plot.contourf(ax=ax,
-                         alpha=0.85,
-                         transform=ccrs.PlateCarree(),
-                         levels=levels,
-                         cmap='viridis',
-                         add_labels=False,
-                         add_colorbar=False,
-                         zorder=3)
+p = wrap_T.plot.contourf(
+    ax=ax,
+    alpha=0.85,
+    transform=ccrs.PlateCarree(),
+    levels=levels,
+    cmap='viridis',
+    add_labels=False,
+    add_colorbar=False,
+    zorder=3,
+)
 
 # Draw vector plot
 # (there is no matplotlib equivalent to "CurlyVector" yet)
-Q = ax.quiver(wrap_U['lon'],
-              wrap_U['lat'],
-              wrap_U.data,
-              wrap_V.data,
-              zorder=4,
-              pivot="middle",
-              width=0.0025,
-              color='white',
-              transform=ccrs.PlateCarree(),
-              regrid_shape=20)
+Q = ax.quiver(
+    wrap_U['lon'],
+    wrap_U['lat'],
+    wrap_U.data,
+    wrap_V.data,
+    zorder=4,
+    pivot="middle",
+    width=0.0025,
+    color='white',
+    transform=ccrs.PlateCarree(),
+    regrid_shape=20,
+)
 
-plt.quiverkey(Q,
-              X=0.7,
-              Y=0.2,
-              U=40,
-              label=r'$40\: \frac{m}{s}$',
-              labelpos='E',
-              coordinates='figure',
-              color='black',
-              fontproperties={'size': 12})
+plt.quiverkey(
+    Q,
+    X=0.7,
+    Y=0.2,
+    U=40,
+    label=r'$40\: \frac{m}{s}$',
+    labelpos='E',
+    coordinates='figure',
+    color='black',
+    fontproperties={'size': 12},
+)
 
 # Add colorbar
-clb = plt.colorbar(p,
-                   ax=ax,
-                   pad=0.12,
-                   shrink=0.85,
-                   aspect=9,
-                   ticks=levels,
-                   extendrect=True,
-                   extendfrac='auto',
-                   orientation='horizontal')
+clb = plt.colorbar(
+    p,
+    ax=ax,
+    pad=0.12,
+    shrink=0.85,
+    aspect=9,
+    ticks=levels,
+    extendrect=True,
+    extendfrac='auto',
+    orientation='horizontal',
+)
 
 # Set colorbar ticks
 clb.ax.xaxis.set_tick_params(length=0, labelsize=13, pad=9)
 
 # Use geocat.viz.util convenience function to add left and right titles
-gv.set_titles_and_labels(ax,
-                         lefttitle="Surface temperature",
-                         righttitle="K",
-                         lefttitlefontsize=16,
-                         righttitlefontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle="Surface temperature",
+    righttitle="K",
+    lefttitlefontsize=16,
+    righttitlefontsize=16,
+)
 
 # Show the plot
 plt.tight_layout()

--- a/Gallery/Line/NCL_leg_1.py
+++ b/Gallery/Line/NCL_leg_1.py
@@ -45,10 +45,7 @@ plt.plot(uz.lat, uz.values, c='gray', label='U')
 plt.legend(loc='upper left', frameon=False, prop={'weight': 'bold'})
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=5,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=5, labelsize=12)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, tick values, and tick labels to show latitude & longitude (i.e. North (N) - South (S))
@@ -57,7 +54,8 @@ gv.set_axes_limits_and_ticks(
     xlim=(-90, 90),
     ylim=(-10, 40),
     xticks=np.linspace(-90, 90, 7),
-    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'])
+    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'],
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Line/NCL_text_11.py
+++ b/Gallery/Line/NCL_text_11.py
@@ -47,10 +47,7 @@ U.plot(x="lat", color="gray", linewidth=1.1)
 plt.title("")
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=5,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=5, labelsize=12)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, tick values, and tick labels to show latitude & longitude (i.e. North (N) - South (S))
@@ -59,7 +56,8 @@ gv.set_axes_limits_and_ticks(
     xlim=(-90, 90),
     ylim=(-10, 40),
     xticks=np.linspace(-90, 90, 7),
-    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'])
+    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'],
+)
 gv.set_axes_limits_and_ticks(ax1, ylim=(-10, 40), yticklabels=[])
 
 # Use geocat.viz.util convenience function to set titles and labels

--- a/Gallery/Line/NCL_text_add_1.py
+++ b/Gallery/Line/NCL_text_add_1.py
@@ -37,17 +37,14 @@ plt.figure(figsize=(6.5, 6.5))
 ax = plt.gca()
 
 # Plot data
-plt.plot(lon, uz.values, c='gray', linewidth=.9)
+plt.plot(lon, uz.values, c='gray', linewidth=0.9)
 
 # Add text with set parameters
 text_kwargs = dict(ha='center', va='center', fontsize=22.5, color='black')
 plt.text(10, 0.0, 'Text in Plot Coordinates', **text_kwargs)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=5,
-                         labelsize=15)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=5, labelsize=15)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, tick values, and tick labels to show latitude & longitude (i.e. North (N) - South (S))
@@ -56,7 +53,8 @@ gv.set_axes_limits_and_ticks(
     xlim=(-90, 90),
     ylim=(-10, 40),
     xticks=np.linspace(-90, 90, 7),
-    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'])
+    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'],
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
 gv.set_titles_and_labels(ax, ylabel='Zonal Wind', labelfontsize=18)

--- a/Gallery/MapProjections/NCL_coast_1.py
+++ b/Gallery/MapProjections/NCL_coast_1.py
@@ -41,7 +41,6 @@ t = ds.t
 
 
 def Plot(res, title):
-
     fig = plt.figure(figsize=(8, 6))
 
     # Generate axes, using Cartopy, drawing coastlines, and adding features
@@ -52,31 +51,37 @@ def Plot(res, title):
     ax1.add_feature(cfeature.LAND.with_scale(res), facecolor="wheat")
 
     # Contourf-plot data
-    temp = t.plot.contourf(ax=ax1,
-                           transform=projection,
-                           levels=25,
-                           vmin=14.9,
-                           vmax=17.3,
-                           cmap='magma',
-                           add_colorbar=False)
+    temp = t.plot.contourf(
+        ax=ax1,
+        transform=projection,
+        levels=25,
+        vmin=14.9,
+        vmax=17.3,
+        cmap='magma',
+        add_colorbar=False,
+    )
 
     # Add color bar
     cbar_ticks = np.arange(15, 17.3, 0.3)
-    cbar = plt.colorbar(temp,
-                        orientation='horizontal',
-                        shrink=0.8,
-                        pad=0.073,
-                        extendrect=True,
-                        ticks=cbar_ticks)
+    cbar = plt.colorbar(
+        temp,
+        orientation='horizontal',
+        shrink=0.8,
+        pad=0.073,
+        extendrect=True,
+        ticks=cbar_ticks,
+    )
 
     cbar.ax.tick_params(labelsize=10)
 
     # Use geocat.viz.util convenience function to set axes limit and tick values
-    gv.set_axes_limits_and_ticks(ax1,
-                                 xlim=(-8, -3),
-                                 ylim=(35, 37),
-                                 xticks=np.linspace(-3, -8, 6),
-                                 yticks=np.linspace(35, 37, 3))
+    gv.set_axes_limits_and_ticks(
+        ax1,
+        xlim=(-8, -3),
+        ylim=(35, 37),
+        xticks=np.linspace(-3, -8, 6),
+        yticks=np.linspace(35, 37, 3),
+    )
 
     # Use geocat.viz.util convenience function to add major tick lines
     gv.add_major_minor_ticks(ax1, y_minor_per_major=1, labelsize=12)
@@ -89,16 +94,18 @@ def Plot(res, title):
     ax1.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
     # Use geocat.viz.util convenience function to set titles and labels
-    gv.set_titles_and_labels(ax1,
-                             righttitle="Deg C",
-                             righttitlefontsize=15,
-                             lefttitle="Temperature",
-                             lefttitlefontsize=15,
-                             xlabel="",
-                             ylabel="")
+    gv.set_titles_and_labels(
+        ax1,
+        righttitle="Deg C",
+        righttitlefontsize=15,
+        lefttitle="Temperature",
+        lefttitlefontsize=15,
+        xlabel="",
+        ylabel="",
+    )
 
-    plt.suptitle("Strait of Gibraltar", x=.5, y=.83, fontsize=18)
-    plt.title(title, x=.5, y=1.07, fontsize=15)
+    plt.suptitle("Strait of Gibraltar", x=0.5, y=0.83, fontsize=18)
+    plt.title(title, x=0.5, y=1.07, fontsize=15)
     plt.tight_layout()
     plt.show()
 

--- a/Gallery/MapProjections/NCL_lcnative_1.py
+++ b/Gallery/MapProjections/NCL_lcnative_1.py
@@ -35,8 +35,7 @@ import geocat.datafiles as gdf
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/pre.8912.mon.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/pre.8912.mon.nc"), decode_times=False)
 
 # Extract a slice of the data
 t = ds.pre.isel(time=0)
@@ -68,10 +67,7 @@ def Plot(row, col, pos, proj, title):
     ax.coastlines(linewidth=0.5)
 
     # Use ax "gridlines" function to draw lat/lon markers on projections
-    gl = ax.gridlines(draw_labels=True,
-                      dms=False,
-                      x_inline=False,
-                      y_inline=False)
+    gl = ax.gridlines(draw_labels=True, dms=False, x_inline=False, y_inline=False)
     gl.top_labels = True
     gl.right_labels = True
     gl.xlines = False
@@ -98,18 +94,18 @@ def Plot(row, col, pos, proj, title):
     """
 
     # Plot data and create colorbar
-    prec = t.plot.contourf(ax=ax,
-                           cmap="Blues_r",
-                           transform=ccrs.PlateCarree(),
-                           levels=14,
-                           add_colorbar=False)
+    prec = t.plot.contourf(
+        ax=ax,
+        cmap="Blues_r",
+        transform=ccrs.PlateCarree(),
+        levels=14,
+        add_colorbar=False,
+    )
 
     cbar_ticks = np.arange(0, 240, 20)
-    cbar = plt.colorbar(prec,
-                        orientation='horizontal',
-                        pad=0.075,
-                        shrink=0.8,
-                        ticks=cbar_ticks)
+    cbar = plt.colorbar(
+        prec, orientation='horizontal', pad=0.075, shrink=0.8, ticks=cbar_ticks
+    )
 
     cbar.ax.tick_params(labelsize=10)
     plt.title(title, loc='center', y=1.17, size=15)
@@ -118,11 +114,13 @@ def Plot(row, col, pos, proj, title):
 
 
 Plot(
-    2, 2, 1,
-    ccrs.LambertConformal(central_longitude=45,
-                          standard_parallels=(36, 55),
-                          globe=ccrs.Globe()), "Lambert Conformal")
-Plot(2, 2, 2, ccrs.LambertCylindrical(central_longitude=45),
-     "Lambert Cylindrical")
-Plot(2, 2, 3, ccrs.LambertAzimuthalEqualArea(central_longitude=45),
-     "Lambert Azimuthal")
+    2,
+    2,
+    1,
+    ccrs.LambertConformal(
+        central_longitude=45, standard_parallels=(36, 55), globe=ccrs.Globe()
+    ),
+    "Lambert Conformal",
+)
+Plot(2, 2, 2, ccrs.LambertCylindrical(central_longitude=45), "Lambert Cylindrical")
+Plot(2, 2, 3, ccrs.LambertAzimuthalEqualArea(central_longitude=45), "Lambert Azimuthal")

--- a/Gallery/MapProjections/NCL_maponly_1.py
+++ b/Gallery/MapProjections/NCL_maponly_1.py
@@ -33,9 +33,9 @@ ax = plt.axes(projection=ccrs.PlateCarree())
 ax.add_feature(cfeature.LAND, color='silver')
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.linspace(-180, 180, 13), yticks=np.linspace(-90, 90, 7)
+)
 
 # Use geocat.viz.util convenience function to make lat/lon tick labels
 gv.add_lat_lon_ticklabels(ax)

--- a/Gallery/MapProjections/NCL_maponly_2.py
+++ b/Gallery/MapProjections/NCL_maponly_2.py
@@ -27,8 +27,7 @@ import geocat.viz as gv
 # Plot:
 
 
-def map_plot(scale, long_min, long_max, lat_min, lat_max, long_labels,
-             lat_labels):
+def map_plot(scale, long_min, long_max, lat_min, lat_max, long_labels, lat_labels):
     """Plots a map-only figure with continent borders, country borders, and
     lakes at a certain longitude and latitude.
 
@@ -70,37 +69,39 @@ def map_plot(scale, long_min, long_max, lat_min, lat_max, long_labels,
 
     # Add in country borders, continent borders, and lakes
     ax.add_feature(
-        cfeature.NaturalEarthFeature(category='cultural',
-                                     name="admin_0_countries",
-                                     scale="110m",
-                                     facecolor="none",
-                                     edgecolor="black",
-                                     linewidth=0.2))
-    ax.add_feature(cfeature.LAND.with_scale(scale),
-                   edgecolor="#4141a0",
-                   facecolor="none")
-    ax.add_feature(cfeature.LAKES.with_scale(scale),
-                   edgecolor="#4141a0",
-                   facecolor="none")
+        cfeature.NaturalEarthFeature(
+            category='cultural',
+            name="admin_0_countries",
+            scale="110m",
+            facecolor="none",
+            edgecolor="black",
+            linewidth=0.2,
+        )
+    )
+    ax.add_feature(
+        cfeature.LAND.with_scale(scale), edgecolor="#4141a0", facecolor="none"
+    )
+    ax.add_feature(
+        cfeature.LAKES.with_scale(scale), edgecolor="#4141a0", facecolor="none"
+    )
 
     # Set extent to show particular area of the map
     ax.set_extent((long_min, long_max, lat_min, lat_max), crs=projection)
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
-    gv.add_major_minor_ticks(ax,
-                             x_minor_per_major=3,
-                             y_minor_per_major=3,
-                             labelsize=15)
+    gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=3, labelsize=15)
 
     # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
     # Set axes limits, tick values, and tick labels for both latitude and longitude
-    gv.set_axes_limits_and_ticks(ax,
-                                 xlim=(long_min, long_max),
-                                 ylim=(lat_min, lat_max),
-                                 xticks=np.linspace(long_min, long_max + 20, 4),
-                                 yticks=np.linspace(lat_min, lat_max, 4),
-                                 xticklabels=long_labels,
-                                 yticklabels=lat_labels)
+    gv.set_axes_limits_and_ticks(
+        ax,
+        xlim=(long_min, long_max),
+        ylim=(lat_min, lat_max),
+        xticks=np.linspace(long_min, long_max + 20, 4),
+        yticks=np.linspace(lat_min, lat_max, 4),
+        xticklabels=long_labels,
+        yticklabels=lat_labels,
+    )
     # Show plot with minimal whitespace
     plt.tight_layout()
     plt.show()

--- a/Gallery/MapProjections/NCL_maponly_6.py
+++ b/Gallery/MapProjections/NCL_maponly_6.py
@@ -38,21 +38,104 @@ import geocat.viz as gv
 
 # Define data from original NCL script
 data = [
-    84.7, 59.2, 94.6, 54.7, 48.2, 58.0, 81.0, 69.4, 85.2, 51.2, 71.7, 80.2,
-    66.2, 66.1, 100.7, 90.5, 77.0, 73.6, 64.6, 70.6, 54.0, 90.5, 79.8, 56.1,
-    62.6, 69.0, 68.6, 64.5, 46.4, 61.1, 84.9, 54.8, 76.9, 82.7, 63.8, 70.1,
-    74.7, 81.7, 61.3, 93.5, 73.0, 29.8, 64.6, 77.4, 61.1, 87.0, 57.3, 55.1
+    84.7,
+    59.2,
+    94.6,
+    54.7,
+    48.2,
+    58.0,
+    81.0,
+    69.4,
+    85.2,
+    51.2,
+    71.7,
+    80.2,
+    66.2,
+    66.1,
+    100.7,
+    90.5,
+    77.0,
+    73.6,
+    64.6,
+    70.6,
+    54.0,
+    90.5,
+    79.8,
+    56.1,
+    62.6,
+    69.0,
+    68.6,
+    64.5,
+    46.4,
+    61.1,
+    84.9,
+    54.8,
+    76.9,
+    82.7,
+    63.8,
+    70.1,
+    74.7,
+    81.7,
+    61.3,
+    93.5,
+    73.0,
+    29.8,
+    64.6,
+    77.4,
+    61.1,
+    87.0,
+    57.3,
+    55.1,
 ]
 states = [
-    "Alabama", "Arizona", "Arkansas", "California", "Colorado", "Connecticut",
-    "Delaware", "Florida", "Georgia", "Idaho", "Illinois", "Indiana", "Iowa",
-    "Kansas", "Kentucky", "Louisiana", "Maine", "Maryland", "Massachusetts",
-    "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana", "Nebraska",
-    "Nevada", "New Hampshire", "New Jersey", "New Mexico", "New York",
-    "North Carolina", "North Dakota", "Ohio", "Oklahoma", "Oregon",
-    "Pennsylvania", "Rhode Island", "South Carolina", "South Dakota",
-    "Tennessee", "Texas", "Utah", "Vermont", "Virginia", "Washington",
-    "West Virginia", "Wisconsin", "Wyoming"
+    "Alabama",
+    "Arizona",
+    "Arkansas",
+    "California",
+    "Colorado",
+    "Connecticut",
+    "Delaware",
+    "Florida",
+    "Georgia",
+    "Idaho",
+    "Illinois",
+    "Indiana",
+    "Iowa",
+    "Kansas",
+    "Kentucky",
+    "Louisiana",
+    "Maine",
+    "Maryland",
+    "Massachusetts",
+    "Michigan",
+    "Minnesota",
+    "Mississippi",
+    "Missouri",
+    "Montana",
+    "Nebraska",
+    "Nevada",
+    "New Hampshire",
+    "New Jersey",
+    "New Mexico",
+    "New York",
+    "North Carolina",
+    "North Dakota",
+    "Ohio",
+    "Oklahoma",
+    "Oregon",
+    "Pennsylvania",
+    "Rhode Island",
+    "South Carolina",
+    "South Dakota",
+    "Tennessee",
+    "Texas",
+    "Utah",
+    "Vermont",
+    "Virginia",
+    "Washington",
+    "West Virginia",
+    "Wisconsin",
+    "Wyoming",
 ]
 
 # Combine data into a dictionary to make it easier to call
@@ -65,29 +148,34 @@ state_dict = {states[i]: data[i] for i in range(len(states))}
 fig = plt.figure(figsize=(7, 5.5))
 
 # Set axes [left, bottom, width, height] to ensure map takes up entire figure
-ax = plt.axes([.02, -.05, .98, .98],
-              projection=ccrs.LambertConformal(),
-              frameon=False)
+ax = plt.axes(
+    [0.02, -0.05, 0.98, 0.98], projection=ccrs.LambertConformal(), frameon=False
+)
 
 # Limit map to just show United States
 ax.set_extent([-118, -75, 20, 50], ccrs.PlateCarree())
 
 # Add inset axes (axes within pre-existing axes) to hold colorbar
-axins1 = ax.inset_axes([0.0, 0.12, .975, .05])
+axins1 = ax.inset_axes([0.0, 0.12, 0.975, 0.05])
 
 # Download the Natural Earth shapefile for state boundaries at 10m resolution and lakes at 110m
 state_shapefile = shapereader.natural_earth(
-    category='cultural',
-    resolution='10m',
-    name='admin_1_states_provinces_lakes')
-lake_shapefile = shapereader.natural_earth(category="physical",
-                                           resolution="110m",
-                                           name="lakes")
+    category='cultural', resolution='10m', name='admin_1_states_provinces_lakes'
+)
+lake_shapefile = shapereader.natural_earth(
+    category="physical", resolution="110m", name="lakes"
+)
 
 # List of lakes to exclude that would otherwise be visible within plot boundaries
 exclude_list = [
-    "Great Slave Lake", "Great Bear Lake", "Lake Winnipeg", "Lake Huron",
-    "Lake Ontario", "Lake Michigan", "Lake Erie", "Lake Superior"
+    "Great Slave Lake",
+    "Great Bear Lake",
+    "Lake Winnipeg",
+    "Lake Huron",
+    "Lake Ontario",
+    "Lake Michigan",
+    "Lake Erie",
+    "Lake Superior",
 ]
 
 # Set colormap and its bounds
@@ -106,35 +194,42 @@ for state in shapereader.Reader(state_shapefile).records():
         edgecolor = "black"
 
         # Plot state with correct color
-        ax.add_geometries([state.geometry],
-                          ccrs.PlateCarree(),
-                          facecolor=facecolor,
-                          edgecolor=edgecolor,
-                          linewidth=0.7)
+        ax.add_geometries(
+            [state.geometry],
+            ccrs.PlateCarree(),
+            facecolor=facecolor,
+            edgecolor=edgecolor,
+            linewidth=0.7,
+        )
 
 # Loop through lakes in lakes file and plot all except those in exclude_list
 for lake in shapereader.Reader(lake_shapefile).records():
     if lake.attributes["name"] not in exclude_list:
-        ax.add_geometries([lake.geometry],
-                          crs=ccrs.PlateCarree(),
-                          facecolor="white",
-                          edgecolor="black",
-                          linewidth=0.7)
+        ax.add_geometries(
+            [lake.geometry],
+            crs=ccrs.PlateCarree(),
+            facecolor="white",
+            edgecolor="black",
+            linewidth=0.7,
+        )
 
 # Create colorbar based on mapped colormap norm
-fig.colorbar(mappable=mappable,
-             cax=axins1,
-             boundaries=colorbounds,
-             ticks=colorbounds[1:-1],
-             spacing='uniform',
-             orientation='horizontal',
-             drawedges=True,
-             anchor=(0.1, 0.5))
+fig.colorbar(
+    mappable=mappable,
+    cax=axins1,
+    boundaries=colorbounds,
+    ticks=colorbounds[1:-1],
+    spacing='uniform',
+    orientation='horizontal',
+    drawedges=True,
+    anchor=(0.1, 0.5),
+)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
 gv.set_titles_and_labels(
     ax,
     maintitle="1994-1998 Male Lung Cancer Age-Adjusted Deaths per 100,000",
-    maintitlefontsize=15)
+    maintitlefontsize=15,
+)
 
 plt.show()

--- a/Gallery/MapProjections/NCL_native_1.py
+++ b/Gallery/MapProjections/NCL_native_1.py
@@ -72,22 +72,26 @@ color_list[-1] = [1, 1, 1]
 
 # Plot contour data, use the transform keyword to specify that the data is
 # stored as rectangular lon,lat coordinates
-contour = ax.contourf(lon,
-                      lat,
-                      topo,
-                      transform=ccrs.PlateCarree(),
-                      levels=np.arange(-300, 3301, 300),
-                      extend='neither',
-                      colors=color_list)
+contour = ax.contourf(
+    lon,
+    lat,
+    topo,
+    transform=ccrs.PlateCarree(),
+    levels=np.arange(-300, 3301, 300),
+    extend='neither',
+    colors=color_list,
+)
 
 # Create colorbar
-plt.colorbar(contour,
-             ax=ax,
-             ticks=np.arange(0, 3001, 300),
-             orientation='horizontal',
-             aspect=12,
-             pad=0.1,
-             shrink=0.8)
+plt.colorbar(
+    contour,
+    ax=ax,
+    ticks=np.arange(0, 3001, 300),
+    orientation='horizontal',
+    aspect=12,
+    pad=0.1,
+    shrink=0.8,
+)
 
 # Use geocat-viz utility function to add gridlines to the map
 gl = gv.add_lat_lon_gridlines(
@@ -95,17 +99,20 @@ gl = gv.add_lat_lon_gridlines(
     color='black',
     labelsize=14,
     xlocator=np.arange(4, 18, 2),  # longitudes for gridlines
-    ylocator=np.arange(43, 50))  # latitudes for gridlines
+    ylocator=np.arange(43, 50),
+)  # latitudes for gridlines
 
 # Add padding between figure and longitude labels
 gl.xpadding = 12
 
 # Use geocat.viz.util function to easily set left and right titles
-gv.set_titles_and_labels(ax,
-                         lefttitle="topography",
-                         lefttitlefontsize=16,
-                         righttitle="m",
-                         righttitlefontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle="topography",
+    lefttitlefontsize=16,
+    righttitle="m",
+    righttitlefontsize=16,
+)
 
 # Add a main title above the left and right titles
 plt.title("Native Stereographic Example", y=1.1, size=18, fontweight="bold")

--- a/Gallery/MapProjections/NCL_native_2.py
+++ b/Gallery/MapProjections/NCL_native_2.py
@@ -33,8 +33,7 @@ import geocat.viz as gv
 
 # Open a netCDF data file using xarray default engine and
 # load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/1994_256_FSD.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/1994_256_FSD.nc"), decode_times=False)
 t = ds.FSD.isel(time=0)
 
 ###############################################################################
@@ -53,39 +52,36 @@ ax.add_feature(cfeature.LAND, facecolor="lightgray")
 ax.set_extent([128, 144, 34, 52], ccrs.PlateCarree())
 
 # Plot data and create colorbar
-pt = t.plot.contourf(ax=ax,
-                     transform=ccrs.PlateCarree(),
-                     vmin=0,
-                     vmax=70,
-                     levels=15,
-                     cmap="inferno",
-                     add_colorbar=False)
+pt = t.plot.contourf(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    vmin=0,
+    vmax=70,
+    levels=15,
+    cmap="inferno",
+    add_colorbar=False,
+)
 
 cbar_ticks = np.arange(0, 71, 5)
-cbar = plt.colorbar(pt,
-                    orientation='vertical',
-                    extendrect=True,
-                    ticks=cbar_ticks)
+cbar = plt.colorbar(pt, orientation='vertical', extendrect=True, ticks=cbar_ticks)
 
 # Draw gridlines
-gl = gv.add_lat_lon_gridlines(ax,
-                              xlocator=[130, 134, 138, 142],
-                              ylocator=[36, 38, 40, 42, 44, 46, 48, 50],
-                              labelsize=15,
-                              linewidth=1,
-                              color='black',
-                              alpha=0.25)
+gl = gv.add_lat_lon_gridlines(
+    ax,
+    xlocator=[130, 134, 138, 142],
+    ylocator=[36, 38, 40, 42, 44, 46, 48, 50],
+    labelsize=15,
+    linewidth=1,
+    color='black',
+    alpha=0.25,
+)
 
 # Remove lat/lon labels on top and right sides of plot
 gl.top_labels = False
 gl.right_labels = False
 
 # Add title
-plt.title("Native Mercator Projection",
-          y=1.05,
-          size=15,
-          fontweight="bold",
-          pad=0)
+plt.title("Native Mercator Projection", y=1.05, size=15, fontweight="bold", pad=0)
 plt.title(t.units, loc="right", y=1.0, size=14)
 plt.title("free surface deviation", loc="left", y=1.0, size=14)
 

--- a/Gallery/MapProjections/NCL_proj_1.py
+++ b/Gallery/MapProjections/NCL_proj_1.py
@@ -52,36 +52,36 @@ gl = ax.gridlines(crs=ccrs.PlateCarree(), linewidth=1, color='black', alpha=0.5)
 newcmp = cmaps.gui_default
 
 # Contourf-plot data (for filled contours)
-temp = wrap_t.plot.contourf(ax=ax,
-                            transform=ccrs.PlateCarree(),
-                            levels=11,
-                            cmap=newcmp,
-                            add_colorbar=False)
+temp = wrap_t.plot.contourf(
+    ax=ax, transform=ccrs.PlateCarree(), levels=11, cmap=newcmp, add_colorbar=False
+)
 
 # Add color bar
 cbar_ticks = np.arange(220, 310, 10)
-cbar = plt.colorbar(temp,
-                    orientation='horizontal',
-                    shrink=0.8,
-                    pad=0.05,
-                    extendrect=True,
-                    ticks=cbar_ticks,
-                    drawedges=True)
+cbar = plt.colorbar(
+    temp,
+    orientation='horizontal',
+    shrink=0.8,
+    pad=0.05,
+    extendrect=True,
+    ticks=cbar_ticks,
+    drawedges=True,
+)
 
 cbar.ax.tick_params(labelsize=10)
 
 # Contour-plot data (for borderlines)
-wrap_t.plot.contour(ax=ax,
-                    transform=ccrs.PlateCarree(),
-                    levels=11,
-                    linewidths=0.5,
-                    cmap='black')
+wrap_t.plot.contour(
+    ax=ax, transform=ccrs.PlateCarree(), levels=11, linewidths=0.5, cmap='black'
+)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         maintitle="Example of Mollweide Projection",
-                         lefttitle="Surface Temperature",
-                         righttitle="K")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Example of Mollweide Projection",
+    lefttitle="Surface Temperature",
+    righttitle="K",
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/MapProjections/NCL_proj_2.py
+++ b/Gallery/MapProjections/NCL_proj_2.py
@@ -47,8 +47,7 @@ wrap_t = gv.xr_add_cyclic_longitudes(t, "lon")
 fig = plt.figure(figsize=(10, 10))
 
 # Generate axes using Cartopy and draw coastlines
-ax = plt.axes(
-    projection=ccrs.Mercator(central_longitude=0, min_latitude=-87.8638))
+ax = plt.axes(projection=ccrs.Mercator(central_longitude=0, min_latitude=-87.8638))
 
 # Add coastlines
 ax.coastlines(linewidths=0.5)
@@ -64,25 +63,23 @@ gl.ylocator = mticker.FixedLocator(np.arange(-84.5, 91, 20))
 gl.xlocator = mticker.FixedLocator(np.arange(-180, 181, 20))
 
 # Contourf-plot data (for filled contours)
-wrap_t.plot.contourf(ax=ax,
-                     transform=ccrs.PlateCarree(),
-                     levels=12,
-                     cmap='inferno',
-                     add_colorbar=False)
+wrap_t.plot.contourf(
+    ax=ax, transform=ccrs.PlateCarree(), levels=12, cmap='inferno', add_colorbar=False
+)
 
 # Contour-plot data (for borderlines)
-wrap_t.plot.contour(ax=ax,
-                    transform=ccrs.PlateCarree(),
-                    levels=12,
-                    linewidths=0.5,
-                    cmap='black')
+wrap_t.plot.contour(
+    ax=ax, transform=ccrs.PlateCarree(), levels=12, linewidths=0.5, cmap='black'
+)
 
 # Use geocat.viz.util convenience function to add titles to left and right
 # of the plot axis.
-gv.set_titles_and_labels(ax,
-                         maintitle="Example of Mercator Projection",
-                         lefttitle="Surface Temperature",
-                         righttitle="K")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Example of Mercator Projection",
+    lefttitle="Surface Temperature",
+    righttitle="K",
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/MapProjections/NCL_proj_3.py
+++ b/Gallery/MapProjections/NCL_proj_3.py
@@ -34,14 +34,13 @@ t = ds.TS.isel(time=0)
 wrap_t = gv.xr_add_cyclic_longitudes(t, "lon")
 
 ###############################################################################
-#Plot:
+# Plot:
 
 # Generate figure (set its size (width, height) in inches)
 fig = plt.figure(figsize=(10, 10))
 
 # Generate axes using Cartopy and draw coastlines with
-ax = plt.axes(
-    projection=ccrs.Orthographic(central_longitude=-120, central_latitude=50))
+ax = plt.axes(projection=ccrs.Orthographic(central_longitude=-120, central_latitude=50))
 
 # Set extent to include latitudes between 0 and 90, and longitude between
 # 0 and -180 only
@@ -50,28 +49,30 @@ ax.set_global()
 ax.coastlines(linewidths=0.5)
 
 # Plot data and add a colorbar
-temp = wrap_t.plot.contourf(ax=ax,
-                            transform=ccrs.PlateCarree(),
-                            levels=11,
-                            cmap='coolwarm',
-                            add_colorbar=False)
+temp = wrap_t.plot.contourf(
+    ax=ax, transform=ccrs.PlateCarree(), levels=11, cmap='coolwarm', add_colorbar=False
+)
 
 cbar_ticks = np.arange(210, 311, 10)
-cbar = plt.colorbar(temp,
-                    orientation='horizontal',
-                    shrink=0.75,
-                    pad=0.05,
-                    extendrect=True,
-                    ticks=cbar_ticks)
+cbar = plt.colorbar(
+    temp,
+    orientation='horizontal',
+    shrink=0.75,
+    pad=0.05,
+    extendrect=True,
+    ticks=cbar_ticks,
+)
 
 cbar.ax.tick_params(labelsize=10)
 
 # Use geocat.viz.util convenience function to add titles to left and right
 # of the plot axis.
-gv.set_titles_and_labels(ax,
-                         maintitle="Example of Orthogonal Projection",
-                         lefttitle="Surface Temperature",
-                         righttitle="K")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Example of Orthogonal Projection",
+    lefttitle="Surface Temperature",
+    righttitle="K",
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/MapProjections/NCL_radar_1.py
+++ b/Gallery/MapProjections/NCL_radar_1.py
@@ -65,50 +65,50 @@ def radar_plot(X, Y, values, bg_color=None):
     cmap = cmaps.gui_default
 
     # Plot using contourf
-    p = plt.contourf(X,
-                     Y,
-                     values,
-                     cmap=cmap,
-                     levels=np.arange(-20, 70, 5) * 100,
-                     zorder=3)
+    p = plt.contourf(
+        X, Y, values, cmap=cmap, levels=np.arange(-20, 70, 5) * 100, zorder=3
+    )
 
     # Change orientation and tick marks of colorbar
-    plt.colorbar(p,
-                 orientation="horizontal",
-                 ticks=np.arange(-15, 65, 15) * 100,
-                 drawedges=True,
-                 aspect=12)
+    plt.colorbar(
+        p,
+        orientation="horizontal",
+        ticks=np.arange(-15, 65, 15) * 100,
+        drawedges=True,
+        aspect=12,
+    )
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
     gv.add_major_minor_ticks(ax, labelsize=12)
 
     # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-    gv.set_titles_and_labels(ax,
-                             lefttitle=ds.DZ.long_name,
-                             lefttitlefontsize=16,
-                             righttitle=ds.DZ.units,
-                             righttitlefontsize=16,
-                             xlabel="",
-                             ylabel="")
+    gv.set_titles_and_labels(
+        ax,
+        lefttitle=ds.DZ.long_name,
+        lefttitlefontsize=16,
+        righttitle=ds.DZ.units,
+        righttitlefontsize=16,
+        xlabel="",
+        ylabel="",
+    )
 
     # Use geocat.viz.util convenience function to set axes limits & tick values
-    gv.set_axes_limits_and_ticks(ax,
-                                 xlim=(-240, 240),
-                                 ylim=(-240, 240),
-                                 xticks=np.arange(-200, 201, 100),
-                                 yticks=np.arange(-200, 201, 100))
+    gv.set_axes_limits_and_ticks(
+        ax,
+        xlim=(-240, 240),
+        ylim=(-240, 240),
+        xticks=np.arange(-200, 201, 100),
+        yticks=np.arange(-200, 201, 100),
+    )
 
     # Use geocat.viz.util convenience function to set tick placements
-    gv.add_major_minor_ticks(ax,
-                             x_minor_per_major=5,
-                             y_minor_per_major=5,
-                             labelsize=14)
+    gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=5, labelsize=14)
 
     # Set aspect ratio
     ax.set_aspect('equal')
 
     # Allow optional background circle to be set
-    if (bg_color is not None):
+    if bg_color is not None:
         circle_bg = plt.Circle((0, 0), 240, color=bg_color, zorder=1)
         ax.add_artist(circle_bg)
 

--- a/Gallery/MapProjections/NCL_sat_1.py
+++ b/Gallery/MapProjections/NCL_sat_1.py
@@ -50,85 +50,103 @@ fig = plt.figure(figsize=(8, 8))
 
 # Set global axes with a nearside perspective projection (equivalent to NCL's
 # satellite projection)
-proj = ccrs.NearsidePerspective(central_longitude=270.0,
-                                central_latitude=45.0,
-                                satellite_height=12742000)
+proj = ccrs.NearsidePerspective(
+    central_longitude=270.0, central_latitude=45.0, satellite_height=12742000
+)
 ax = plt.axes(projection=proj)
 ax.set_global()
 
 # Add land, coastlines, and ocean features
 ax.add_feature(cfeature.LAND, facecolor='lightgray')
-ax.add_feature(cfeature.COASTLINE, linewidth=.5)
+ax.add_feature(cfeature.COASTLINE, linewidth=0.5)
 ax.add_feature(cfeature.OCEAN, facecolor='lightcyan')
-ax.add_feature(cfeature.BORDERS, linewidth=.5)
-ax.add_feature(cfeature.LAKES,
-               facecolor='lightcyan',
-               edgecolor='black',
-               linewidth=.5)
+ax.add_feature(cfeature.BORDERS, linewidth=0.5)
+ax.add_feature(cfeature.LAKES, facecolor='lightcyan', edgecolor='black', linewidth=0.5)
 
 # Make array of the contour levels that will be plotted
 contours = np.arange(948, 1072, 4)
 
 # Plot contour data
-p = wrap_pressure.plot.contour(ax=ax,
-                               transform=ccrs.PlateCarree(),
-                               linewidths=0.5,
-                               levels=contours,
-                               cmap='black',
-                               add_labels=False)
+p = wrap_pressure.plot.contour(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    linewidths=0.5,
+    levels=contours,
+    cmap='black',
+    add_labels=False,
+)
 
 # regular pressure contour levels- These values were found by setting
 # 'manual' argument in ax.clabel call to 'True' and then hovering mouse
 # over desired location of contour label to find coordinate
 # (which can be found in bottom left of figure window).
-regularCLabels = [(176.4, 34.63), (-150.46, 42.44), (-142.16, 28.5),
-                  (-134.12, 16.32), (-108.9, 17.08), (-98.17, 15.6),
-                  (-108.73, 42.19), (-111.25, 49.66), (-127.83, 41.93),
-                  (-92.49, 25.64), (-77.29, 29.08), (-77.04, 16.42),
-                  (-95.93, 57.59), (-156.05, 84.47), (-17.83, 82.52),
-                  (-76.3, 41.99), (-48.89, 41.45), (-33.43, 37.55),
-                  (-46.98, 17.17), (1.79, 63.67), (-58.78, 67.05),
-                  (-44.78, 53.68), (-69.69, 53.71), (-78.02, 52.22),
-                  (-16.91, 44.33), (-95.72, 35.17), (-102.69, 73.62)]
+regularCLabels = [
+    (176.4, 34.63),
+    (-150.46, 42.44),
+    (-142.16, 28.5),
+    (-134.12, 16.32),
+    (-108.9, 17.08),
+    (-98.17, 15.6),
+    (-108.73, 42.19),
+    (-111.25, 49.66),
+    (-127.83, 41.93),
+    (-92.49, 25.64),
+    (-77.29, 29.08),
+    (-77.04, 16.42),
+    (-95.93, 57.59),
+    (-156.05, 84.47),
+    (-17.83, 82.52),
+    (-76.3, 41.99),
+    (-48.89, 41.45),
+    (-33.43, 37.55),
+    (-46.98, 17.17),
+    (1.79, 63.67),
+    (-58.78, 67.05),
+    (-44.78, 53.68),
+    (-69.69, 53.71),
+    (-78.02, 52.22),
+    (-16.91, 44.33),
+    (-95.72, 35.17),
+    (-102.69, 73.62),
+]
 
 # low pressure contour levels- these will be plotted
 # as a subscript to an 'L' symbol.
-lowCLabels = gv.find_local_extrema(pressure,
-                                   eType='Low',
-                                   highVal=1040,
-                                   lowVal=975)
+lowCLabels = gv.find_local_extrema(pressure, eType='Low', highVal=1040, lowVal=975)
 
 # Plot Clabels
-gv.plot_contour_labels(ax,
-                       p,
-                       ccrs.Geodetic(),
-                       proj,
-                       clabel_locations=regularCLabels)
-gv.plot_extrema_labels(pressure,
-                       ccrs.Geodetic(),
-                       proj,
-                       label_locations=lowCLabels)
+gv.plot_contour_labels(ax, p, ccrs.Geodetic(), proj, clabel_locations=regularCLabels)
+gv.plot_extrema_labels(pressure, ccrs.Geodetic(), proj, label_locations=lowCLabels)
 
 # Use gv function to set title and subtitles
-gv.set_titles_and_labels(ax,
-                         maintitle=r"$\bf{SLP}$" + " " + r"$\bf{1963,}$" + " " +
-                         r"$\bf{January}$" + " " + r"$\bf{24th}$",
-                         maintitlefontsize=20,
-                         lefttitle="mean Daily Sea Level Pressure",
-                         lefttitlefontsize=16,
-                         righttitle="hPa",
-                         righttitlefontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    maintitle=r"$\bf{SLP}$"
+    + " "
+    + r"$\bf{1963,}$"
+    + " "
+    + r"$\bf{January}$"
+    + " "
+    + r"$\bf{24th}$",
+    maintitlefontsize=20,
+    lefttitle="mean Daily Sea Level Pressure",
+    lefttitlefontsize=16,
+    righttitle="hPa",
+    righttitlefontsize=16,
+)
 
 # Set characteristics of text box
 props = dict(facecolor='white', edgecolor='black', alpha=0.5)
 
 # Place text box
-ax.text(0.40,
-        -0.1,
-        'CONTOUR FROM 948 TO 1064 BY 4',
-        transform=ax.transAxes,
-        fontsize=16,
-        bbox=props)
+ax.text(
+    0.40,
+    -0.1,
+    'CONTOUR FROM 948 TO 1064 BY 4',
+    transform=ax.transAxes,
+    fontsize=16,
+    bbox=props,
+)
 
 # Make layout tight
 plt.tight_layout()

--- a/Gallery/MapProjections/NCL_sat_2.py
+++ b/Gallery/MapProjections/NCL_sat_2.py
@@ -52,21 +52,18 @@ fig = plt.figure(figsize=(8, 8))
 
 # Set global axes with a nearside perspective projection (equivalent to NCL's
 # satellite projection)
-proj = ccrs.NearsidePerspective(central_longitude=270.0,
-                                central_latitude=45.0,
-                                satellite_height=12742000)
+proj = ccrs.NearsidePerspective(
+    central_longitude=270.0, central_latitude=45.0, satellite_height=12742000
+)
 ax = plt.axes(projection=proj)
 ax.set_global()
 
 # Add land, coastlines, and ocean features
 ax.add_feature(cfeature.LAND, facecolor='lightgray', zorder=1)
-ax.add_feature(cfeature.COASTLINE, linewidth=.3, zorder=2)
+ax.add_feature(cfeature.COASTLINE, linewidth=0.3, zorder=2)
 ax.add_feature(cfeature.OCEAN, facecolor='white')
-ax.add_feature(cfeature.BORDERS, linewidth=.3)
-ax.add_feature(cfeature.LAKES,
-               facecolor='white',
-               edgecolor='black',
-               linewidth=.3)
+ax.add_feature(cfeature.BORDERS, linewidth=0.3)
+ax.add_feature(cfeature.LAKES, facecolor='white', edgecolor='black', linewidth=0.3)
 
 # Create color map
 colorvalues = [1020, 1036, 1500]
@@ -74,21 +71,25 @@ cmap = colors.ListedColormap(['None', 'lightgray', 'dimgrey'])
 norm = colors.BoundaryNorm(colorvalues, 2)
 
 # Plot contour data
-p = wrap_pressure.plot.contourf(ax=ax,
-                                zorder=2,
-                                transform=ccrs.PlateCarree(),
-                                levels=30,
-                                cmap=cmap,
-                                norm=norm,
-                                add_labels=False,
-                                add_colorbar=False)
+p = wrap_pressure.plot.contourf(
+    ax=ax,
+    zorder=2,
+    transform=ccrs.PlateCarree(),
+    levels=30,
+    cmap=cmap,
+    norm=norm,
+    add_labels=False,
+    add_colorbar=False,
+)
 
-p = wrap_pressure.plot.contour(ax=ax,
-                               transform=ccrs.PlateCarree(),
-                               linewidths=0.3,
-                               levels=30,
-                               cmap='black',
-                               add_labels=False)
+p = wrap_pressure.plot.contour(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    linewidths=0.3,
+    levels=30,
+    cmap='black',
+    add_labels=False,
+)
 
 # low pressure contour levels- these will be plotted
 # as a subscript to an 'L' symbol.
@@ -97,45 +98,52 @@ highClevels = gv.find_local_extrema(pressure, highVal=1042, eType='High')
 
 # Label regular contours with automatic matplotlib labeling
 # Specify the levels to label every other contour level
-ax.clabel(p,
-          levels=np.arange(956, 1064, 8),
-          inline=True,
-          fontsize=12,
-          colors='black',
-          fmt="%.0f")
+ax.clabel(
+    p,
+    levels=np.arange(956, 1064, 8),
+    inline=True,
+    fontsize=12,
+    colors='black',
+    fmt="%.0f",
+)
 
 # Label low and high contours
-gv.plot_extrema_labels(wrap_pressure,
-                       ccrs.Geodetic(),
-                       proj,
-                       label_locations=lowClevels,
-                       label='L')
-gv.plot_extrema_labels(wrap_pressure,
-                       ccrs.Geodetic(),
-                       proj,
-                       label_locations=highClevels,
-                       label='H')
+gv.plot_extrema_labels(
+    wrap_pressure, ccrs.Geodetic(), proj, label_locations=lowClevels, label='L'
+)
+gv.plot_extrema_labels(
+    wrap_pressure, ccrs.Geodetic(), proj, label_locations=highClevels, label='H'
+)
 
 # Use gv function to set title and subtitles
-gv.set_titles_and_labels(ax,
-                         maintitle=r"$\bf{SLP}$" + " " + r"$\bf{1963,}$" + " " +
-                         r"$\bf{January}$" + " " + r"$\bf{24th}$",
-                         maintitlefontsize=20,
-                         lefttitle="mean Daily Sea Level Pressure",
-                         lefttitlefontsize=16,
-                         righttitle="hPa",
-                         righttitlefontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    maintitle=r"$\bf{SLP}$"
+    + " "
+    + r"$\bf{1963,}$"
+    + " "
+    + r"$\bf{January}$"
+    + " "
+    + r"$\bf{24th}$",
+    maintitlefontsize=20,
+    lefttitle="mean Daily Sea Level Pressure",
+    lefttitlefontsize=16,
+    righttitle="hPa",
+    righttitlefontsize=16,
+)
 
 # Set characteristics of text box
 props = dict(facecolor='white', edgecolor='black', alpha=0.5)
 
 # Place text box
-ax.text(0.40,
-        -0.1,
-        'CONTOUR FROM 948 TO 1064 BY 4',
-        transform=ax.transAxes,
-        fontsize=16,
-        bbox=props)
+ax.text(
+    0.40,
+    -0.1,
+    'CONTOUR FROM 948 TO 1064 BY 4',
+    transform=ax.transAxes,
+    fontsize=16,
+    bbox=props,
+)
 
 # Add gridlines to axis
 gl = ax.gridlines(color='gray', linestyle='--')

--- a/Gallery/MapProjections/NCL_sat_3.py
+++ b/Gallery/MapProjections/NCL_sat_3.py
@@ -19,7 +19,6 @@ import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import xarray as xr
 import numpy as np
-import matplotlib.ticker as mticker
 
 import geocat.datafiles as gdf
 
@@ -30,8 +29,7 @@ import geocat.viz as gv
 
 # Open a netCDF data file using xarray default engine and
 # load the data into xarrays
-ds = xr.open_dataset(gdf.get('netcdf_files/h_avg_Y0191_D000.00.nc'),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get('netcdf_files/h_avg_Y0191_D000.00.nc'), decode_times=False)
 
 # Extract a slice of the data
 t = ds.T.isel(time=0, z_t=0)
@@ -43,8 +41,7 @@ plt.figure(figsize=(8, 8))
 
 # Create an axis with an orthographic projection (equivalent to NCL's satellite
 # projection where mpSatelliteDistF <= 1.0)
-ax = plt.axes(
-    projection=ccrs.Orthographic(central_longitude=-35, central_latitude=60))
+ax = plt.axes(projection=ccrs.Orthographic(central_longitude=-35, central_latitude=60))
 
 # Set extent of map
 ax.set_extent((-80, -10, 30, 80), crs=ccrs.PlateCarree())
@@ -53,32 +50,34 @@ ax.set_extent((-80, -10, 30, 80), crs=ccrs.PlateCarree())
 ax.coastlines(resolution='110m')
 ax.add_feature(cfeature.LAND, facecolor='lightgray', zorder=1.25)
 ax.add_feature(cfeature.COASTLINE, linewidth=0.2, zorder=1.5)
-ax.add_feature(cfeature.LAKES,
-               edgecolor='black',
-               linewidth=0.2,
-               facecolor='white',
-               zorder=1.5)
+ax.add_feature(
+    cfeature.LAKES, edgecolor='black', linewidth=0.2, facecolor='white', zorder=1.5
+)
 
 # plot filled contour data
-heatmap = t.plot.contourf(ax=ax,
-                          transform=ccrs.PlateCarree(),
-                          levels=80,
-                          vmin=-1.5,
-                          vmax=28.5,
-                          cmap='RdGy',
-                          add_colorbar=False,
-                          zorder=0.5)
+heatmap = t.plot.contourf(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    levels=80,
+    vmin=-1.5,
+    vmax=28.5,
+    cmap='RdGy',
+    add_colorbar=False,
+    zorder=0.5,
+)
 
 # Add color bar
 cbar_ticks = np.arange(-1.5, 31.5, 3)
-cbar = plt.colorbar(heatmap,
-                    orientation='horizontal',
-                    extendfrac=[0, .1],
-                    shrink=0.8,
-                    aspect=14,
-                    pad=0.05,
-                    extendrect=True,
-                    ticks=cbar_ticks)
+cbar = plt.colorbar(
+    heatmap,
+    orientation='horizontal',
+    extendfrac=[0, 0.1],
+    shrink=0.8,
+    aspect=14,
+    pad=0.05,
+    extendrect=True,
+    ticks=cbar_ticks,
+)
 
 cbar.ax.tick_params(labelsize=10)
 
@@ -89,31 +88,46 @@ cbar.ax.minorticks_off()
 cbar.outline.set_visible(False)
 
 # Set main plot title
-main = r"$\bf{Example}$" + " " + r"$\bf{of}$" + " " + r"$\bf{Zooming}$" + \
-       " " + r"$\bf{a}$" + " " + r"$\bf{Sat}$" + " " + r"$\bf{Projection}$"
+main = (
+    r"$\bf{Example}$"
+    + " "
+    + r"$\bf{of}$"
+    + " "
+    + r"$\bf{Zooming}$"
+    + " "
+    + r"$\bf{a}$"
+    + " "
+    + r"$\bf{Sat}$"
+    + " "
+    + r"$\bf{Projection}$"
+)
 
 # Set plot subtitles using NetCDF metadata
 left = t.long_name
 right = t.units
 
 # Use geocat-viz function to create main, left, and right plot titles
-title = gv.set_titles_and_labels(ax,
-                                 maintitle=main,
-                                 maintitlefontsize=16,
-                                 lefttitle=left,
-                                 lefttitlefontsize=14,
-                                 righttitle=right,
-                                 righttitlefontsize=14,
-                                 xlabel="",
-                                 ylabel="")
+title = gv.set_titles_and_labels(
+    ax,
+    maintitle=main,
+    maintitlefontsize=16,
+    lefttitle=left,
+    lefttitlefontsize=14,
+    righttitle=right,
+    righttitlefontsize=14,
+    xlabel="",
+    ylabel="",
+)
 
 # Plot gridlines
-gl = ax.gridlines(color='black',
-                  linewidth=0.2,
-                  zorder=1,
-                  xlocs=np.arange(-180, 180, 15),
-                  ylocs=np.arange(-90, 90, 15),
-                  draw_labels=True)
+gl = ax.gridlines(
+    color='black',
+    linewidth=0.2,
+    zorder=1,
+    xlocs=np.arange(-180, 180, 15),
+    ylocs=np.arange(-90, 90, 15),
+    draw_labels=True,
+)
 
 plt.tight_layout()
 plt.show()

--- a/Gallery/Masking/NCL_lcmask_1.py
+++ b/Gallery/Masking/NCL_lcmask_1.py
@@ -53,26 +53,28 @@ ax.coastlines(linewidth=0.5)
 # Plot data and create colorbar
 newcmp = cmaps.BlWhRe
 
-wind = V.plot.contourf(ax=ax,
-                       cmap=newcmp,
-                       transform=ccrs.PlateCarree(),
-                       add_colorbar=False,
-                       levels=24)
-cbar = plt.colorbar(wind,
-                    ax=ax,
-                    orientation='horizontal',
-                    drawedges=True,
-                    ticks=np.arange(-48, 48, 8),
-                    pad=0.1,
-                    aspect=12)
+wind = V.plot.contourf(
+    ax=ax, cmap=newcmp, transform=ccrs.PlateCarree(), add_colorbar=False, levels=24
+)
+cbar = plt.colorbar(
+    wind,
+    ax=ax,
+    orientation='horizontal',
+    drawedges=True,
+    ticks=np.arange(-48, 48, 8),
+    pad=0.1,
+    aspect=12,
+)
 cbar.ax.tick_params(length=0)  # remove tick marks but leave in labels
 
 # Use geocat.viz.util convenience function to add left and right titles
-gv.set_titles_and_labels(ax,
-                         lefttitle=V.long_name,
-                         lefttitlefontsize=16,
-                         righttitle=V.units,
-                         righttitlefontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle=V.long_name,
+    lefttitlefontsize=16,
+    righttitle=V.units,
+    righttitlefontsize=16,
+)
 
 plt.show()
 
@@ -91,8 +93,7 @@ masked['lon'] = masked['lon'] + 180
 
 # Generate figure and projection using Cartopy
 plt.figure(figsize=(10, 7))
-proj = ccrs.LambertConformal(central_longitude=-22.5,
-                             standard_parallels=(45, 89))
+proj = ccrs.LambertConformal(central_longitude=-22.5, standard_parallels=(45, 89))
 # Set axis projection
 ax = plt.axes(projection=proj)
 ax.coastlines(linewidth=0.5)
@@ -101,24 +102,26 @@ ax.coastlines(linewidth=0.5)
 gv.set_map_boundary(ax, [-85, 40], [20, 80], south_pad=1)
 
 # Plot data and create colorbar
-wind = masked.plot.contourf(ax=ax,
-                            cmap=newcmp,
-                            transform=ccrs.PlateCarree(),
-                            add_colorbar=False,
-                            levels=24)
-cbar = plt.colorbar(wind,
-                    ax=ax,
-                    orientation='horizontal',
-                    drawedges=True,
-                    ticks=np.arange(-40, 44, 4),
-                    pad=0.1,
-                    aspect=18)
+wind = masked.plot.contourf(
+    ax=ax, cmap=newcmp, transform=ccrs.PlateCarree(), add_colorbar=False, levels=24
+)
+cbar = plt.colorbar(
+    wind,
+    ax=ax,
+    orientation='horizontal',
+    drawedges=True,
+    ticks=np.arange(-40, 44, 4),
+    pad=0.1,
+    aspect=18,
+)
 cbar.ax.tick_params(length=0)  # remove tick marks but leave in labels
 
 # Use geocat.viz.util convenience function to add left and right titles
-gv.set_titles_and_labels(ax,
-                         lefttitle=V.long_name,
-                         lefttitlefontsize=16,
-                         righttitle=V.units,
-                         righttitlefontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    lefttitle=V.long_name,
+    lefttitlefontsize=16,
+    righttitle=V.units,
+    righttitlefontsize=16,
+)
 plt.show()

--- a/Gallery/Masking/NCL_mask_1.py
+++ b/Gallery/Masking/NCL_mask_1.py
@@ -28,8 +28,9 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/atmos.nc"), decode_times=False
-                    )  # Disable time decoding due to missing necessary metadata
+ds = xr.open_dataset(
+    gdf.get("netcdf_files/atmos.nc"), decode_times=False
+)  # Disable time decoding due to missing necessary metadata
 # Extract a slice of the data
 ds = ds.isel(time=0, drop=True)
 
@@ -57,23 +58,21 @@ ax.coastlines(linewidth=0.5, resolution="110m")
 newcmp = gv.truncate_colormap(cmaps.BlAqGrYeOrRe, minval=0.1, maxval=1.0, n=22)
 
 # Contourf-plot ocean-only data (for filled contours)
-filled = ocean_only.plot.contourf(ax=ax,
-                                  cmap=newcmp,
-                                  levels=np.arange(260, 305, 2),
-                                  xticks=np.arange(-180, 181, 30),
-                                  yticks=np.arange(-90, 91, 30),
-                                  transform=ccrs.PlateCarree(),
-                                  add_colorbar=False,
-                                  add_labels=False,
-                                  vmin=260,
-                                  vmax=304)
+filled = ocean_only.plot.contourf(
+    ax=ax,
+    cmap=newcmp,
+    levels=np.arange(260, 305, 2),
+    xticks=np.arange(-180, 181, 30),
+    yticks=np.arange(-90, 91, 30),
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    add_labels=False,
+    vmin=260,
+    vmax=304,
+)
 
 # Add horizontal colorbar
-cbar = plt.colorbar(filled,
-                    ax=ax,
-                    orientation="horizontal",
-                    aspect=30,
-                    drawedges=True)
+cbar = plt.colorbar(filled, ax=ax, orientation="horizontal", aspect=30, drawedges=True)
 cbar.set_ticks(np.arange(262, 304, 4))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
@@ -83,12 +82,14 @@ gv.add_major_minor_ticks(ax)
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to add main title as well as titles to left and right of the plot axes.
-gv.set_titles_and_labels(ax,
-                         maintitle="Ocean Only",
-                         lefttitle=ocean_only.attrs['long_name'],
-                         lefttitlefontsize=14,
-                         righttitle=ocean_only.attrs['units'],
-                         righttitlefontsize=14)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Ocean Only",
+    lefttitle=ocean_only.attrs['long_name'],
+    lefttitlefontsize=14,
+    righttitle=ocean_only.attrs['units'],
+    righttitlefontsize=14,
+)
 
 # Show the plot
 plt.show()
@@ -107,23 +108,21 @@ ax.coastlines(linewidth=0.5, resolution="110m")
 newcmp = gv.truncate_colormap(cmaps.BlAqGrYeOrRe, minval=0.1, maxval=1.0, n=32)
 
 # Contourf-plot land-only data (for filled contours)
-filled = land_only.plot.contourf(ax=ax,
-                                 cmap=newcmp,
-                                 levels=np.arange(215, 316, 4),
-                                 xticks=np.arange(-180, 181, 30),
-                                 yticks=np.arange(-90, 91, 30),
-                                 transform=ccrs.PlateCarree(),
-                                 add_colorbar=False,
-                                 add_labels=False,
-                                 vmin=215,
-                                 vmax=315)
+filled = land_only.plot.contourf(
+    ax=ax,
+    cmap=newcmp,
+    levels=np.arange(215, 316, 4),
+    xticks=np.arange(-180, 181, 30),
+    yticks=np.arange(-90, 91, 30),
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    add_labels=False,
+    vmin=215,
+    vmax=315,
+)
 
 # Add horizontal colorbar
-cbar = plt.colorbar(filled,
-                    ax=ax,
-                    orientation="horizontal",
-                    aspect=30,
-                    drawedges=True)
+cbar = plt.colorbar(filled, ax=ax, orientation="horizontal", aspect=30, drawedges=True)
 cbar.set_ticks(np.arange(219, 304, 12))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
@@ -133,12 +132,14 @@ gv.add_major_minor_ticks(ax)
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to add main title as well as titles to left and right of the plot axes.
-gv.set_titles_and_labels(ax,
-                         maintitle="Land Only",
-                         lefttitle=land_only.attrs['long_name'],
-                         lefttitlefontsize=14,
-                         righttitle=land_only.attrs['units'],
-                         righttitlefontsize=14)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Land Only",
+    lefttitle=land_only.attrs['long_name'],
+    lefttitlefontsize=14,
+    righttitle=land_only.attrs['units'],
+    righttitlefontsize=14,
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Masking/NCL_mask_2.py
+++ b/Gallery/Masking/NCL_mask_2.py
@@ -60,36 +60,44 @@ lakes = GeometryCollection(list(cfeature.LAKES.with_scale('110m').geometries()))
 land_no_lakes = land.difference(lakes)  # LAND where not in LAKES
 
 # Add LAND minus LAKES to axis
-ax.add_geometries(land_no_lakes,
-                  crs=ccrs.PlateCarree(),
-                  facecolor='lightgray',
-                  edgecolor='black',
-                  linewidth=0.5,
-                  zorder=1)
+ax.add_geometries(
+    land_no_lakes,
+    crs=ccrs.PlateCarree(),
+    facecolor='lightgray',
+    edgecolor='black',
+    linewidth=0.5,
+    zorder=1,
+)
 
 # Plot filled contour
-contour = TS.plot.contourf(ax=ax,
-                           transform=ccrs.PlateCarree(),
-                           cmap='magma',
-                           levels=np.arange(216, 315, 3),
-                           extend='neither',
-                           add_colorbar=False,
-                           add_labels=False,
-                           zorder=0)
-plt.colorbar(contour,
-             ax=ax,
-             ticks=np.linspace(219, 303, 8),
-             orientation='horizontal',
-             pad=0.075,
-             drawedges=True,
-             shrink=0.7)
+contour = TS.plot.contourf(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    cmap='magma',
+    levels=np.arange(216, 315, 3),
+    extend='neither',
+    add_colorbar=False,
+    add_labels=False,
+    zorder=0,
+)
+plt.colorbar(
+    contour,
+    ax=ax,
+    ticks=np.linspace(219, 303, 8),
+    orientation='horizontal',
+    pad=0.075,
+    drawedges=True,
+    shrink=0.7,
+)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(-180, 180),
-                             ylim=(-90, 90),
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(-180, 180),
+    ylim=(-90, 90),
+    xticks=np.linspace(-180, 180, 13),
+    yticks=np.linspace(-90, 90, 7),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, labelsize=12)
@@ -102,11 +110,13 @@ ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use geocat.viz.util convenience function to add titles
-gv.set_titles_and_labels(ax,
-                         maintitle='Draw land ON TOP of contours',
-                         lefttitle=TS.long_name,
-                         righttitle=TS.units,
-                         lefttitlefontsize=14,
-                         righttitlefontsize=14)
+gv.set_titles_and_labels(
+    ax,
+    maintitle='Draw land ON TOP of contours',
+    lefttitle=TS.long_name,
+    righttitle=TS.units,
+    lefttitlefontsize=14,
+    righttitlefontsize=14,
+)
 
 plt.show()

--- a/Gallery/Masking/NCL_mask_5.py
+++ b/Gallery/Masking/NCL_mask_5.py
@@ -66,17 +66,15 @@ ocean = mpatches.Rectangle((0, 0), 1, 1, facecolor="blue")
 labels = ['Land ', 'Lakes', 'Ocean']
 
 # Add a legend to plot
-plt.legend([land, lakes, ocean],
-           labels,
-           loc='lower center',
-           bbox_to_anchor=(0.5, -0.2),
-           ncol=3)
+plt.legend(
+    [land, lakes, ocean], labels, loc='lower center', bbox_to_anchor=(0.5, -0.2), ncol=3
+)
 
 # Use geocat.viz.util convenience function to set titles and labels without
 # calling several matplotlib functions
-gv.set_titles_and_labels(ax,
-                         maintitle="land sea mask using 'atmos.nc'",
-                         maintitlefontsize=14)
+gv.set_titles_and_labels(
+    ax, maintitle="land sea mask using 'atmos.nc'", maintitlefontsize=14
+)
 
 # Plot second plot
 ax1 = plt.subplot(2, 1, 2, projection=ccrs.PlateCarree())
@@ -86,24 +84,28 @@ ax1.coastlines(linewidths=0.5)
 plt.suptitle("dummy TS field (ocean-masked)", x=0.5, y=0.5, fontsize=14)
 
 # Contourf-plot data
-contour = wrap_t.plot.contourf(ax=ax1,
-                               transform=ccrs.PlateCarree(),
-                               vmin=235,
-                               vmax=315,
-                               levels=17,
-                               cmap='magma',
-                               add_colorbar=False)
+contour = wrap_t.plot.contourf(
+    ax=ax1,
+    transform=ccrs.PlateCarree(),
+    vmin=235,
+    vmax=315,
+    levels=17,
+    cmap='magma',
+    add_colorbar=False,
+)
 
 # Add colorbar to bottom of plot
-cbar = plt.colorbar(contour,
-                    ax=ax1,
-                    orientation='horizontal',
-                    shrink=0.75,
-                    pad=0.11,
-                    extendrect=True,
-                    extendfrac='auto',
-                    use_gridspec=False,
-                    ticks=np.arange(235, 315, 5))
+cbar = plt.colorbar(
+    contour,
+    ax=ax1,
+    orientation='horizontal',
+    shrink=0.75,
+    pad=0.11,
+    extendrect=True,
+    extendfrac='auto',
+    use_gridspec=False,
+    ticks=np.arange(235, 315, 5),
+)
 
 cbar.ax.tick_params(labelsize=10)
 
@@ -112,12 +114,14 @@ ax1.add_feature(cfeature.OCEAN, zorder=10, edgecolor='k')
 
 # Use geocat.viz.util convenience function to set titles and labels without
 # calling several matplotlib functions
-gv.set_titles_and_labels(ax1,
-                         maintitle="",
-                         maintitlefontsize=14,
-                         righttitle="degK",
-                         righttitlefontsize=14,
-                         lefttitle="temperature",
-                         lefttitlefontsize=14)
+gv.set_titles_and_labels(
+    ax1,
+    maintitle="",
+    maintitlefontsize=14,
+    righttitle="degK",
+    righttitlefontsize=14,
+    lefttitle="temperature",
+    lefttitlefontsize=14,
+)
 
 plt.show()

--- a/Gallery/Meteograms/NCL_meteo_1.py
+++ b/Gallery/Meteograms/NCL_meteo_1.py
@@ -62,101 +62,159 @@ ax1.set_aspect(2)
 
 # Create a color map with a combination of matplotlib colors and hex values
 colors = ListedColormap(
-    np.array([
-        'white', 'white', 'white', 'white', 'white', 'mintcream', "#DAF6D3",
-        "#B2FAB9", "#B2FAB9", 'springgreen', 'lime', "#54A63F"
-    ]))
+    np.array(
+        [
+            'white',
+            'white',
+            'white',
+            'white',
+            'white',
+            'mintcream',
+            "#DAF6D3",
+            "#B2FAB9",
+            "#B2FAB9",
+            'springgreen',
+            'lime',
+            "#54A63F",
+        ]
+    )
+)
 contour_levels = [-20, -10, 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
 normalized_levels = BoundaryNorm(boundaries=contour_levels, ncolors=12)
 
 # Plot filled contours for the rh variable
-contour1 = ax1.contourf(rh,
-                        transform=ccrs.PlateCarree(),
-                        cmap=colors,
-                        norm=normalized_levels,
-                        levels=contour_levels,
-                        zorder=2)
+contour1 = ax1.contourf(
+    rh,
+    transform=ccrs.PlateCarree(),
+    cmap=colors,
+    norm=normalized_levels,
+    levels=contour_levels,
+    zorder=2,
+)
 
 # Plot black outlines on top of the filled rh contours
-contour2 = ax1.contour(rh,
-                       transform=ccrs.PlateCarree(),
-                       colors='black',
-                       levels=contour_levels,
-                       linewidths=0.1,
-                       zorder=3)
+contour2 = ax1.contour(
+    rh,
+    transform=ccrs.PlateCarree(),
+    colors='black',
+    levels=contour_levels,
+    linewidths=0.1,
+    zorder=3,
+)
 
 # Plot contours for the tempisobar variable
-contour3 = ax1.contour(tempisobar,
-                       transform=ccrs.PlateCarree(),
-                       colors='red',
-                       levels=[-20, -10, 0, 10, 20, 30, 40, 50, 60],
-                       linewidths=0.7,
-                       linestyles='solid',
-                       zorder=4)
+contour3 = ax1.contour(
+    tempisobar,
+    transform=ccrs.PlateCarree(),
+    colors='red',
+    levels=[-20, -10, 0, 10, 20, 30, 40, 50, 60],
+    linewidths=0.7,
+    linestyles='solid',
+    zorder=4,
+)
 
 # Create lists of coordinates where the contour labels are going to go
 # Before creating an axes over top of the contour plot, hover your
 # mouse over the locations where you want to plot the contour labels.
 # The coordinate will show up on the bottom right of the figure window.
-cont2Labels = [(1.71, 3.82), (5.49, 3.23), (9.53, 4.34), (9.27, 3.53),
-               (14.08, 4.81), (19.21, 2.24), (17.74, 1.00), (22.23, 3.87),
-               (12.87, 2.54), (10.45, 6.02), (11.51, 4.92)]
+cont2Labels = [
+    (1.71, 3.82),
+    (5.49, 3.23),
+    (9.53, 4.34),
+    (9.27, 3.53),
+    (14.08, 4.81),
+    (19.21, 2.24),
+    (17.74, 1.00),
+    (22.23, 3.87),
+    (12.87, 2.54),
+    (10.45, 6.02),
+    (11.51, 4.92),
+]
 
-cont3Labels = [(7.5, 6.1), (10.0, 4.58), (19.06, 1.91), (8.68, 0.46),
-               (19.52, 4.80), (16.7, 6.07), (8.62, 5.41), (18.53, 5.46)]
+cont3Labels = [
+    (7.5, 6.1),
+    (10.0, 4.58),
+    (19.06, 1.91),
+    (8.68, 0.46),
+    (19.52, 4.80),
+    (16.7, 6.07),
+    (8.62, 5.41),
+    (18.53, 5.46),
+]
 
 # Manually plot contour labels
-cont2labels = ax1.clabel(contour2,
-                         manual=cont2Labels,
-                         fmt='%d',
-                         inline=True,
-                         fontsize=7)
-cont3labels = ax1.clabel(contour3,
-                         manual=cont3Labels,
-                         fmt='%d',
-                         inline=True,
-                         fontsize=7,
-                         colors='black')
+cont2labels = ax1.clabel(
+    contour2, manual=cont2Labels, fmt='%d', inline=True, fontsize=7
+)
+cont3labels = ax1.clabel(
+    contour3, manual=cont3Labels, fmt='%d', inline=True, fontsize=7, colors='black'
+)
 
 # Set contour label backgrounds white
 [
-    txt.set_bbox(dict(facecolor='white', edgecolor='none', pad=.5))
+    txt.set_bbox(dict(facecolor='white', edgecolor='none', pad=0.5))
     for txt in contour2.labelTexts
 ]
 [
-    txt.set_bbox(dict(facecolor='white', edgecolor='none', pad=.5))
+    txt.set_bbox(dict(facecolor='white', edgecolor='none', pad=0.5))
     for txt in contour3.labelTexts
 ]
 
 # Determine the labels for each tick on the x and y axes
 yticklabels = np.array(levels, dtype=np.int32)
 xticklabels = [
-    '12z', '15z', '18z', '21z', 'Apr29', '03z', '06z', '09z', '12z', '15z',
-    '18z', '21z', 'Apr30', '03z', '06z', '09z', '12z', '15z', '18z', '21z',
-    'May01', '03z', '06z', '09z', '12z'
+    '12z',
+    '15z',
+    '18z',
+    '21z',
+    'Apr29',
+    '03z',
+    '06z',
+    '09z',
+    '12z',
+    '15z',
+    '18z',
+    '21z',
+    'Apr30',
+    '03z',
+    '06z',
+    '09z',
+    '12z',
+    '15z',
+    '18z',
+    '21z',
+    'May01',
+    '03z',
+    '06z',
+    '09z',
+    '12z',
 ]
 
 # Make an axis to overlay on top of the contour plot
 axin = fig.add_subplot(spec[0, 0])
 
 # Use the geocat.viz function to set the main title of the plot
-gv.set_titles_and_labels(axin,
-                         maintitle='Meteogram for LGSA, 28/12Z',
-                         maintitlefontsize=18,
-                         ylabel='Pressure (mb)',
-                         labelfontsize=12)
+gv.set_titles_and_labels(
+    axin,
+    maintitle='Meteogram for LGSA, 28/12Z',
+    maintitlefontsize=18,
+    ylabel='Pressure (mb)',
+    labelfontsize=12,
+)
 
 # Add a pad between the y axis label and the axis spine
 axin.yaxis.labelpad = 5
 
 # Use the geocat.viz function to set axes limits and ticks
-gv.set_axes_limits_and_ticks(axin,
-                             xlim=[taus[0], taus[-1]],
-                             ylim=[levels[0], levels[-1]],
-                             xticks=np.array(taus),
-                             yticks=np.linspace(1000, 400, 8),
-                             xticklabels=xticklabels,
-                             yticklabels=yticklabels)
+gv.set_axes_limits_and_ticks(
+    axin,
+    xlim=[taus[0], taus[-1]],
+    ylim=[levels[0], levels[-1]],
+    xticks=np.array(taus),
+    yticks=np.linspace(1000, 400, 8),
+    xticklabels=xticklabels,
+    yticklabels=yticklabels,
+)
 
 # Make axis invisible
 axin.patch.set_alpha(0.0)
@@ -173,23 +231,19 @@ for tick in axin.get_xticklabels():
 axin.set_aspect(0.07)
 
 # Plot wind barbs
-barbs = axin.barbs(taus,
-                   np.linspace(1000, 400, 8),
-                   ugrid,
-                   vgrid,
-                   color='black',
-                   lw=0.1,
-                   length=5)
+barbs = axin.barbs(
+    taus, np.linspace(1000, 400, 8), ugrid, vgrid, color='black', lw=0.1, length=5
+)
 
 # Create text box at lower right of contour plot
-ax1.text(1.0,
-         -0.28,
-         "CONTOUR FROM -20 TO 60 BY 10",
-         horizontalalignment='right',
-         transform=ax1.transAxes,
-         bbox=dict(boxstyle='square, pad=0.15',
-                   facecolor='white',
-                   edgecolor='black'))
+ax1.text(
+    1.0,
+    -0.28,
+    "CONTOUR FROM -20 TO 60 BY 10",
+    horizontalalignment='right',
+    transform=ax1.transAxes,
+    bbox=dict(boxstyle='square, pad=0.15', facecolor='white', edgecolor='black'),
+)
 
 # Create two more axes, one for the bar chart and one for the line graph
 axin1 = fig.add_subplot(spec[1, 0])
@@ -198,12 +252,7 @@ axin2 = fig.add_subplot(spec[2, 0])
 # Plot bar chart
 
 # Plot bars depicting the rain03 variable
-axin1.bar(taus,
-          rain03,
-          width=3,
-          color='limegreen',
-          edgecolor='black',
-          linewidth=.2)
+axin1.bar(taus, rain03, width=3, color='limegreen', edgecolor='black', linewidth=0.2)
 
 # Use the geocat.viz function to set the y axis label
 gv.set_titles_and_labels(axin1, ylabel='3hr rain total', labelfontsize=12)
@@ -211,18 +260,43 @@ gv.set_titles_and_labels(axin1, ylabel='3hr rain total', labelfontsize=12)
 # Determine the labels for each tick on the x and y axes
 yticklabels = ['0.0', '0.10', '0.20', '0.30', '0.40', '0.50']
 xticklabels = [
-    '12z', '', '18z', '', 'Apr29', '', '06z', '', '12z', '', '18z', '', 'Apr30',
-    '', '06z', '', '12z', '', '18z', '', 'May01', '', '06z', '', '12z'
+    '12z',
+    '',
+    '18z',
+    '',
+    'Apr29',
+    '',
+    '06z',
+    '',
+    '12z',
+    '',
+    '18z',
+    '',
+    'Apr30',
+    '',
+    '06z',
+    '',
+    '12z',
+    '',
+    '18z',
+    '',
+    'May01',
+    '',
+    '06z',
+    '',
+    '12z',
 ]
 
 # Use the geocat.viz function to set axes limits and ticks
-gv.set_axes_limits_and_ticks(axin1,
-                             xlim=[0, 72],
-                             ylim=[0, .5],
-                             xticks=np.arange(0, 75, 3),
-                             yticks=np.arange(0, .6, 0.1),
-                             xticklabels=xticklabels,
-                             yticklabels=yticklabels)
+gv.set_axes_limits_and_ticks(
+    axin1,
+    xlim=[0, 72],
+    ylim=[0, 0.5],
+    xticks=np.arange(0, 75, 3),
+    yticks=np.arange(0, 0.6, 0.1),
+    xticklabels=xticklabels,
+    yticklabels=yticklabels,
+)
 
 # Use the geocat.viz function to add minor ticks
 gv.add_major_minor_ticks(axin1, y_minor_per_major=5, labelsize="small")
@@ -242,18 +316,43 @@ gv.set_titles_and_labels(axin2, ylabel='Temp at 2m', labelfontsize=12)
 # Determine the labels for each tick on the x and y axes
 yticklabels = ['59.0', '60.0', '61.0', '62.0', '63.0', '64.0']
 xticklabels = [
-    '12z', '', '18z', '', 'Apr29', '', '06z', '', '12z', '', '18z', '', 'Apr30',
-    '', '06z', '', '12z', '', '18z', '', 'May01', '', '06z', '', '12z'
+    '12z',
+    '',
+    '18z',
+    '',
+    'Apr29',
+    '',
+    '06z',
+    '',
+    '12z',
+    '',
+    '18z',
+    '',
+    'Apr30',
+    '',
+    '06z',
+    '',
+    '12z',
+    '',
+    '18z',
+    '',
+    'May01',
+    '',
+    '06z',
+    '',
+    '12z',
 ]
 
 # Use the geocat.viz function to set inset axes limits and ticks
-gv.set_axes_limits_and_ticks(axin2,
-                             xlim=[0, 72],
-                             ylim=[59, 64.5],
-                             xticks=np.arange(0, 75, 3),
-                             yticks=np.arange(59, 65),
-                             xticklabels=xticklabels,
-                             yticklabels=yticklabels)
+gv.set_axes_limits_and_ticks(
+    axin2,
+    xlim=[0, 72],
+    ylim=[59, 64.5],
+    xticks=np.arange(0, 75, 3),
+    yticks=np.arange(59, 65),
+    xticklabels=xticklabels,
+    yticklabels=yticklabels,
+)
 
 # Use the geocat.viz function to add minor ticks
 gv.add_major_minor_ticks(axin2, y_minor_per_major=5, labelsize="small")

--- a/Gallery/Overlays/NCL_overlay_1.py
+++ b/Gallery/Overlays/NCL_overlay_1.py
@@ -53,35 +53,34 @@ ax = plt.axes(projection=ccrs.PlateCarree())
 ax.set_extent([230, 300, 20, 60], crs=ccrs.PlateCarree())
 
 # Draw map features
-ax.add_feature(cfeature.LAKES,
-               linewidth=0.5,
-               edgecolor='black',
-               facecolor='None')
+ax.add_feature(cfeature.LAKES, linewidth=0.5, edgecolor='black', facecolor='None')
 ax.add_feature(cfeature.COASTLINE, linewidth=0.5)
 
 # Plot filled contour
-temp = t.plot.contourf(ax=ax,
-                       transform=ccrs.PlateCarree(),
-                       cmap=cmap,
-                       levels=t_lev,
-                       extend='neither',
-                       add_colorbar=False,
-                       add_labels=False)
-plt.colorbar(temp,
-             ax=ax,
-             ticks=np.arange(215, 270, 5),
-             orientation='horizontal',
-             pad=0.075)
+temp = t.plot.contourf(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    cmap=cmap,
+    levels=t_lev,
+    extend='neither',
+    add_colorbar=False,
+    add_labels=False,
+)
+plt.colorbar(
+    temp, ax=ax, ticks=np.arange(215, 270, 5), orientation='horizontal', pad=0.075
+)
 
 # Plot line contour
-wind = u.plot.contour(ax=ax,
-                      transform=ccrs.PlateCarree(),
-                      vmin=-5,
-                      vmax=35,
-                      levels=u_lev,
-                      colors='black',
-                      linewidths=0.5,
-                      add_labels=False)
+wind = u.plot.contour(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    vmin=-5,
+    vmax=35,
+    levels=u_lev,
+    colors='black',
+    linewidths=0.5,
+    add_labels=False,
+)
 
 # Manually specify where contour labels will go using lat and lon coordinates
 manual = [(-107, 52), (-79, 57), (-78, 47), (-103, 32), (-86, 23)]
@@ -94,20 +93,19 @@ ax.clabel(wind, u_lev, fmt='%d', inline=True, fontsize=10, manual=manual)
 ]
 
 # Add lower text box
-ax.text(1,
-        -0.3,
-        "CONTOUR FROM -5 TO 35 BY 5",
-        horizontalalignment='right',
-        transform=ax.transAxes,
-        bbox=dict(boxstyle='square, pad=0.25',
-                  facecolor='white',
-                  edgecolor='black'))
+ax.text(
+    1,
+    -0.3,
+    "CONTOUR FROM -5 TO 35 BY 5",
+    horizontalalignment='right',
+    transform=ax.transAxes,
+    bbox=dict(boxstyle='square, pad=0.25', facecolor='white', edgecolor='black'),
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle=r"$\bf{T/U @500hPa}$",
-                         lefttitle=t.long_name,
-                         righttitle=t.units)
+gv.set_titles_and_labels(
+    ax, maintitle=r"$\bf{T/U @500hPa}$", lefttitle=t.long_name, righttitle=t.units
+)
 # Add secondary title below the one placed by gv
 ax.text(0, 1.01, u.long_name, transform=ax.transAxes)
 ax.text(0.97, 1.01, u.units, transform=ax.transAxes)
@@ -121,14 +119,11 @@ ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=5,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=5, labelsize=12)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.arange(-120, -30, 30),
-                             yticks=np.arange(20, 70, 10))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.arange(-120, -30, 30), yticks=np.arange(20, 70, 10)
+)
 
 plt.show()

--- a/Gallery/Overlays/NCL_overlay_11a.py
+++ b/Gallery/Overlays/NCL_overlay_11a.py
@@ -78,9 +78,9 @@ lon = ds["lon"]
 # China or Taiwan.
 
 # Download the Natural Earth shapefile for country boundaries at 10m resolution
-shapefile = natural_earth(category='cultural',
-                          resolution='10m',
-                          name='admin_0_countries')
+shapefile = natural_earth(
+    category='cultural', resolution='10m', name='admin_0_countries'
+)
 
 # Sort the geometries in the shapefile into Chinese/Taiwanese or other
 country_geos = []
@@ -97,20 +97,17 @@ projection = PlateCarree()
 
 # Define a Cartopy Feature for the country borders and the land mask (i.e.,
 # all other land) from the shapefile geometries, so they can be easily plotted
-countries = ShapelyFeature(country_geos,
-                           crs=projection,
-                           facecolor='none',
-                           edgecolor='black',
-                           lw=1.5)
-land_mask = ShapelyFeature(other_land_geos,
-                           crs=projection,
-                           facecolor='white',
-                           edgecolor='none')
+countries = ShapelyFeature(
+    country_geos, crs=projection, facecolor='none', edgecolor='black', lw=1.5
+)
+land_mask = ShapelyFeature(
+    other_land_geos, crs=projection, facecolor='white', edgecolor='none'
+)
 
 # Download the Natural Earth shapefile for the states/provinces at 10m resolution
-shapefile = natural_earth(category='cultural',
-                          resolution='10m',
-                          name='admin_1_states_provinces')
+shapefile = natural_earth(
+    category='cultural', resolution='10m', name='admin_1_states_provinces'
+)
 
 # Extract the Chinese province borders
 province_geos = [
@@ -120,11 +117,9 @@ province_geos = [
 ]
 
 # Define a Cartopy Feature for the province borders, so they can be easily plotted
-provinces = ShapelyFeature(province_geos,
-                           crs=projection,
-                           facecolor='none',
-                           edgecolor='black',
-                           lw=0.25)
+provinces = ShapelyFeature(
+    province_geos, crs=projection, facecolor='none', edgecolor='black', lw=0.25
+)
 
 ###############################################################################
 # Plot:
@@ -140,10 +135,9 @@ ax.set_extent([100, 145, 15, 55], crs=projection)
 clevs = np.arange(228, 273, 4, dtype=float)
 
 # Import an NCL colormap, truncating it by using geocat.viz.util convenience function
-newcmp = gv.truncate_colormap(cmaps.BkBlAqGrYeOrReViWh200,
-                              minval=0.1,
-                              maxval=0.6,
-                              n=len(clevs))
+newcmp = gv.truncate_colormap(
+    cmaps.BkBlAqGrYeOrReViWh200, minval=0.1, maxval=0.6, n=len(clevs)
+)
 
 # Draw the temperature contour plot with the subselected colormap
 # (Place the zorder of the contour plot at the lowest level)
@@ -151,12 +145,9 @@ cf = ax.contourf(lon, lat, T, levels=clevs, cmap=newcmp, zorder=1)
 
 # Draw horizontal color bar
 cax = plt.axes((0.14, 0.08, 0.74, 0.02))
-cbar = plt.colorbar(cf,
-                    ax=ax,
-                    cax=cax,
-                    ticks=clevs[1:-1],
-                    drawedges=True,
-                    orientation='horizontal')
+cbar = plt.colorbar(
+    cf, ax=ax, cax=cax, ticks=clevs[1:-1], drawedges=True, orientation='horizontal'
+)
 cbar.ax.tick_params(labelsize=12, rotation=45)
 
 # Add the land mask feature on top of the contour plot (higher zorder)
@@ -171,67 +162,55 @@ ax.add_feature(countries, zorder=3)
 ax.add_feature(provinces, zorder=3)
 
 # Draw the wind quiver plot on top of everything else
-Q = ax.quiver(lon,
-              lat,
-              U,
-              V,
-              color='black',
-              width=.003,
-              scale=600.,
-              headwidth=3.75,
-              zorder=4)
+Q = ax.quiver(
+    lon, lat, U, V, color='black', width=0.003, scale=600.0, headwidth=3.75, zorder=4
+)
 
 # Draw the key for the quiver plot
-rect = plt.Rectangle((142, 52),
-                     3,
-                     3,
-                     facecolor='mediumorchid',
-                     edgecolor=None,
-                     zorder=4)
+rect = plt.Rectangle(
+    (142, 52), 3, 3, facecolor='mediumorchid', edgecolor=None, zorder=4
+)
 ax.add_patch(rect)
-ax.quiverkey(Q,
-             0.9675,
-             0.95,
-             30,
-             '30',
-             labelpos='N',
-             color='black',
-             coordinates='axes',
-             fontproperties={'size': 14},
-             labelsep=0.1)
+ax.quiverkey(
+    Q,
+    0.9675,
+    0.95,
+    30,
+    '30',
+    labelpos='N',
+    color='black',
+    coordinates='axes',
+    fontproperties={'size': 14},
+    labelsep=0.1,
+)
 
 # Add a text box to indicate the pressure level
 props = dict(facecolor='white', edgecolor='none', alpha=0.8)
-ax.text(105,
-        52.7,
-        '500hPa',
-        transform=projection,
-        fontsize=18,
-        ha='center',
-        va='center',
-        color='mediumorchid',
-        bbox=props)
+ax.text(
+    105,
+    52.7,
+    '500hPa',
+    transform=projection,
+    fontsize=18,
+    ha='center',
+    va='center',
+    color='mediumorchid',
+    bbox=props,
+)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=[100, 120, 140],
-                             yticks=[20, 30, 40, 50])
+gv.set_axes_limits_and_ticks(ax, xticks=[100, 120, 140], yticks=[20, 30, 40, 50])
 
 # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=18)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=18)
 
 # Use geocat.viz.util convenience function to add main title as well as titles to left and right of the plot axes.
-gv.set_titles_and_labels(ax,
-                         lefttitle="Temp",
-                         lefttitlefontsize=20,
-                         righttitle="Wind",
-                         righttitlefontsize=20)
+gv.set_titles_and_labels(
+    ax, lefttitle="Temp", lefttitlefontsize=20, righttitle="Wind", righttitlefontsize=20
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Overlays/NCL_overlay_11b.py
+++ b/Gallery/Overlays/NCL_overlay_11b.py
@@ -80,9 +80,9 @@ lon = ds["lon"]
 # China or Taiwan.
 
 # Download the Natural Earth shapefile for country boundaries at 10m resolution
-shapefile = natural_earth(category='cultural',
-                          resolution='10m',
-                          name='admin_0_countries')
+shapefile = natural_earth(
+    category='cultural', resolution='10m', name='admin_0_countries'
+)
 
 # Sort the geometries in the shapefile into Chinese/Taiwanese or other
 country_geos = []
@@ -99,20 +99,17 @@ projection = PlateCarree()
 
 # Define a Cartopy Feature for the country borders and the land mask (i.e.,
 # all other land) from the shapefile geometries, so they can be easily plotted
-countries = ShapelyFeature(country_geos,
-                           crs=projection,
-                           facecolor='none',
-                           edgecolor='black',
-                           lw=1.5)
-land_mask = ShapelyFeature(other_land_geos,
-                           crs=projection,
-                           facecolor='white',
-                           edgecolor='none')
+countries = ShapelyFeature(
+    country_geos, crs=projection, facecolor='none', edgecolor='black', lw=1.5
+)
+land_mask = ShapelyFeature(
+    other_land_geos, crs=projection, facecolor='white', edgecolor='none'
+)
 
 # Download the Natural Earth shapefile for the states/provinces at 10m resolution
-shapefile = natural_earth(category='cultural',
-                          resolution='10m',
-                          name='admin_1_states_provinces')
+shapefile = natural_earth(
+    category='cultural', resolution='10m', name='admin_1_states_provinces'
+)
 
 # Extract the Chinese province borders
 province_geos = [
@@ -122,11 +119,9 @@ province_geos = [
 ]
 
 # Define a Cartopy Feature for the province borders, so they can be easily plotted
-provinces = ShapelyFeature(province_geos,
-                           crs=projection,
-                           facecolor='none',
-                           edgecolor='black',
-                           lw=0.25)
+provinces = ShapelyFeature(
+    province_geos, crs=projection, facecolor='none', edgecolor='black', lw=0.25
+)
 
 ###############################################################################
 # Plot:
@@ -146,10 +141,9 @@ ax.add_feature(LAKES.with_scale('50m'), edgecolor='black', lw=1)
 clevs = np.arange(228, 273, 4, dtype=float)
 
 # Import an NCL colormap, truncating it by using geocat.viz.util convenience function
-newcmp = gv.truncate_colormap(cmaps.BkBlAqGrYeOrReViWh200,
-                              minval=0.1,
-                              maxval=0.6,
-                              n=len(clevs))
+newcmp = gv.truncate_colormap(
+    cmaps.BkBlAqGrYeOrReViWh200, minval=0.1, maxval=0.6, n=len(clevs)
+)
 
 # Draw the contour plot, "clipped" to the country boundaries
 # (NOTE: There are multiple closed polygons representing the boundaries of the
@@ -158,11 +152,9 @@ newcmp = gv.truncate_colormap(cmaps.BkBlAqGrYeOrReViWh200,
 #        As a result, we have to loop over *all closed paths* and construct a
 #        matplotlib patch object that we can use the clip the contour plot.)
 for path in geos_to_path(country_geos):
-    patch = PathPatch(path,
-                      transform=ax.transData,
-                      facecolor='none',
-                      edgecolor='black',
-                      lw=1.5)
+    patch = PathPatch(
+        path, transform=ax.transData, facecolor='none', edgecolor='black', lw=1.5
+    )
 
     # Draw the patch on the plot
     ax.add_patch(patch)
@@ -179,76 +171,60 @@ for path in geos_to_path(country_geos):
 
 # Add horizontal colorbar
 cax = plt.axes((0.14, 0.08, 0.74, 0.02))
-cbar = plt.colorbar(cf,
-                    ax=ax,
-                    cax=cax,
-                    ticks=clevs[1:-1],
-                    drawedges=True,
-                    orientation='horizontal')
+cbar = plt.colorbar(
+    cf, ax=ax, cax=cax, ticks=clevs[1:-1], drawedges=True, orientation='horizontal'
+)
 cbar.ax.tick_params(labelsize=12)
 
 # Draw the province borders
 ax.add_feature(provinces)
 
 # Draw the quiver plot (and its key)
-Q = ax.quiver(lon,
-              lat,
-              U,
-              V,
-              color='black',
-              width=.003,
-              scale=600.,
-              headwidth=3.75)
-rect = plt.Rectangle((142, 52),
-                     3,
-                     3,
-                     facecolor='mediumorchid',
-                     edgecolor=None,
-                     zorder=1)
+Q = ax.quiver(lon, lat, U, V, color='black', width=0.003, scale=600.0, headwidth=3.75)
+rect = plt.Rectangle(
+    (142, 52), 3, 3, facecolor='mediumorchid', edgecolor=None, zorder=1
+)
 ax.add_patch(rect)
-ax.quiverkey(Q,
-             0.9675,
-             0.95,
-             30,
-             '30',
-             labelpos='N',
-             color='black',
-             coordinates='axes',
-             fontproperties={'size': 14},
-             labelsep=0.1)
+ax.quiverkey(
+    Q,
+    0.9675,
+    0.95,
+    30,
+    '30',
+    labelpos='N',
+    color='black',
+    coordinates='axes',
+    fontproperties={'size': 14},
+    labelsep=0.1,
+)
 
 # Draw the '500hPa' label at the top left of the plot
 props = dict(facecolor='white', edgecolor='none', alpha=0.8)
-ax.text(105,
-        52.7,
-        '500hPa',
-        transform=projection,
-        fontsize=18,
-        ha='center',
-        va='center',
-        color='mediumorchid',
-        bbox=props)
+ax.text(
+    105,
+    52.7,
+    '500hPa',
+    transform=projection,
+    fontsize=18,
+    ha='center',
+    va='center',
+    color='mediumorchid',
+    bbox=props,
+)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=[100, 120, 140],
-                             yticks=[20, 30, 40, 50])
+gv.set_axes_limits_and_ticks(ax, xticks=[100, 120, 140], yticks=[20, 30, 40, 50])
 
 # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=18)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=18)
 
 # Use geocat.viz.util convenience function to add main title as well as titles to left and right of the plot axes.
-gv.set_titles_and_labels(ax,
-                         lefttitle="Temp",
-                         lefttitlefontsize=20,
-                         righttitle="Wind",
-                         righttitlefontsize=20)
+gv.set_titles_and_labels(
+    ax, lefttitle="Temp", lefttitlefontsize=20, righttitle="Wind", righttitlefontsize=20
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Overlays/NCL_overlay_12.py
+++ b/Gallery/Overlays/NCL_overlay_12.py
@@ -39,8 +39,9 @@ import cmaps
 # Read in data
 
 # Read in the dataset
-wrfin = Dataset(gdf.get("netcdf_files/wrfout_d01_2003-07-15_00_00_00"),
-                decode_times=True)
+wrfin = Dataset(
+    gdf.get("netcdf_files/wrfout_d01_2003-07-15_00_00_00"), decode_times=True
+)
 
 # Read variables
 hgt = getvar(wrfin, "HGT")  # terrain height in m
@@ -63,14 +64,16 @@ shapefile = shpreader.Reader(gdf.get("shape_files/countyl010g.dbf"))
 
 # This print output resembles NCL printMinMax function
 print("------------------------------------------")
-print("{} ({}) : min={:.1f}    max={:.3f}".format(hgt.attrs['description'],
-                                                  hgt.attrs['units'],
-                                                  hgt.min().data,
-                                                  hgt.max().data))
-print("{} ({}) : min={:.1f}    max={:.3f}".format(dbz.attrs['description'],
-                                                  dbz.attrs['units'],
-                                                  dbz.min().data,
-                                                  dbz.max().data))
+print(
+    "{} ({}) : min={:.1f}    max={:.3f}".format(
+        hgt.attrs['description'], hgt.attrs['units'], hgt.min().data, hgt.max().data
+    )
+)
+print(
+    "{} ({}) : min={:.1f}    max={:.3f}".format(
+        dbz.attrs['description'], dbz.attrs['units'], dbz.min().data, dbz.max().data
+    )
+)
 
 ###############################################################################
 # Create plot
@@ -85,26 +88,29 @@ projection = ccrs.PlateCarree()
 ax = plt.axes([0.05, 0.22, 0.9, 0.7], projection=projection)
 
 # Create inset axes for color bars
-cax1 = inset_axes(ax,
-                  width='98%',
-                  height='10%',
-                  loc='lower left',
-                  bbox_to_anchor=(0.01, -0.25, 1, 1),
-                  bbox_transform=ax.transAxes,
-                  borderpad=0)
-cax2 = inset_axes(ax,
-                  width='6%',
-                  height='98%',
-                  loc='lower right',
-                  bbox_to_anchor=(0.08, 0.01, 1, 1),
-                  bbox_transform=ax.transAxes,
-                  borderpad=0)
+cax1 = inset_axes(
+    ax,
+    width='98%',
+    height='10%',
+    loc='lower left',
+    bbox_to_anchor=(0.01, -0.25, 1, 1),
+    bbox_transform=ax.transAxes,
+    borderpad=0,
+)
+cax2 = inset_axes(
+    ax,
+    width='6%',
+    height='98%',
+    loc='lower right',
+    bbox_to_anchor=(0.08, 0.01, 1, 1),
+    bbox_transform=ax.transAxes,
+    borderpad=0,
+)
 
 # Set latitude and longitude extent to zoom in on map
-ax.set_extent([lon.min().data,
-               lon.max().data,
-               lat.min().data,
-               lat.max().data], projection)
+ax.set_extent(
+    [lon.min().data, lon.max().data, lat.min().data, lat.max().data], projection
+)
 
 #
 # Add state and county borders
@@ -112,22 +118,21 @@ ax.set_extent([lon.min().data,
 
 # Add US states borders
 ax.add_feature(
-    cfeature.NaturalEarthFeature(category='cultural',
-                                 name='admin_1_states_provinces',
-                                 scale='10m',
-                                 facecolor='none',
-                                 edgecolor='black',
-                                 linewidth=0.2,
-                                 zorder=5))
+    cfeature.NaturalEarthFeature(
+        category='cultural',
+        name='admin_1_states_provinces',
+        scale='10m',
+        facecolor='none',
+        edgecolor='black',
+        linewidth=0.2,
+        zorder=5,
+    )
+)
 
 # Add US county borders
 counties = list(shapefile.geometries())
 COUNTIES = cfeature.ShapelyFeature(counties, ccrs.PlateCarree())
-ax.add_feature(COUNTIES,
-               facecolor='none',
-               edgecolor='black',
-               linewidth=0.2,
-               zorder=5)
+ax.add_feature(COUNTIES, facecolor='none', edgecolor='black', linewidth=0.2, zorder=5)
 
 #
 # Plot terrain height contour
@@ -140,19 +145,11 @@ cmap = cmaps.OceanLakeLandSnow
 levels = np.array([0, 1] + [i for i in range(201, 3202, 200)])
 
 # Contourf hgt data
-contour = ax.contourf(lon,
-                      lat,
-                      hgt.data,
-                      alpha=0.6,
-                      levels=levels,
-                      cmap=cmap,
-                      zorder=3)
+contour = ax.contourf(lon, lat, hgt.data, alpha=0.6, levels=levels, cmap=cmap, zorder=3)
 # Add first color bar
-clb = fig.colorbar(contour,
-                   cax=cax1,
-                   orientation='horizontal',
-                   ticks=levels[1:-1],
-                   drawedges=True)
+clb = fig.colorbar(
+    contour, cax=cax1, orientation='horizontal', ticks=levels[1:-1], drawedges=True
+)
 
 # Manually set color bar tick length and tick labels padding.
 clb.ax.xaxis.set_tick_params(length=0, pad=10)
@@ -168,12 +165,7 @@ clb.set_label("Terrain Height (m)", fontsize=16, labelpad=-90)
 levels = np.arange(-28, 41, 4)
 
 # Contourf dbz data
-contour2 = ax.contourf(lon,
-                       lat,
-                       dbz.data,
-                       cmap='magma',
-                       levels=levels,
-                       zorder=4)
+contour2 = ax.contourf(lon, lat, dbz.data, cmap='magma', levels=levels, zorder=4)
 
 # Set colormap and its bounds for the second contour
 cmap = plt.get_cmap('magma')
@@ -196,28 +188,26 @@ clb2.ax.set_yticklabels(levels, ha='center')
 # Set axes features (tick formats and main title)
 #
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.arange(-105, -84, 5),
-                             yticks=np.arange(18, 35, 2))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.arange(-105, -84, 5), yticks=np.arange(18, 35, 2)
+)
 
 # Use gv function to format latitude and longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
 
 # Use gv function to add major and minor ticks
-gv.add_major_minor_ticks(ax,
-                         y_minor_per_major=1,
-                         x_minor_per_major=1,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, y_minor_per_major=1, x_minor_per_major=1, labelsize=16)
 
 # Set padding between tick labels and axes, and turn off ticks on top and right spines
 ax.tick_params(pad=9, top=False, right=False)
 
 # Set title and title fontsize
-ax.set_title("Reflectivity ({}) at znu level = {:.3f}".format(
-    dbz.attrs['units'], znu[1].data),
-             fontweight='bold',
-             fontsize=30,
-             y=1.03)
+ax.set_title(
+    "Reflectivity ({}) at znu level = {:.3f}".format(dbz.attrs['units'], znu[1].data),
+    fontweight='bold',
+    fontsize=30,
+    y=1.03,
+)
 
 # Show plot
 plt.show()

--- a/Gallery/Overlays/NCL_overlay_6.py
+++ b/Gallery/Overlays/NCL_overlay_6.py
@@ -73,27 +73,30 @@ t = (t - 273.15) * 9 / 5 + 32
 ###############################################################################
 # Create plot:
 fig = plt.figure(figsize=(8, 7))
-proj = ccrs.LambertAzimuthalEqualArea(central_longitude=-100,
-                                      central_latitude=40)
+proj = ccrs.LambertAzimuthalEqualArea(central_longitude=-100, central_latitude=40)
 
 # Set axis projection
 ax = plt.axes([0, 0.2, 0.8, 0.7], projection=proj)
 # Create inset axes for color bars
-cax1 = inset_axes(ax,
-                  width='5%',
-                  height='100%',
-                  loc='lower right',
-                  bbox_to_anchor=(0.125, 0, 1, 1),
-                  bbox_transform=ax.transAxes,
-                  borderpad=0)
+cax1 = inset_axes(
+    ax,
+    width='5%',
+    height='100%',
+    loc='lower right',
+    bbox_to_anchor=(0.125, 0, 1, 1),
+    bbox_transform=ax.transAxes,
+    borderpad=0,
+)
 
-cax2 = inset_axes(ax,
-                  width='100%',
-                  height='7%',
-                  loc='lower left',
-                  bbox_to_anchor=(0, -0.15, 1, 1),
-                  bbox_transform=ax.transAxes,
-                  borderpad=0)
+cax2 = inset_axes(
+    ax,
+    width='100%',
+    height='7%',
+    loc='lower left',
+    bbox_to_anchor=(0, -0.15, 1, 1),
+    bbox_transform=ax.transAxes,
+    borderpad=0,
+)
 
 # Set extent to include roughly the United States
 ax.set_extent((-128, -58, 18, 65), crs=ccrs.PlateCarree())
@@ -108,35 +111,33 @@ ax.set_extent((-128, -58, 18, 65), crs=ccrs.PlateCarree())
 transparent = (0, 0, 0, 0)  # RGBA value for a transparent color for lakes
 ax.add_feature(cfeature.OCEAN, color='lightskyblue', zorder=0)
 ax.add_feature(cfeature.LAND, color='silver', zorder=0)
-ax.add_feature(cfeature.LAKES,
-               linewidth=0.5,
-               edgecolor=transparent,
-               facecolor='white',
-               zorder=0)
-ax.add_feature(cfeature.LAKES,
-               linewidth=0.5,
-               edgecolor='black',
-               facecolor=transparent,
-               zorder=2)
+ax.add_feature(
+    cfeature.LAKES, linewidth=0.5, edgecolor=transparent, facecolor='white', zorder=0
+)
+ax.add_feature(
+    cfeature.LAKES, linewidth=0.5, edgecolor='black', facecolor=transparent, zorder=2
+)
 ax.add_feature(cfeature.COASTLINE, linewidth=0.5, zorder=2)
 
 #
 # Plot pressure level contour
 #
 p_cmap = cmaps.StepSeq25
-pressure = p.plot.contourf(ax=ax,
-                           transform=ccrs.PlateCarree(),
-                           cmap=p_cmap,
-                           levels=np.arange(975, 1050, 5),
-                           add_colorbar=False,
-                           add_labels=False,
-                           zorder=1)
+pressure = p.plot.contourf(
+    ax=ax,
+    transform=ccrs.PlateCarree(),
+    cmap=p_cmap,
+    levels=np.arange(975, 1050, 5),
+    add_colorbar=False,
+    add_labels=False,
+    zorder=1,
+)
 plt.colorbar(pressure, cax=cax1, ticks=np.arange(980, 1045, 5))
 
 # Format color bar label
-cax1.yaxis.set_label_text(label='\n'.join('Sea Level Pressure'),
-                          fontsize=14,
-                          rotation=0)
+cax1.yaxis.set_label_text(
+    label='\n'.join('Sea Level Pressure'), fontsize=14, rotation=0
+)
 cax1.yaxis.set_label_coords(-0.5, 0.9)
 cax1.tick_params(size=0)
 
@@ -144,18 +145,20 @@ cax1.tick_params(size=0)
 # Overlay streamlines
 #
 with np.errstate(
-        invalid='ignore'
+    invalid='ignore'
 ):  # Indeed not needed, just to get rid of warnings about numpy's NaN comparisons
-    streams = ax.streamplot(u500.lon,
-                            u500.lat,
-                            u500.data,
-                            v500.data,
-                            transform=ccrs.PlateCarree(),
-                            color='black',
-                            arrowstyle='-',
-                            linewidth=0.5,
-                            density=2,
-                            zorder=5)
+    streams = ax.streamplot(
+        u500.lon,
+        u500.lat,
+        u500.data,
+        v500.data,
+        transform=ccrs.PlateCarree(),
+        color='black',
+        arrowstyle='-',
+        linewidth=0.5,
+        density=2,
+        zorder=5,
+    )
 
 # Divide streamlines into segments
 seg = streams.lines.get_segments()
@@ -163,24 +166,24 @@ seg = streams.lines.get_segments()
 period = 7
 arrow_x = np.array([seg[i][0, 0] for i in range(0, len(seg), period)])
 arrow_y = np.array([seg[i][0, 1] for i in range(0, len(seg), period)])
-arrow_dx = np.array(
-    [seg[i][1, 0] - seg[i][0, 0] for i in range(0, len(seg), period)])
-arrow_dy = np.array(
-    [seg[i][1, 1] - seg[i][0, 1] for i in range(0, len(seg), period)])
+arrow_dx = np.array([seg[i][1, 0] - seg[i][0, 0] for i in range(0, len(seg), period)])
+arrow_dy = np.array([seg[i][1, 1] - seg[i][0, 1] for i in range(0, len(seg), period)])
 # Add arrows to streamlines
-q = ax.quiver(arrow_x,
-              arrow_y,
-              arrow_dx,
-              arrow_dy,
-              color='black',
-              angles='xy',
-              scale=1,
-              units='y',
-              minshaft=3,
-              headwidth=4,
-              headlength=2,
-              headaxislength=2,
-              zorder=5)
+q = ax.quiver(
+    arrow_x,
+    arrow_y,
+    arrow_dx,
+    arrow_dy,
+    color='black',
+    angles='xy',
+    scale=1,
+    units='y',
+    minshaft=3,
+    headwidth=4,
+    headlength=2,
+    headaxislength=2,
+    zorder=5,
+)
 
 #
 # Overlay wind vectors
@@ -201,24 +204,23 @@ bounds = np.arange(-30, 120, 10)  # Sets where boundaries on color map will be
 norm = mcolors.BoundaryNorm(bounds, wind_cmap.N)  # Assigns colors to values
 # Draw wind vectors
 with np.errstate(
-        invalid='ignore'
+    invalid='ignore'
 ):  # Indeed not needed, just to get rid of warnings about numpy's NaN comparisons
-    Q = ax.quiver(x,
-                  y,
-                  u,
-                  v,
-                  t,
-                  transform=ccrs.PlateCarree(),
-                  norm=norm,
-                  headwidth=5,
-                  cmap=wind_cmap,
-                  zorder=4)
+    Q = ax.quiver(
+        x,
+        y,
+        u,
+        v,
+        t,
+        transform=ccrs.PlateCarree(),
+        norm=norm,
+        headwidth=5,
+        cmap=wind_cmap,
+        zorder=4,
+    )
 
 # Add color bar
-plt.colorbar(Q,
-             cax=cax2,
-             ticks=np.arange(-20, 110, 10),
-             orientation='horizontal')
+plt.colorbar(Q, cax=cax2, ticks=np.arange(-20, 110, 10), orientation='horizontal')
 
 # Format color bar label
 cax2.xaxis.set_label_text(label='Surface Temperature', fontsize=14)
@@ -227,17 +229,20 @@ cax2.tick_params(size=0)
 
 # Add quiverkey and white patch behind it
 ax.add_patch(
-    mpatches.Rectangle(xy=[0.85, 0],
-                       width=0.15,
-                       height=0.0925,
-                       facecolor='white',
-                       transform=ax.transAxes,
-                       zorder=3))
+    mpatches.Rectangle(
+        xy=[0.85, 0],
+        width=0.15,
+        height=0.0925,
+        facecolor='white',
+        transform=ax.transAxes,
+        zorder=3,
+    )
+)
 ax.quiverkey(Q, 0.925, 0.025, 20, label='20', zorder=4)
 
 # Add title
-ax.set_title('January 1996 Snow Storm\n1996 01 05 00:00 + 0',
-             fontweight='bold',
-             fontsize=16)
+ax.set_title(
+    'January 1996 Snow Storm\n1996 01 05 00:00 + 0', fontweight='bold', fontsize=16
+)
 
 plt.show()

--- a/Gallery/Panels/NCL_dev_1.py
+++ b/Gallery/Panels/NCL_dev_1.py
@@ -63,10 +63,7 @@ proj = ccrs.PlateCarree()
 
 # Generate figure (set its size (width, height) in inches)
 fig = plt.figure(figsize=(8, 8))
-grid = fig.add_gridspec(ncols=2,
-                        nrows=2,
-                        width_ratios=[0.85, 0.15],
-                        wspace=0.08)
+grid = fig.add_gridspec(ncols=2, nrows=2, width_ratios=[0.85, 0.15], wspace=0.08)
 
 # Create axis for original data plot
 ax1 = fig.add_subplot(grid[0, 0], projection=ccrs.PlateCarree())
@@ -85,11 +82,13 @@ ax4 = fig.add_subplot(grid[1, 1], aspect=10)
 # Format ticks and ticklabels for the map axes
 for ax in [ax1, ax3]:
     # Use the geocat.viz function to set axes limits and ticks
-    gv.set_axes_limits_and_ticks(ax,
-                                 xlim=[-180, 180],
-                                 ylim=[-90, 90],
-                                 xticks=np.arange(-180, 181, 30),
-                                 yticks=np.arange(-90, 91, 30))
+    gv.set_axes_limits_and_ticks(
+        ax,
+        xlim=[-180, 180],
+        ylim=[-90, 90],
+        xticks=np.arange(-180, 181, 30),
+        yticks=np.arange(-90, 91, 30),
+    )
 
     # Use the geocat.viz function to add minor ticks
     gv.add_major_minor_ticks(ax)
@@ -103,24 +102,24 @@ for ax in [ax1, ax3]:
     ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use the geocat.viz function to set axes limits and ticks for zonal average plot
-gv.set_axes_limits_and_ticks(ax2,
-                             xlim=[0, 375],
-                             ylim=[-90, 90],
-                             xticks=[0, 200],
-                             yticks=[])
+gv.set_axes_limits_and_ticks(
+    ax2, xlim=[0, 375], ylim=[-90, 90], xticks=[0, 200], yticks=[]
+)
 
 # Use the geocat.viz function to add minor ticks to zonal average plot
 gv.add_major_minor_ticks(ax2, x_minor_per_major=2)
 
 # Plot original data contour lines
-contour = TS.plot.contour(ax=ax1,
-                          transform=proj,
-                          vmin=235,
-                          vmax=305,
-                          levels=np.arange(235, 305, 5),
-                          colors='black',
-                          linewidths=0.25,
-                          add_labels=False)
+contour = TS.plot.contour(
+    ax=ax1,
+    transform=proj,
+    vmin=235,
+    vmax=305,
+    levels=np.arange(235, 305, 5),
+    colors='black',
+    linewidths=0.25,
+    add_labels=False,
+)
 
 # Label contours lines
 ax1.clabel(contour, np.arange(240, 301, 10), fmt='%d', inline=True, fontsize=10)
@@ -130,16 +129,16 @@ for txt in contour.labelTexts:
     txt.set_bbox(dict(facecolor='white', edgecolor='none', pad=0))
 
 # Add lower text box
-ax1.text(0.995,
-         0.03,
-         "CONTOUR FROM 235 TO 305 BY 5",
-         horizontalalignment='right',
-         transform=ax1.transAxes,
-         fontsize=8,
-         bbox=dict(boxstyle='square, pad=0.25',
-                   facecolor='white',
-                   edgecolor='black'),
-         zorder=5)
+ax1.text(
+    0.995,
+    0.03,
+    "CONTOUR FROM 235 TO 305 BY 5",
+    horizontalalignment='right',
+    transform=ax1.transAxes,
+    fontsize=8,
+    bbox=dict(boxstyle='square, pad=0.25', facecolor='white', edgecolor='black'),
+    zorder=5,
+)
 
 # Add titles to top plot
 size = 10
@@ -158,20 +157,24 @@ cmap = cmaps.BlWhRe
 cmap = gv.truncate_colormap(cmap, minval=0.22, maxval=0.74, n=15)
 
 # Plot deviations from zonal mean
-deviations = ax3.contourf(TS['lon'],
-                          TS['lat'],
-                          dev,
-                          levels=np.linspace(-40, 35, 16),
-                          cmap=cmap,
-                          vmin=-40,
-                          vmax=35)
-ax3.contour(TS['lon'],
-            TS['lat'],
-            dev,
-            levels=np.linspace(-40, 35, 16),
-            colors='black',
-            linewidths=0.25,
-            linestyles='solid')
+deviations = ax3.contourf(
+    TS['lon'],
+    TS['lat'],
+    dev,
+    levels=np.linspace(-40, 35, 16),
+    cmap=cmap,
+    vmin=-40,
+    vmax=35,
+)
+ax3.contour(
+    TS['lon'],
+    TS['lat'],
+    dev,
+    levels=np.linspace(-40, 35, 16),
+    colors='black',
+    linewidths=0.25,
+    linestyles='solid',
+)
 
 # Add titles to bottom plot
 ax3.set_title('Deviation from zonal ave', fontsize=size, y=y)
@@ -179,10 +182,8 @@ ax3.set_title(TS.long_name, fontsize=size, loc='left', y=y)
 ax3.set_title(TS.units, fontsize=size, loc='right', y=y)
 
 # Add colorbar
-plt.colorbar(deviations,
-             cax=ax4,
-             shrink=0.9,
-             ticks=np.linspace(-35, 30, 14),
-             drawedges=True)
+plt.colorbar(
+    deviations, cax=ax4, shrink=0.9, ticks=np.linspace(-35, 30, 14), drawedges=True
+)
 
 plt.show()

--- a/Gallery/Panels/NCL_dev_2.py
+++ b/Gallery/Panels/NCL_dev_2.py
@@ -35,8 +35,7 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/b003_TS_200-299.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/b003_TS_200-299.nc"), decode_times=False)
 
 # Extract slice of data at first timestep
 TS_0 = ds.TS.isel(time=0, drop=True)
@@ -64,10 +63,7 @@ fig = plt.figure(figsize=(8, 8))
 
 # Create girdspec for layout, width_ratio is used to make the plots on the
 # right narrower than the ones on the left
-grid = fig.add_gridspec(ncols=2,
-                        nrows=2,
-                        width_ratios=[0.85, 0.15],
-                        wspace=0.08)
+grid = fig.add_gridspec(ncols=2, nrows=2, width_ratios=[0.85, 0.15], wspace=0.08)
 
 # Create axis for plot with data from first timestep
 ax1 = fig.add_subplot(grid[0, 0], projection=ccrs.PlateCarree())
@@ -86,11 +82,13 @@ ax4 = fig.add_subplot(grid[1, 1], aspect=10)
 # Format ticks and ticklabels for the map axes
 for ax in [ax1, ax3]:
     # Use the geocat.viz function to set axes limits and ticks
-    gv.set_axes_limits_and_ticks(ax,
-                                 xlim=[-180, 180],
-                                 ylim=[-90, 90],
-                                 xticks=np.arange(-180, 181, 30),
-                                 yticks=np.arange(-90, 91, 30))
+    gv.set_axes_limits_and_ticks(
+        ax,
+        xlim=[-180, 180],
+        ylim=[-90, 90],
+        xticks=np.arange(-180, 181, 30),
+        yticks=np.arange(-90, 91, 30),
+    )
 
     # Use the geocat.viz function to add minor ticks
     gv.add_major_minor_ticks(ax)
@@ -104,24 +102,24 @@ for ax in [ax1, ax3]:
     ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use the geocat.viz function to set axes limits and ticks for zonal average plot
-gv.set_axes_limits_and_ticks(ax2,
-                             xlim=[200, 310],
-                             ylim=[-90, 90],
-                             xticks=[200, 240, 280],
-                             yticks=[])
+gv.set_axes_limits_and_ticks(
+    ax2, xlim=[200, 310], ylim=[-90, 90], xticks=[200, 240, 280], yticks=[]
+)
 
 # Use the geocat.viz function to add minor ticks to zonal average plot
 gv.add_major_minor_ticks(ax2, x_minor_per_major=2)
 
 # Plot contour lines for data at first timestep
-contour = TS_0.plot.contour(ax=ax1,
-                            transform=proj,
-                            vmin=235,
-                            vmax=305,
-                            levels=np.arange(210, 311, 10),
-                            colors='black',
-                            linewidths=0.25,
-                            add_labels=False)
+contour = TS_0.plot.contour(
+    ax=ax1,
+    transform=proj,
+    vmin=235,
+    vmax=305,
+    levels=np.arange(210, 311, 10),
+    colors='black',
+    linewidths=0.25,
+    add_labels=False,
+)
 
 # Label every other contour lines
 ax1.clabel(contour, np.arange(220, 311, 20), fmt='%d', inline=True, fontsize=10)
@@ -131,16 +129,16 @@ for txt in contour.labelTexts:
     txt.set_bbox(dict(facecolor='white', edgecolor='none', pad=0))
 
 # Add lower text box
-ax1.text(0.995,
-         0.03,
-         "CONTOUR FROM 210 TO 310 BY 10",
-         horizontalalignment='right',
-         transform=ax1.transAxes,
-         fontsize=8,
-         bbox=dict(boxstyle='square, pad=0.25',
-                   facecolor='white',
-                   edgecolor='black'),
-         zorder=5)
+ax1.text(
+    0.995,
+    0.03,
+    "CONTOUR FROM 210 TO 310 BY 10",
+    horizontalalignment='right',
+    transform=ax1.transAxes,
+    fontsize=8,
+    bbox=dict(boxstyle='square, pad=0.25', facecolor='white', edgecolor='black'),
+    zorder=5,
+)
 
 # Add titles to top plot
 size = 10
@@ -162,25 +160,29 @@ cmap = cmaps.BlWhRe
 cmap = gv.truncate_colormap(cmap, minval=0.22, maxval=0.74, n=14)
 
 # Plot filled contour for deviation from time avg plot
-deviations = time_dev.plot.contourf(ax=ax3,
-                                    transform=proj,
-                                    vmin=-14,
-                                    vmax=18,
-                                    levels=np.arange(-14, 20, 2),
-                                    cmap=cmap,
-                                    add_colorbar=False,
-                                    add_labels=False)
+deviations = time_dev.plot.contourf(
+    ax=ax3,
+    transform=proj,
+    vmin=-14,
+    vmax=18,
+    levels=np.arange(-14, 20, 2),
+    cmap=cmap,
+    add_colorbar=False,
+    add_labels=False,
+)
 
 # Draw contour lines for deviation from time avg plot
-time_dev.plot.contour(ax=ax3,
-                      transform=proj,
-                      vmin=-14,
-                      vmax=18,
-                      levels=np.arange(-14, 20, 2),
-                      colors='black',
-                      linewidths=0.25,
-                      linestyles='solid',
-                      add_labels=False)
+time_dev.plot.contour(
+    ax=ax3,
+    transform=proj,
+    vmin=-14,
+    vmax=18,
+    levels=np.arange(-14, 20, 2),
+    colors='black',
+    linewidths=0.25,
+    linestyles='solid',
+    add_labels=False,
+)
 
 # Add titles to bottom plot
 ax3.set_title('Deviation from time ave', fontsize=size, y=y)
@@ -188,9 +190,6 @@ ax3.set_title(ds.TS.long_name, fontsize=size, loc='left', y=y)
 ax3.set_title(ds.TS.units, fontsize=size, loc='right', y=y)
 
 # Add colorbar
-plt.colorbar(deviations,
-             cax=ax4,
-             ticks=np.linspace(-12, 16, 15),
-             drawedges=True)
+plt.colorbar(deviations, cax=ax4, ticks=np.linspace(-12, 16, 15), drawedges=True)
 
 plt.show()

--- a/Gallery/Panels/NCL_panel_1.py
+++ b/Gallery/Panels/NCL_panel_1.py
@@ -38,20 +38,21 @@ ds = xr.open_dataset(gdf.get("netcdf_files/uv300.nc")).isel(time=1)
 # See https://matplotlib.org/tutorials/intermediate/constrainedlayout_guide.html
 # Generate figure and axes using Cartopy projection
 projection = ccrs.PlateCarree()
-fig, ax = plt.subplots(3,
-                       1,
-                       constrained_layout=True,
-                       subplot_kw={"projection": projection})
+fig, ax = plt.subplots(
+    3, 1, constrained_layout=True, subplot_kw={"projection": projection}
+)
 
 # Set figure size (width, height) in inches
 fig.set_size_inches((6, 9.6))
 
 # Add continents
-continents = cartopy.feature.NaturalEarthFeature(name="coastline",
-                                                 category="physical",
-                                                 scale="50m",
-                                                 edgecolor="None",
-                                                 facecolor="lightgray")
+continents = cartopy.feature.NaturalEarthFeature(
+    name="coastline",
+    category="physical",
+    scale="50m",
+    edgecolor="None",
+    facecolor="lightgray",
+)
 [axes.add_feature(continents) for axes in ax.flat]
 
 # Define the contour levels
@@ -83,11 +84,13 @@ hdl = ds.U.plot.contour(
 ax[0].clabel(hdl, np.arange(0, 32, 8), fontsize="small", fmt="%.0f")
 
 # Use geocat.viz.util convenience function to add left and right title to the plot axes.
-gv.set_titles_and_labels(ax[0],
-                         lefttitle="Zonal Wind",
-                         lefttitlefontsize=12,
-                         righttitle=ds.U.units,
-                         righttitlefontsize=12)
+gv.set_titles_and_labels(
+    ax[0],
+    lefttitle="Zonal Wind",
+    lefttitlefontsize=12,
+    righttitle=ds.U.units,
+    righttitlefontsize=12,
+)
 
 # Panel 2 (Subplot 2)
 # Contour-plot V data (for borderlines)
@@ -97,35 +100,41 @@ hdl = ds.V.plot.contour(x="lon", y="lat", ax=ax[1], **kwargs)
 ax[1].clabel(hdl, [0], fontsize="small", fmt="%.0f")
 
 # Use geocat.viz.util convenience function to add left and right title to the plot axes.
-gv.set_titles_and_labels(ax[1],
-                         lefttitle="Meridional Wind",
-                         lefttitlefontsize=12,
-                         righttitle=ds.V.units,
-                         righttitlefontsize=12)
+gv.set_titles_and_labels(
+    ax[1],
+    lefttitle="Meridional Wind",
+    lefttitlefontsize=12,
+    righttitle=ds.V.units,
+    righttitlefontsize=12,
+)
 
 # Panel 3 (Subplot 3)
 # Draw arrows
 # xarray doesn't have a quiver method (yet)
 # the NCL code plots every 4th value in lat, lon; this is the equivalent of u(::4, ::4)
 subset = ds.isel(lat=slice(None, None, 4), lon=slice(None, None, 4))
-ax[2].quiver(subset.lon,
-             subset.lat,
-             subset.U,
-             subset.V,
-             width=0.0015,
-             transform=projection,
-             zorder=2,
-             scale=1100)
+ax[2].quiver(
+    subset.lon,
+    subset.lat,
+    subset.U,
+    subset.V,
+    width=0.0015,
+    transform=projection,
+    zorder=2,
+    scale=1100,
+)
 
 # Set axes title
 ax[2].set_title("Vector Wind", loc="left", y=1.05)
 
 # Use geocat.viz.util convenience function to add left and right title to the plot axes.
-gv.set_titles_and_labels(ax[2],
-                         lefttitle="Vector Wind",
-                         lefttitlefontsize=12,
-                         righttitle=ds.U.units,
-                         righttitlefontsize=12)
+gv.set_titles_and_labels(
+    ax[2],
+    lefttitle="Vector Wind",
+    lefttitlefontsize=12,
+    righttitle=ds.U.units,
+    righttitlefontsize=12,
+)
 
 # cartopy axes require this to be manual
 ax[2].set_xticks(kwargs["xticks"])

--- a/Gallery/Panels/NCL_panel_10.py
+++ b/Gallery/Panels/NCL_panel_10.py
@@ -43,95 +43,95 @@ chi = ds.CHI
 chi = chi / scale
 
 # Calculate zonal mean
-with warnings.catch_warnings(
-):  # This is not needed but is suppressing a warning thrown by numpy checking for NaN values
+with warnings.catch_warnings():  # This is not needed but is suppressing a warning thrown by numpy checking for NaN values
     warnings.simplefilter("ignore")
     mean = chi.mean(dim='lon')
 
 ###############################################################################
 # Create Single Plot:
-fig, (ax1, ax2) = plt.subplots(nrows=1,
-                               ncols=2,
-                               sharey=True,
-                               figsize=(12, 9),
-                               gridspec_kw=dict(wspace=0,
-                                                width_ratios=[0.75, 0.25],
-                                                left=0.15,
-                                                right=0.85,
-                                                top=0.85,
-                                                bottom=0.15))
+fig, (ax1, ax2) = plt.subplots(
+    nrows=1,
+    ncols=2,
+    sharey=True,
+    figsize=(12, 9),
+    gridspec_kw=dict(
+        wspace=0,
+        width_ratios=[0.75, 0.25],
+        left=0.15,
+        right=0.85,
+        top=0.85,
+        bottom=0.15,
+    ),
+)
 # Create inset axes for color bar
-cax1 = inset_axes(ax1,
-                  width='100%',
-                  height='7%',
-                  loc='lower left',
-                  bbox_to_anchor=(0, -0.15, 1, 1),
-                  bbox_transform=ax1.transAxes,
-                  borderpad=0)
+cax1 = inset_axes(
+    ax1,
+    width='100%',
+    height='7%',
+    loc='lower left',
+    bbox_to_anchor=(0, -0.15, 1, 1),
+    bbox_transform=ax1.transAxes,
+    borderpad=0,
+)
 
 # Draw contour lines
-ax1.contour(lon,
-            times,
-            chi,
-            levels=np.arange(-12, 13, 2),
-            colors='black',
-            linestyles='solid',
-            linewidths=.5)
+ax1.contour(
+    lon,
+    times,
+    chi,
+    levels=np.arange(-12, 13, 2),
+    colors='black',
+    linestyles='solid',
+    linewidths=0.5,
+)
 
 # Draw filled contours
-cf = ax1.contourf(lon,
-                  times,
-                  chi,
-                  levels=np.arange(-12, 13, 2),
-                  cmap=cmaps.BlWhRe)
+cf = ax1.contourf(lon, times, chi, levels=np.arange(-12, 13, 2), cmap=cmaps.BlWhRe)
 
 # Draw colorbar with larger tick labels
-cbar = plt.colorbar(cf,
-                    cax=cax1,
-                    orientation='horizontal',
-                    ticks=np.arange(-10, 11, 2))
+cbar = plt.colorbar(cf, cax=cax1, orientation='horizontal', ticks=np.arange(-10, 11, 2))
 cbar.ax.tick_params(labelsize=12)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values
-gv.set_axes_limits_and_ticks(ax1,
-                             xlim=[100, 220],
-                             ylim=[0, 1.55 * 1e16],
-                             xticks=[135, 180],
-                             yticks=np.linspace(0, 1.55 * 1e16, 7),
-                             xticklabels=['135E', '180'],
-                             yticklabels=np.arange(0, 181, 30))
+gv.set_axes_limits_and_ticks(
+    ax1,
+    xlim=[100, 220],
+    ylim=[0, 1.55 * 1e16],
+    xticks=[135, 180],
+    yticks=np.linspace(0, 1.55 * 1e16, 7),
+    xticklabels=['135E', '180'],
+    yticklabels=np.arange(0, 181, 30),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax1,
-                         x_minor_per_major=3,
-                         y_minor_per_major=3,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax1, x_minor_per_major=3, y_minor_per_major=3, labelsize=12)
 
 # Remove tick marks on right side of ax1
 ax1.tick_params('y', which='both', right=False)
 
 # Use geocat.viz.util convenience function to add titles
-gv.set_titles_and_labels(ax1,
-                         maintitle="Pacific Region",
-                         lefttitle="Velocity Potential",
-                         righttitle="m2/s",
-                         ylabel="elapsed time")
+gv.set_titles_and_labels(
+    ax1,
+    maintitle="Pacific Region",
+    lefttitle="Velocity Potential",
+    righttitle="m2/s",
+    ylabel="elapsed time",
+)
 
 # Format axes for zonal average plot
 # Use geocat.viz.util convenience function to set axes limits & tick values
-gv.set_axes_limits_and_ticks(ax2,
-                             xlim=[-0.6, 0.9],
-                             ylim=[0, 1.55 * 1e16],
-                             xticks=np.arange(-0.3, 0.7, 0.3),
-                             yticks=np.linspace(0, 1.55 * 1e16, 7),
-                             xticklabels=['-0.30', '', '0.30', ''],
-                             yticklabels=np.arange(0, 181, 30))
+gv.set_axes_limits_and_ticks(
+    ax2,
+    xlim=[-0.6, 0.9],
+    ylim=[0, 1.55 * 1e16],
+    xticks=np.arange(-0.3, 0.7, 0.3),
+    yticks=np.linspace(0, 1.55 * 1e16, 7),
+    xticklabels=['-0.30', '', '0.30', ''],
+    yticklabels=np.arange(0, 181, 30),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax2,
-                         x_minor_per_major=1,
-                         y_minor_per_major=3,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax2, x_minor_per_major=1, y_minor_per_major=3, labelsize=12)
 
 # Remove tick marks on left side of ax2
 ax2.tick_params('y', which='both', left=False)
@@ -154,20 +154,20 @@ def make_subplot(fig, gridspec, xlim):
     ax2 = fig.add_subplot(gridspec[1])
 
     # Draw contour lines
-    ax1.contour(lon,
-                times,
-                chi,
-                levels=np.arange(-12, 13, 2),
-                colors='black',
-                linestyles='solid',
-                linewidths=.5)
+    ax1.contour(
+        lon,
+        times,
+        chi,
+        levels=np.arange(-12, 13, 2),
+        colors='black',
+        linestyles='solid',
+        linewidths=0.5,
+    )
 
     # Draw filled contours, save the mappable to create colorbar later
-    color_mappable = ax1.contourf(lon,
-                                  times,
-                                  chi,
-                                  levels=np.arange(-12, 13, 2),
-                                  cmap=cmaps.BlWhRe)
+    color_mappable = ax1.contourf(
+        lon, times, chi, levels=np.arange(-12, 13, 2), cmap=cmaps.BlWhRe
+    )
 
     # Use geocat.viz.util convenience function to add longitude tick labels
     gv.add_lat_lon_ticklabels(ax1)
@@ -176,44 +176,46 @@ def make_subplot(fig, gridspec, xlim):
     ax1.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
     # Use geocat.viz.util convenience function to set axes limits & tick values
-    gv.set_axes_limits_and_ticks(ax1,
-                                 xlim=xlim,
-                                 ylim=[0, 1.55 * 1e16],
-                                 xticks=np.arange(xlim[0], xlim[1], 30),
-                                 yticks=np.linspace(0, 1.55 * 1e16, 7),
-                                 yticklabels=[])
+    gv.set_axes_limits_and_ticks(
+        ax1,
+        xlim=xlim,
+        ylim=[0, 1.55 * 1e16],
+        xticks=np.arange(xlim[0], xlim[1], 30),
+        yticks=np.linspace(0, 1.55 * 1e16, 7),
+        yticklabels=[],
+    )
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
-    gv.add_major_minor_ticks(ax1,
-                             x_minor_per_major=2,
-                             y_minor_per_major=3,
-                             labelsize=10)
+    gv.add_major_minor_ticks(
+        ax1, x_minor_per_major=2, y_minor_per_major=3, labelsize=10
+    )
 
     # Remove tick marks on right side of ax1
     ax1.tick_params('y', which='both', right=False)
 
     # Use geocat.viz.util convenience function to add titles
-    gv.set_titles_and_labels(ax1,
-                             lefttitle="Velocity Potential",
-                             righttitle="m2/s",
-                             lefttitlefontsize=10,
-                             righttitlefontsize=10)
+    gv.set_titles_and_labels(
+        ax1,
+        lefttitle="Velocity Potential",
+        righttitle="m2/s",
+        lefttitlefontsize=10,
+        righttitlefontsize=10,
+    )
 
     # Format axes for zonal average plot
     # Use geocat.viz.util convenience function to set axes limits & tick values
-    gv.set_axes_limits_and_ticks(ax2,
-                                 xlim=[-0.6, 0.9],
-                                 ylim=[0, 1.55 * 1e16],
-                                 xticks=np.arange(-0.3, 0.7, 0.3),
-                                 yticks=np.linspace(0, 1.55 * 1e16, 7),
-                                 xticklabels=['-0.30', '', '0.30', ''],
-                                 yticklabels=[])
+    gv.set_axes_limits_and_ticks(
+        ax2,
+        xlim=[-0.6, 0.9],
+        ylim=[0, 1.55 * 1e16],
+        xticks=np.arange(-0.3, 0.7, 0.3),
+        yticks=np.linspace(0, 1.55 * 1e16, 7),
+        xticklabels=['-0.30', '', '0.30', ''],
+        yticklabels=[],
+    )
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
-    gv.add_major_minor_ticks(ax2,
-                             x_minor_per_major=1,
-                             y_minor_per_major=3,
-                             labelsize=8)
+    gv.add_major_minor_ticks(ax2, x_minor_per_major=1, y_minor_per_major=3, labelsize=8)
 
     # Remove tick marks on left side of ax2
     ax2.tick_params('y', which='both', left=False)
@@ -231,11 +233,9 @@ def make_subplot(fig, gridspec, xlim):
 fig = plt.figure(figsize=(10, 10))
 
 # Create a three by two grid to hold the four plots and the colorbar
-outer_grid = gridspec.GridSpec(3,
-                               2,
-                               figure=fig,
-                               hspace=0.35,
-                               height_ratios=[0.475, 0.475, 0.05])
+outer_grid = gridspec.GridSpec(
+    3, 2, figure=fig, hspace=0.35, height_ratios=[0.475, 0.475, 0.05]
+)
 
 # Create an array to hold the internal gridspecs
 inner_grids = np.empty(4, dtype=gridspec.GridSpec)
@@ -243,7 +243,8 @@ inner_grids = np.empty(4, dtype=gridspec.GridSpec)
 # Create the gridspecs for each of the four plots
 for i in range(0, 4):
     inner_grids[i] = gridspec.GridSpecFromSubplotSpec(
-        1, 2, subplot_spec=outer_grid[i], wspace=0, width_ratios=[0.75, 0.25])
+        1, 2, subplot_spec=outer_grid[i], wspace=0, width_ratios=[0.75, 0.25]
+    )
 make_subplot(fig, inner_grids[0], [0, 90])
 make_subplot(fig, inner_grids[1], [90, 180])
 make_subplot(fig, inner_grids[2], [180, 270])
@@ -251,11 +252,13 @@ color_mappable = make_subplot(fig, inner_grids[3], [270, 360])
 
 # Create axes for colorbar and then draw colorbar
 cax = fig.add_subplot(outer_grid[2, :])
-plt.colorbar(color_mappable,
-             cax=cax,
-             ticks=np.arange(-10, 12, 2),
-             orientation='horizontal',
-             drawedges=True)
+plt.colorbar(
+    color_mappable,
+    cax=cax,
+    ticks=np.arange(-10, 12, 2),
+    orientation='horizontal',
+    drawedges=True,
+)
 
 # Add figure title
 fig.suptitle(filename, fontsize=18, y=0.95)

--- a/Gallery/Panels/NCL_panel_11.py
+++ b/Gallery/Panels/NCL_panel_11.py
@@ -63,13 +63,15 @@ def contour_plot(fig):
         h_boundary = l_boundary + 80
 
         # Draw contour lines at levels [-10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10]
-        cs = axis.contour(lon,
-                          times,
-                          chi,
-                          levels=np.arange(-10, 12, 2),
-                          colors='black',
-                          linestyles="-",
-                          linewidths=.8)
+        cs = axis.contour(
+            lon,
+            times,
+            chi,
+            levels=np.arange(-10, 12, 2),
+            colors='black',
+            linestyles="-",
+            linewidths=0.8,
+        )
 
         # Label the contour levels -4, 0, and 4
         axis.clabel(cs, fmt='%d', levels=[-4, 0, 4], fontsize=7)
@@ -93,44 +95,46 @@ def contour_plot(fig):
             x_tick_labels = ["90E", "135E"]
 
         # Use geocat.viz.util convenience function to add titles
-        gv.set_axes_limits_and_ticks(axis,
-                                     xlim=[l_boundary, h_boundary],
-                                     ylim=[0, 1.55 * 1e16],
-                                     xticks=x_ticks,
-                                     yticks=np.linspace(0, 1.55 * 1e16, 7),
-                                     xticklabels=x_tick_labels,
-                                     yticklabels=np.linspace(0,
-                                                             180,
-                                                             7,
-                                                             dtype='int'))
+        gv.set_axes_limits_and_ticks(
+            axis,
+            xlim=[l_boundary, h_boundary],
+            ylim=[0, 1.55 * 1e16],
+            xticks=x_ticks,
+            yticks=np.linspace(0, 1.55 * 1e16, 7),
+            xticklabels=x_tick_labels,
+            yticklabels=np.linspace(0, 180, 7, dtype='int'),
+        )
 
         # Use geocat.viz.util convenience function to add minor and major tick lines
-        gv.add_major_minor_ticks(axis,
-                                 x_minor_per_major=3,
-                                 y_minor_per_major=3,
-                                 labelsize=8)
+        gv.add_major_minor_ticks(
+            axis, x_minor_per_major=3, y_minor_per_major=3, labelsize=8
+        )
 
         # Use geocat.viz.util convenience function to add titles
-        gv.set_titles_and_labels(axis,
-                                 maintitle="Pacific Region",
-                                 maintitlefontsize=9,
-                                 lefttitle="Velocity Potential",
-                                 lefttitlefontsize=8,
-                                 righttitle="m2/s",
-                                 righttitlefontsize=8,
-                                 ylabel="elapsed time",
-                                 labelfontsize=9)
+        gv.set_titles_and_labels(
+            axis,
+            maintitle="Pacific Region",
+            maintitlefontsize=9,
+            lefttitle="Velocity Potential",
+            lefttitlefontsize=8,
+            righttitle="m2/s",
+            righttitlefontsize=8,
+            ylabel="elapsed time",
+            labelfontsize=9,
+        )
 
         # Add lower text box
-        axis.text(1,
-                  -0.12,
-                  "CONTOUR FROM -10 TO 10 BY 2",
-                  horizontalalignment='right',
-                  transform=axis.transAxes,
-                  fontsize=5,
-                  bbox=dict(boxstyle='square, pad=0.25',
-                            facecolor='white',
-                            edgecolor='black'))
+        axis.text(
+            1,
+            -0.12,
+            "CONTOUR FROM -10 TO 10 BY 2",
+            horizontalalignment='right',
+            transform=axis.transAxes,
+            fontsize=5,
+            bbox=dict(
+                boxstyle='square, pad=0.25', facecolor='white', edgecolor='black'
+            ),
+        )
 
         # Change the size of the tick marks for both axes
         axis.tick_params('both', size=4)

--- a/Gallery/Panels/NCL_panel_13.py
+++ b/Gallery/Panels/NCL_panel_13.py
@@ -56,10 +56,7 @@ magnitude = np.sqrt(U.data**2 + V.data**2)
 
 # Create subplots and specify their projections
 projection = ccrs.PlateCarree()
-fig, axs = plt.subplots(2,
-                        1,
-                        figsize=(7, 10),
-                        subplot_kw={"projection": projection})
+fig, axs = plt.subplots(2, 1, figsize=(7, 10), subplot_kw={"projection": projection})
 plt.tight_layout(pad=4, h_pad=7)
 
 # Add coastlines, the zorder keyword specifies the order in which the elements
@@ -68,16 +65,20 @@ axs[0].coastlines(linewidth=0.5, zorder=1)
 axs[1].coastlines(linewidth=0.5, zorder=1)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(axs[0],
-                             xlim=[-180, 180],
-                             ylim=[-90, 90],
-                             xticks=np.arange(-180, 181, 30),
-                             yticks=np.arange(-90, 91, 30))
-gv.set_axes_limits_and_ticks(axs[1],
-                             xlim=[-180, 180],
-                             ylim=[-90, 90],
-                             xticks=np.arange(-180, 181, 30),
-                             yticks=np.arange(-90, 91, 30))
+gv.set_axes_limits_and_ticks(
+    axs[0],
+    xlim=[-180, 180],
+    ylim=[-90, 90],
+    xticks=np.arange(-180, 181, 30),
+    yticks=np.arange(-90, 91, 30),
+)
+gv.set_axes_limits_and_ticks(
+    axs[1],
+    xlim=[-180, 180],
+    ylim=[-90, 90],
+    xticks=np.arange(-180, 181, 30),
+    yticks=np.arange(-90, 91, 30),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(axs[0])
@@ -94,16 +95,20 @@ axs[1].yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 axs[1].xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(axs[0],
-                         lefttitle='Speed',
-                         lefttitlefontsize=10,
-                         righttitle=U.units,
-                         righttitlefontsize=10)
-gv.set_titles_and_labels(axs[1],
-                         lefttitle='Wind',
-                         lefttitlefontsize=10,
-                         righttitle=U.units,
-                         righttitlefontsize=10)
+gv.set_titles_and_labels(
+    axs[0],
+    lefttitle='Speed',
+    lefttitlefontsize=10,
+    righttitle=U.units,
+    righttitlefontsize=10,
+)
+gv.set_titles_and_labels(
+    axs[1],
+    lefttitle='Wind',
+    lefttitlefontsize=10,
+    righttitle=U.units,
+    righttitlefontsize=10,
+)
 
 # Load in colormap
 newcmap = cmaps.gui_default
@@ -115,84 +120,84 @@ wind_levels = np.arange(-16, 44, 4)
 wind_ticks = np.arange(-12, 40, 4)
 
 # Plot filled contours
-speed = axs[0].contourf(U['lon'],
-                        U['lat'],
-                        magnitude,
-                        levels=speed_levels,
-                        cmap=newcmap,
-                        zorder=0)
-wind = axs[1].contourf(U['lon'],
-                       U['lat'],
-                       U.data,
-                       levels=wind_levels,
-                       cmap=newcmap,
-                       zorder=0)
+speed = axs[0].contourf(
+    U['lon'], U['lat'], magnitude, levels=speed_levels, cmap=newcmap, zorder=0
+)
+wind = axs[1].contourf(
+    U['lon'], U['lat'], U.data, levels=wind_levels, cmap=newcmap, zorder=0
+)
 
 # Create color bars
-speed_cbar = plt.colorbar(speed,
-                          ax=axs[0],
-                          orientation='horizontal',
-                          ticks=speed_ticks,
-                          shrink=0.8,
-                          drawedges=True,
-                          pad=0.1)
-plt.colorbar(wind,
-             ax=axs[1],
-             orientation='horizontal',
-             ticks=wind_ticks,
-             shrink=0.8,
-             drawedges=True,
-             pad=0.1)
+speed_cbar = plt.colorbar(
+    speed,
+    ax=axs[0],
+    orientation='horizontal',
+    ticks=speed_ticks,
+    shrink=0.8,
+    drawedges=True,
+    pad=0.1,
+)
+plt.colorbar(
+    wind,
+    ax=axs[1],
+    orientation='horizontal',
+    ticks=wind_ticks,
+    shrink=0.8,
+    drawedges=True,
+    pad=0.1,
+)
 # Remove trailing zeros from speed color bar tick labels
 speed_cbar.ax.xaxis.set_major_formatter(FormatStrFormatter('%g'))
 
 # Plotting vector field
-quiver_speed = axs[0].quiver(U['lon'],
-                             U['lat'],
-                             U.data,
-                             V.data,
-                             scale=400,
-                             width=0.002,
-                             headwidth=6,
-                             headlength=7,
-                             zorder=2)
-quiver_wind = axs[1].quiver(U['lon'],
-                            U['lat'],
-                            U.data,
-                            V.data,
-                            scale=400,
-                            width=0.002,
-                            headwidth=6,
-                            headlength=7,
-                            zorder=2)
+quiver_speed = axs[0].quiver(
+    U['lon'],
+    U['lat'],
+    U.data,
+    V.data,
+    scale=400,
+    width=0.002,
+    headwidth=6,
+    headlength=7,
+    zorder=2,
+)
+quiver_wind = axs[1].quiver(
+    U['lon'],
+    U['lat'],
+    U.data,
+    V.data,
+    scale=400,
+    width=0.002,
+    headwidth=6,
+    headlength=7,
+    zorder=2,
+)
 
 # Add white box to go behind reference vector
 axs[0].add_patch(
-    mpatches.Rectangle(xy=[0.775, 0],
-                       width=0.225,
-                       height=0.2,
-                       facecolor='white',
-                       transform=axs[0].transAxes,
-                       zorder=2))
+    mpatches.Rectangle(
+        xy=[0.775, 0],
+        width=0.225,
+        height=0.2,
+        facecolor='white',
+        transform=axs[0].transAxes,
+        zorder=2,
+    )
+)
 axs[1].add_patch(
-    mpatches.Rectangle(xy=[0.775, 0],
-                       width=0.225,
-                       height=0.2,
-                       facecolor='white',
-                       transform=axs[1].transAxes,
-                       zorder=2))
+    mpatches.Rectangle(
+        xy=[0.775, 0],
+        width=0.225,
+        height=0.2,
+        facecolor='white',
+        transform=axs[1].transAxes,
+        zorder=2,
+    )
+)
 # Add reference vector and label
 axs[0].quiverkey(quiver_speed, 0.8875, 0.1, 20, 20, zorder=2)
 axs[1].quiverkey(quiver_wind, 0.8875, 0.1, 20, 20, zorder=2)
-axs[0].text(0.785,
-            0.025,
-            "Reference Vector",
-            transform=axs[0].transAxes,
-            zorder=2)
-axs[1].text(0.785,
-            0.025,
-            "Reference Vector",
-            transform=axs[1].transAxes,
-            zorder=2)
+axs[0].text(0.785, 0.025, "Reference Vector", transform=axs[0].transAxes, zorder=2)
+axs[1].text(0.785, 0.025, "Reference Vector", transform=axs[1].transAxes, zorder=2)
 
 plt.show()

--- a/Gallery/Panels/NCL_panel_14.py
+++ b/Gallery/Panels/NCL_panel_14.py
@@ -29,8 +29,7 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/h_avg_Y0191_D000.00.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/h_avg_Y0191_D000.00.nc"), decode_times=False)
 # Ensure longitudes range from 0 to 360 degrees
 T = gv.xr_add_cyclic_longitudes(ds.T, "lon_t")
 
@@ -68,26 +67,24 @@ ax1.xaxis.tick_top()
 ax2.xaxis.tick_top()
 
 # Use geocat.viz.util convenience function to add minor and major ticks
-gv.add_major_minor_ticks(ax1,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=14)
-gv.add_major_minor_ticks(ax2,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax1, x_minor_per_major=4, y_minor_per_major=5, labelsize=14)
+gv.add_major_minor_ticks(ax2, x_minor_per_major=4, y_minor_per_major=5, labelsize=14)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax=ax1,
-                             xlim=(0, 24),
-                             ylim=(500000, 0),
-                             xticks=np.arange(0, 28, 4),
-                             yticks=np.arange(0, 600000, 100000))
-gv.set_axes_limits_and_ticks(ax=ax2,
-                             xlim=(0, 21),
-                             ylim=(500000, 0),
-                             xticks=np.arange(0, 24, 3),
-                             yticks=np.arange(0, 600000, 100000))
+gv.set_axes_limits_and_ticks(
+    ax=ax1,
+    xlim=(0, 24),
+    ylim=(500000, 0),
+    xticks=np.arange(0, 28, 4),
+    yticks=np.arange(0, 600000, 100000),
+)
+gv.set_axes_limits_and_ticks(
+    ax=ax2,
+    xlim=(0, 21),
+    ylim=(500000, 0),
+    xticks=np.arange(0, 24, 3),
+    yticks=np.arange(0, 600000, 100000),
+)
 
 # Remove ticklabels on Y axis for panel 2 (ax2)
 ax2.yaxis.set_ticklabels([])
@@ -107,18 +104,14 @@ levels = np.arange(0, 28, 2)
 newcmp = cmaps.BlAqGrYeOrRe
 
 # Panel 3: Contourf-plot data
-T3.plot.contourf(ax=ax3,
-                 levels=levels,
-                 cmap=newcmp,
-                 add_colorbar=False,
-                 add_labels=False)
+T3.plot.contourf(
+    ax=ax3, levels=levels, cmap=newcmp, add_colorbar=False, add_labels=False
+)
 
 # Panel 4: Contourf-plot data
-colors = T4.plot.contourf(ax=ax4,
-                          levels=levels,
-                          cmap=newcmp,
-                          add_colorbar=False,
-                          add_labels=False)
+colors = T4.plot.contourf(
+    ax=ax4, levels=levels, cmap=newcmp, add_colorbar=False, add_labels=False
+)
 
 
 # Define functions for axis scales
@@ -164,24 +157,28 @@ for axes in [ax3, ax4]:
     axes.set_ylim(axes.get_ylim()[::-1])
 
     # Set ticks to match styles of the original NCL plot
-    axes.tick_params("both",
-                     length=8,
-                     width=0.9,
-                     which="major",
-                     bottom=True,
-                     top=True,
-                     left=True,
-                     right=True,
-                     labelsize=14)
-    axes.tick_params("both",
-                     length=4,
-                     width=0.4,
-                     which="minor",
-                     bottom=True,
-                     top=True,
-                     left=True,
-                     right=True,
-                     labelsize=14)
+    axes.tick_params(
+        "both",
+        length=8,
+        width=0.9,
+        which="major",
+        bottom=True,
+        top=True,
+        left=True,
+        right=True,
+        labelsize=14,
+    )
+    axes.tick_params(
+        "both",
+        length=4,
+        width=0.4,
+        which="minor",
+        bottom=True,
+        top=True,
+        left=True,
+        right=True,
+        labelsize=14,
+    )
 
 # Remove ticklabels on Y axis for panel 4
 ax4.yaxis.set_ticklabels([])
@@ -191,16 +188,18 @@ ax4.yaxis.set_ticklabels([])
 gv.set_titles_and_labels(ax3, ylabel=T.z_t.long_name, labelfontsize=16)
 
 # Add colorbar
-cb = fig.colorbar(colors,
-                  ax=[ax1, ax2, ax3, ax4],
-                  orientation='horizontal',
-                  drawedges=True,
-                  extendrect=True,
-                  aspect=30,
-                  shrink=0.9,
-                  extendfrac='auto',
-                  pad=0.02,
-                  ticks=levels)
+cb = fig.colorbar(
+    colors,
+    ax=[ax1, ax2, ax3, ax4],
+    orientation='horizontal',
+    drawedges=True,
+    extendrect=True,
+    aspect=30,
+    shrink=0.9,
+    extendfrac='auto',
+    pad=0.02,
+    ticks=levels,
+)
 
 # Set colorbar ticklabel fontsize and tick length
 cb.ax.tick_params(labelsize=14, length=0)

--- a/Gallery/Panels/NCL_panel_15.py
+++ b/Gallery/Panels/NCL_panel_15.py
@@ -29,8 +29,7 @@ import geocat.viz as gv
 
 # Open a netCDF data file using xarray default engine and load the data into
 # xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/h_avg_Y0191_D000.00.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/h_avg_Y0191_D000.00.nc"), decode_times=False)
 
 # Ensure longitudes range from 0 to 360 degrees
 t = gv.xr_add_cyclic_longitudes(ds.T, "lon_t")
@@ -55,13 +54,15 @@ ax1 = fig.add_subplot(grid[0], projection=proj)  # upper cell of grid
 ax2 = fig.add_subplot(grid[1], projection=proj)  # middle cell of grid
 ax3 = fig.add_subplot(grid[2], projection=proj)  # lower cell of grid
 
-for (ax, title) in [(ax1, 'level 0'), (ax2, 'level 1'), (ax3, 'level 6')]:
+for ax, title in [(ax1, 'level 0'), (ax2, 'level 1'), (ax3, 'level 6')]:
     # Use geocat.viz.util convenience function to set axes tick values
-    gv.set_axes_limits_and_ticks(ax=ax,
-                                 xlim=(-180, 180),
-                                 ylim=(-90, 90),
-                                 xticks=np.linspace(-180, 180, 13),
-                                 yticks=np.linspace(-90, 90, 7))
+    gv.set_axes_limits_and_ticks(
+        ax=ax,
+        xlim=(-180, 180),
+        ylim=(-90, 90),
+        xticks=np.linspace(-180, 180, 13),
+        yticks=np.linspace(-90, 90, 7),
+    )
 
     # Use geocat.viz.util convenience function to make plots look like NCL
     # plots by using latitude, longitude tick labels
@@ -78,11 +79,13 @@ for (ax, title) in [(ax1, 'level 0'), (ax2, 'level 1'), (ax3, 'level 6')]:
     ax.coastlines(linewidth=0.5)
 
     # Use geocat.viz.util convenience function to set titles
-    gv.set_titles_and_labels(ax,
-                             lefttitle=t_1.long_name,
-                             righttitle=t_1.units,
-                             lefttitlefontsize=10,
-                             righttitlefontsize=10)
+    gv.set_titles_and_labels(
+        ax,
+        lefttitle=t_1.long_name,
+        righttitle=t_1.units,
+        lefttitlefontsize=10,
+        righttitlefontsize=10,
+    )
     # Add center title
     ax.set_title(title, loc='center', y=1.04, fontsize=10)
 
@@ -90,42 +93,52 @@ for (ax, title) in [(ax1, 'level 0'), (ax2, 'level 1'), (ax3, 'level 6')]:
 cmap = 'magma'
 
 # Plot data
-C = ax1.contourf(t_1['lon_t'],
-                 t_1['lat_t'],
-                 t_1.data,
-                 levels=np.arange(0, 30, 2),
-                 cmap=cmap,
-                 extend='both')
-ax2.contourf(t_2['lon_t'],
-             t_2['lat_t'],
-             t_2.data,
-             levels=np.arange(0, 30, 2),
-             cmap=cmap,
-             extend='both')
-C_2 = ax3.contourf(t_6['lon_t'],
-                   t_6['lat_t'],
-                   t_6.data,
-                   levels=np.arange(0, 22, 2),
-                   cmap=cmap,
-                   extend='both')
+C = ax1.contourf(
+    t_1['lon_t'],
+    t_1['lat_t'],
+    t_1.data,
+    levels=np.arange(0, 30, 2),
+    cmap=cmap,
+    extend='both',
+)
+ax2.contourf(
+    t_2['lon_t'],
+    t_2['lat_t'],
+    t_2.data,
+    levels=np.arange(0, 30, 2),
+    cmap=cmap,
+    extend='both',
+)
+C_2 = ax3.contourf(
+    t_6['lon_t'],
+    t_6['lat_t'],
+    t_6.data,
+    levels=np.arange(0, 22, 2),
+    cmap=cmap,
+    extend='both',
+)
 
 # Add colorbars
 # By specifying two axes for `ax` the colorbar will span both of them
-plt.colorbar(C,
-             ax=[ax1, ax2],
-             ticks=range(0, 30, 2),
-             extendrect=True,
-             extendfrac='auto',
-             shrink=0.85,
-             aspect=13,
-             drawedges=True)
-plt.colorbar(C_2,
-             ax=ax3,
-             ticks=range(0, 22, 2),
-             extendrect=True,
-             extendfrac='auto',
-             shrink=0.85,
-             aspect=5.5,
-             drawedges=True)
+plt.colorbar(
+    C,
+    ax=[ax1, ax2],
+    ticks=range(0, 30, 2),
+    extendrect=True,
+    extendfrac='auto',
+    shrink=0.85,
+    aspect=13,
+    drawedges=True,
+)
+plt.colorbar(
+    C_2,
+    ax=ax3,
+    ticks=range(0, 22, 2),
+    extendrect=True,
+    extendfrac='auto',
+    shrink=0.85,
+    aspect=5.5,
+    drawedges=True,
+)
 
 plt.show()

--- a/Gallery/Panels/NCL_panel_18.py
+++ b/Gallery/Panels/NCL_panel_18.py
@@ -30,8 +30,9 @@ import geocat.viz as gv
 
 # Open a netCDF data file using xarray default engine and load the data into
 # xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/TS.cam3.toga_ENS.1950-2000.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(
+    gdf.get("netcdf_files/TS.cam3.toga_ENS.1950-2000.nc"), decode_times=False
+)
 
 # Fix the artifact of not-shown-data around 0 and 360-degree longitudes
 TS = gv.xr_add_cyclic_longitudes(ds.TS, "lon")
@@ -48,7 +49,7 @@ diff = yr1 - yr0
 ###############################################################################
 # Print out a formatted message; note the starting 'f' for the string.
 
-print(f" min= { diff.min().data }    max={ diff.min().data }")
+print(f" min= {diff.min().data}    max={diff.min().data}")
 
 ##############################################################################
 # Plot:
@@ -65,14 +66,19 @@ ax2 = fig.add_subplot(grid[1], projection=proj)  # middle cell of grid
 ax3 = fig.add_subplot(grid[2], projection=proj)  # lower cell of grid
 
 # Customize plots to match NCL standard format
-for (ax, title) in [(ax1, 'Jan. 1999'), (ax2, 'Jan. 1951'),
-                    (ax3, 'Difference: Jan 1999 - Jan 1951')]:
+for ax, title in [
+    (ax1, 'Jan. 1999'),
+    (ax2, 'Jan. 1951'),
+    (ax3, 'Difference: Jan 1999 - Jan 1951'),
+]:
     # Use geocat.viz.util convenience function to set axes tick values
-    gv.set_axes_limits_and_ticks(ax=ax,
-                                 xlim=(-180, 180),
-                                 ylim=(-90, 90),
-                                 xticks=np.linspace(-180, 180, 13),
-                                 yticks=np.linspace(-90, 90, 7))
+    gv.set_axes_limits_and_ticks(
+        ax=ax,
+        xlim=(-180, 180),
+        ylim=(-90, 90),
+        xticks=np.linspace(-180, 180, 13),
+        yticks=np.linspace(-90, 90, 7),
+    )
 
     # Use geocat.viz.util convenience function to make plots look like NCL
     # plots by using latitude, longitude tick labels
@@ -89,11 +95,9 @@ for (ax, title) in [(ax1, 'Jan. 1999'), (ax2, 'Jan. 1951'),
     ax.coastlines(linewidth=0.5)
 
     # Use geocat.viz.util convenience function to set titles
-    gv.set_titles_and_labels(ax,
-                             lefttitle='TS',
-                             righttitle='°C',
-                             lefttitlefontsize=10,
-                             righttitlefontsize=10)
+    gv.set_titles_and_labels(
+        ax, lefttitle='TS', righttitle='°C', lefttitlefontsize=10, righttitlefontsize=10
+    )
     # Add center title
     ax.set_title(title, loc='center', y=1.04, fontsize=10)
 
@@ -102,44 +106,54 @@ newcmp = 'magma'
 newcmp2 = cmaps.BlueWhiteOrangeRed
 
 # Plot data
-C = ax1.contourf(yr1['lon'],
-                 yr1['lat'],
-                 yr1.data,
-                 levels=np.arange(-3, 28, 1.5),
-                 cmap=newcmp,
-                 extend='both')
-ax2.contourf(yr0['lon'],
-             yr0['lat'],
-             yr0.data,
-             levels=np.arange(-3, 28, 1.5),
-             cmap=newcmp,
-             extend='both')
-C_2 = ax3.contourf(diff['lon'],
-                   diff['lat'],
-                   diff.data,
-                   levels=np.arange(-4.0, 5, 1.0),
-                   cmap=newcmp2,
-                   extend='both')
+C = ax1.contourf(
+    yr1['lon'],
+    yr1['lat'],
+    yr1.data,
+    levels=np.arange(-3, 28, 1.5),
+    cmap=newcmp,
+    extend='both',
+)
+ax2.contourf(
+    yr0['lon'],
+    yr0['lat'],
+    yr0.data,
+    levels=np.arange(-3, 28, 1.5),
+    cmap=newcmp,
+    extend='both',
+)
+C_2 = ax3.contourf(
+    diff['lon'],
+    diff['lat'],
+    diff.data,
+    levels=np.arange(-4.0, 5, 1.0),
+    cmap=newcmp2,
+    extend='both',
+)
 
 # Add colorbars
 # By specifying two axes for `ax` the colorbar will span both of them
-cab1 = plt.colorbar(C,
-                    ax=[ax1, ax2],
-                    ticks=np.arange(-3, 28, 1.5),
-                    extendrect=True,
-                    extendfrac='auto',
-                    shrink=0.85,
-                    aspect=13,
-                    drawedges=True)
-cab2 = plt.colorbar(C_2,
-                    ax=ax3,
-                    ticks=range(-4, 5, 1),
-                    extendrect=True,
-                    extendfrac='auto',
-                    shrink=0.85,
-                    aspect=5.5,
-                    drawedges=True,
-                    format='%.1f')
+cab1 = plt.colorbar(
+    C,
+    ax=[ax1, ax2],
+    ticks=np.arange(-3, 28, 1.5),
+    extendrect=True,
+    extendfrac='auto',
+    shrink=0.85,
+    aspect=13,
+    drawedges=True,
+)
+cab2 = plt.colorbar(
+    C_2,
+    ax=ax3,
+    ticks=range(-4, 5, 1),
+    extendrect=True,
+    extendfrac='auto',
+    shrink=0.85,
+    aspect=5.5,
+    drawedges=True,
+    format='%.1f',
+)
 
 # Remove colorbar tick marks and adjust label spacing
 for cab in [cab1, cab2]:

--- a/Gallery/Panels/NCL_panel_19.py
+++ b/Gallery/Panels/NCL_panel_19.py
@@ -31,8 +31,18 @@ import geocat.viz as gv
 
 def convert_date(date):
     months = [
-        'January', 'February', 'March', 'April', 'May', 'June', 'July',
-        'August', 'September', 'October', 'November', 'December'
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
     ]
     year = str(date)[:4]
     month = months[int(str(date)[4:]) - 1]
@@ -44,15 +54,18 @@ def convert_date(date):
 
 
 def add_axes(fig, grid_space, date):
-    ax = fig.add_subplot(grid_space,
-                         projection=ccrs.PlateCarree(central_longitude=-160))
+    ax = fig.add_subplot(
+        grid_space, projection=ccrs.PlateCarree(central_longitude=-160)
+    )
     ax.set_extent([100, 300, -60, 60], crs=ccrs.PlateCarree())
 
     # Usa geocat.viz.util convenience function to set axes parameters
-    gv.set_axes_limits_and_ticks(ax,
-                                 ylim=(-60, 60),
-                                 xticks=np.arange(-80, 120, 30),
-                                 yticks=np.arange(-60, 61, 30))
+    gv.set_axes_limits_and_ticks(
+        ax,
+        ylim=(-60, 60),
+        xticks=np.arange(-80, 120, 30),
+        yticks=np.arange(-60, 61, 30),
+    )
 
     # Use geocat.viz.util convenience function to make plots look like NCL
     # plots by using latitude, longitude tick labels
@@ -68,18 +81,22 @@ def add_axes(fig, grid_space, date):
     ax.tick_params('both', which='both', top=False, right=False)
 
     # Add land to the subplot
-    ax.add_feature(cfeature.LAND,
-                   facecolor='lightgray',
-                   edgecolor='black',
-                   linewidths=0.5,
-                   zorder=2)
+    ax.add_feature(
+        cfeature.LAND,
+        facecolor='lightgray',
+        edgecolor='black',
+        linewidths=0.5,
+        zorder=2,
+    )
 
     # Set subplot titles
-    gv.set_titles_and_labels(ax,
-                             lefttitle='degC',
-                             lefttitlefontsize=10,
-                             righttitle='$(W m s^{-2})$',
-                             righttitlefontsize=10)
+    gv.set_titles_and_labels(
+        ax,
+        lefttitle='degC',
+        lefttitlefontsize=10,
+        righttitle='$(W m s^{-2})$',
+        righttitlefontsize=10,
+    )
     ax.set_title(convert_date(date), fontsize=10, y=1.04)
 
     return ax
@@ -97,15 +114,17 @@ def create_fig(grid, fig, title):
     ax4 = add_axes(fig, grid[1, 1], dates[3])
 
     # Create a dictionary with contour attributes
-    contourf_kw = dict(transform=ccrs.PlateCarree(),
-                       levels=21,
-                       cmap=cmaps.BlueRed,
-                       add_colorbar=False,
-                       add_labels=False,
-                       vmin=-5,
-                       vmax=5,
-                       extend='both',
-                       zorder=1)
+    contourf_kw = dict(
+        transform=ccrs.PlateCarree(),
+        levels=21,
+        cmap=cmaps.BlueRed,
+        add_colorbar=False,
+        add_labels=False,
+        vmin=-5,
+        vmax=5,
+        extend='both',
+        zorder=1,
+    )
 
     # Plot the filled contours
     contour1 = data1.plot.contourf(ax=ax1, **contourf_kw)
@@ -114,15 +133,17 @@ def create_fig(grid, fig, title):
     contour4 = data4.plot.contourf(ax=ax4, **contourf_kw)
 
     # Add colorbar for all four plots
-    fig.colorbar(contour4,
-                 ax=[ax1, ax2, ax3, ax4],
-                 ticks=np.linspace(-5, 5, 11),
-                 drawedges=True,
-                 orientation='horizontal',
-                 shrink=0.5,
-                 pad=0.075,
-                 extendfrac='auto',
-                 extendrect=True)
+    fig.colorbar(
+        contour4,
+        ax=[ax1, ax2, ax3, ax4],
+        ticks=np.linspace(-5, 5, 11),
+        drawedges=True,
+        orientation='horizontal',
+        shrink=0.5,
+        pad=0.075,
+        extendfrac='auto',
+        extendrect=True,
+    )
 
     # Add figure title
     fig.suptitle(title, fontsize=18, y=0.9)

--- a/Gallery/Panels/NCL_panel_2.py
+++ b/Gallery/Panels/NCL_panel_2.py
@@ -35,10 +35,9 @@ ds = xr.open_dataset(gdf.get("netcdf_files/uv300.nc")).isel(time=1)
 # Generate figure and axes using Cartopy projection
 # Make three subplots using matplotlib
 projection = ccrs.PlateCarree()
-fig, ax = plt.subplots(3,
-                       1,
-                       constrained_layout=True,
-                       subplot_kw={"projection": projection})
+fig, ax = plt.subplots(
+    3, 1, constrained_layout=True, subplot_kw={"projection": projection}
+)
 
 # Set figure size
 fig.set_size_inches((8, 13.5))
@@ -47,11 +46,13 @@ fig.set_size_inches((8, 13.5))
 plt.suptitle("A common title", fontsize=16)
 
 # Display continents
-continents = cartopy.feature.NaturalEarthFeature(name="coastline",
-                                                 category="physical",
-                                                 scale="50m",
-                                                 edgecolor="None",
-                                                 facecolor="lightgray")
+continents = cartopy.feature.NaturalEarthFeature(
+    name="coastline",
+    category="physical",
+    scale="50m",
+    edgecolor="None",
+    facecolor="lightgray",
+)
 [axes.add_feature(continents) for axes in ax.flat]
 
 # Using a dictionary makes it easy to reuse the same keyword arguments twice for the contours
@@ -63,7 +64,8 @@ kwargs = dict(
     add_labels=False,  # turn off xarray's automatic Lat, lon labels
     colors="black",  # note plurals in this and following kwargs
     linestyles="-",
-    linewidths=0.5)
+    linewidths=0.5,
+)
 
 # Define first contour levels
 levels = np.arange(-16, 33, 4)
@@ -76,11 +78,13 @@ hdl = ds.U.plot.contour(x="lon", y="lat", ax=ax[0], levels=levels, **kwargs)
 ax[0].clabel(hdl, np.arange(0, 33, 8), fmt="%.0f")
 
 # Use geocat.viz.util convenience function to add left and right title to the plot axes.
-gv.set_titles_and_labels(ax[0],
-                         lefttitle="Zonal Wind",
-                         lefttitlefontsize=12,
-                         righttitle=ds.U.units,
-                         righttitlefontsize=12)
+gv.set_titles_and_labels(
+    ax[0],
+    lefttitle="Zonal Wind",
+    lefttitlefontsize=12,
+    righttitle=ds.U.units,
+    righttitlefontsize=12,
+)
 
 # Panel 2
 # Define second contour levels
@@ -93,35 +97,41 @@ hdl = ds.V.plot.contour(x="lon", y="lat", ax=ax[1], levels=levels, **kwargs)
 ax[1].clabel(hdl, [0], fmt="%.0f")
 
 # Use geocat.viz.util convenience function to add left and right title to the plot axes.
-gv.set_titles_and_labels(ax[1],
-                         lefttitle="Meridional Wind",
-                         lefttitlefontsize=12,
-                         righttitle=ds.V.units,
-                         righttitlefontsize=12)
+gv.set_titles_and_labels(
+    ax[1],
+    lefttitle="Meridional Wind",
+    lefttitlefontsize=12,
+    righttitle=ds.V.units,
+    righttitlefontsize=12,
+)
 
 # Panel 3
 # Draw arrows
 # xarray doesn't have a quiver method (yet)
 # the NCL code plots every 4th value in lat, lon; this is the equivalent of u(::4, ::4)
 subset = ds.isel(lat=slice(None, None, 4), lon=slice(None, None, 4))
-ax[2].quiver(subset.lon,
-             subset.lat,
-             subset.U,
-             subset.V,
-             width=0.0015,
-             transform=projection,
-             zorder=2,
-             scale=1100)
+ax[2].quiver(
+    subset.lon,
+    subset.lat,
+    subset.U,
+    subset.V,
+    width=0.0015,
+    transform=projection,
+    zorder=2,
+    scale=1100,
+)
 
 # Set axes title
 ax[2].set_title("Vector Wind", loc="left", y=1.05)
 
 # Use geocat.viz.util convenience function to add left and right title to the plot axes.
-gv.set_titles_and_labels(ax[2],
-                         lefttitle="Vector Wind",
-                         lefttitlefontsize=12,
-                         righttitle=ds.U.units,
-                         righttitlefontsize=12)
+gv.set_titles_and_labels(
+    ax[2],
+    lefttitle="Vector Wind",
+    lefttitlefontsize=12,
+    righttitle=ds.U.units,
+    righttitlefontsize=12,
+)
 
 # cartopy axes require this to be manual
 ax[2].set_xticks(kwargs["xticks"])

--- a/Gallery/Panels/NCL_panel_20.py
+++ b/Gallery/Panels/NCL_panel_20.py
@@ -57,13 +57,11 @@ def format_linegraph_axes(ax):
         ylim=(-20, 50),
         xticks=np.arange(-90, 91, 30),
         yticks=np.arange(-20, 51, 10),
-        xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'])
+        xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'],
+    )
 
     # Use geocat.viz.util convenience function to add minor and major ticks
-    gv.add_major_minor_ticks(ax,
-                             x_minor_per_major=3,
-                             y_minor_per_major=5,
-                             labelsize=12)
+    gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=5, labelsize=12)
 
 
 def format_contour_axes(ax):
@@ -75,11 +73,13 @@ def format_contour_axes(ax):
             The set of axes to be manipulated
     """
     # Use geocat.viz.util convenience function to set axes tick values
-    gv.set_axes_limits_and_ticks(ax=ax,
-                                 xlim=(-180, 180),
-                                 ylim=(-90, 90),
-                                 xticks=np.arange(-180, 181, 30),
-                                 yticks=np.arange(-90, 91, 30))
+    gv.set_axes_limits_and_ticks(
+        ax=ax,
+        xlim=(-180, 180),
+        ylim=(-90, 90),
+        xticks=np.arange(-180, 181, 30),
+        yticks=np.arange(-90, 91, 30),
+    )
 
     # Use geocat.viz.util convenience function to add minor and major ticks
     gv.add_major_minor_ticks(ax, labelsize=8)
@@ -103,11 +103,9 @@ fig = plt.figure(figsize=(12, 10))
 
 # Create grid with two rows and two columns
 # Use `height_ratios` to adjust the relative heights of the rows
-grid = gridspec.GridSpec(nrows=2,
-                         ncols=2,
-                         height_ratios=[0.55, 0.45],
-                         hspace=0.1,
-                         figure=fig)
+grid = gridspec.GridSpec(
+    nrows=2, ncols=2, height_ratios=[0.55, 0.45], hspace=0.1, figure=fig
+)
 
 # Choose the map projection
 proj = ccrs.PlateCarree()
@@ -124,11 +122,13 @@ ax4.coastlines(linewidth=0.5)
 
 # Use geocat.viz.util convenience function to set titles without calling
 # several matplotlib functions
-gv.set_titles_and_labels(ax1,
-                         maintitle='Time=0',
-                         maintitlefontsize=14,
-                         ylabel=U_0.long_name,
-                         labelfontsize=14)
+gv.set_titles_and_labels(
+    ax1,
+    maintitle='Time=0',
+    maintitlefontsize=14,
+    ylabel=U_0.long_name,
+    labelfontsize=14,
+)
 gv.set_titles_and_labels(ax2, maintitle='Time=1', maintitlefontsize=14)
 
 # Draw tick labels on the right side of the top right plot
@@ -163,56 +163,68 @@ cmap = cmaps.BlueRed
 levels = np.arange(-10, 36, 5)
 
 # Add filled contour to maps
-contour3 = ax3.contourf(U_0['lon'],
-                        U_0['lat'],
-                        U_0.data,
-                        cmap=cmap,
-                        norm=divnorm,
-                        levels=levels,
-                        extend='both')
-contour4 = ax4.contourf(U_1['lon'],
-                        U_1['lat'],
-                        U_1.data,
-                        cmap=cmap,
-                        norm=divnorm,
-                        levels=levels,
-                        extend='both')
+contour3 = ax3.contourf(
+    U_0['lon'],
+    U_0['lat'],
+    U_0.data,
+    cmap=cmap,
+    norm=divnorm,
+    levels=levels,
+    extend='both',
+)
+contour4 = ax4.contourf(
+    U_1['lon'],
+    U_1['lat'],
+    U_1.data,
+    cmap=cmap,
+    norm=divnorm,
+    levels=levels,
+    extend='both',
+)
 
 # Add contour line to maps
-ax3.contour(U_0['lon'],
-            U_0['lat'],
-            U_0.data,
-            colors='black',
-            linewidths=0.5,
-            linestyles='solid',
-            levels=levels)
-ax4.contour(U_1['lon'],
-            U_1['lat'],
-            U_1.data,
-            colors='black',
-            linewidths=0.5,
-            linestyles='solid',
-            levels=levels)
+ax3.contour(
+    U_0['lon'],
+    U_0['lat'],
+    U_0.data,
+    colors='black',
+    linewidths=0.5,
+    linestyles='solid',
+    levels=levels,
+)
+ax4.contour(
+    U_1['lon'],
+    U_1['lat'],
+    U_1.data,
+    colors='black',
+    linewidths=0.5,
+    linestyles='solid',
+    levels=levels,
+)
 
 # Create colorbars
-cbar3 = plt.colorbar(contour3,
-                     ax=ax3,
-                     orientation='horizontal',
-                     extendrect=True,
-                     extendfrac='auto',
-                     shrink=0.75,
-                     aspect=13,
-                     drawedges=True,
-                     pad=0.1)
-cbar4 = plt.colorbar(contour4,
-                     ax=ax4,
-                     orientation='horizontal',
-                     extendrect=True,
-                     extendfrac='auto',
-                     shrink=0.75,
-                     aspect=13,
-                     drawedges=True,
-                     pad=0.1)
+cbar3 = plt.colorbar(
+    contour3,
+    ax=ax3,
+    orientation='horizontal',
+    extendrect=True,
+    extendfrac='auto',
+    shrink=0.75,
+    aspect=13,
+    drawedges=True,
+    pad=0.1,
+)
+cbar4 = plt.colorbar(
+    contour4,
+    ax=ax4,
+    orientation='horizontal',
+    extendrect=True,
+    extendfrac='auto',
+    shrink=0.75,
+    aspect=13,
+    drawedges=True,
+    pad=0.1,
+)
 
 # Format colorbar ticks and labels
 cbar3.ax.tick_params(labelsize=8)

--- a/Gallery/Panels/NCL_panel_3.py
+++ b/Gallery/Panels/NCL_panel_3.py
@@ -86,11 +86,13 @@ def plot_labelled_filled_contours(data, ax=None):
     gv.add_lat_lon_ticklabels(ax)
 
     # Use geocat.viz.util convenience function to add main title as well as titles to left and right of the plot axes.
-    gv.set_titles_and_labels(ax,
-                             lefttitle=data.attrs['long_name'],
-                             lefttitlefontsize=10,
-                             righttitle=data.attrs['units'],
-                             righttitlefontsize=10)
+    gv.set_titles_and_labels(
+        ax,
+        lefttitle=data.attrs['long_name'],
+        lefttitlefontsize=10,
+        righttitle=data.attrs['units'],
+        righttitlefontsize=10,
+    )
 
     return handles
 
@@ -103,10 +105,9 @@ def plot_labelled_filled_contours(data, ax=None):
 # See https://matplotlib.org/tutorials/intermediate/constrainedlayout_guide.html
 # Generate figure and axes using Cartopy projection
 projection = ccrs.PlateCarree()
-fig, ax = plt.subplots(2,
-                       1,
-                       constrained_layout=True,
-                       subplot_kw={"projection": projection})
+fig, ax = plt.subplots(
+    2, 1, constrained_layout=True, subplot_kw={"projection": projection}
+)
 
 # Set figure size (width, height) in inches
 fig.set_size_inches((8, 8.2))
@@ -132,7 +133,8 @@ cbar = plt.colorbar(
     drawedges=True,
     extendrect=True,
     extendfrac='auto',
-    aspect=30)
+    aspect=30,
+)
 cbar.ax.tick_params(labelsize=10)
 
 # Show the plot

--- a/Gallery/Panels/NCL_panel_31.py
+++ b/Gallery/Panels/NCL_panel_31.py
@@ -45,10 +45,9 @@ lon = ds.lon
 # Plot:
 
 # Create a figure and axes
-fig, axs = plt.subplots(ncols=2,
-                        nrows=4,
-                        figsize=(15.5, 18),
-                        subplot_kw={'projection': ccrs.PlateCarree()})
+fig, axs = plt.subplots(
+    ncols=2, nrows=4, figsize=(15.5, 18), subplot_kw={'projection': ccrs.PlateCarree()}
+)
 
 # Define pressures and reshape to match subplot layout (4 rows, 2 columns)
 levs = np.array([1000, 850, 700, 500, 400, 300, 250, 200])
@@ -69,31 +68,32 @@ for i in range(4):
         ax.set_extent([65, 95, 5, 25])
 
         # add the image. The "origin" of the image is in the upper left corner
-        ax.imshow(img,
-                  origin='upper',
-                  extent=img_extent,
-                  transform=ccrs.PlateCarree())
+        ax.imshow(img, origin='upper', extent=img_extent, transform=ccrs.PlateCarree())
         ax.coastlines(resolution='50m', color='black', linewidth=1)
 
         # Add vectors onto the plot
-        Q = ax.quiver(lon,
-                      lat,
-                      U.sel(lev=pressure[i][j]),
-                      V.sel(lev=pressure[i][j]),
-                      color='white',
-                      pivot='middle',
-                      width=.0025,
-                      scale=75)
+        Q = ax.quiver(
+            lon,
+            lat,
+            U.sel(lev=pressure[i][j]),
+            V.sel(lev=pressure[i][j]),
+            color='white',
+            pivot='middle',
+            width=0.0025,
+            scale=75,
+        )
 
         # Use geocat-viz utility function to format lat/lon tick labels
         gv.add_lat_lon_ticklabels(ax=ax)
 
         # Use geocat-viz utility function to customize tick marks
-        gv.set_axes_limits_and_ticks(ax,
-                                     xlim=(65, 95),
-                                     ylim=(5, 25),
-                                     xticks=range(65, 100, 5),
-                                     yticks=range(5, 27, 5))
+        gv.set_axes_limits_and_ticks(
+            ax,
+            xlim=(65, 95),
+            ylim=(5, 25),
+            xticks=range(65, 100, 5),
+            yticks=range(5, 27, 5),
+        )
 
         # Customize ticks and labels
         ax.tick_params(labelsize=11, length=8)
@@ -112,13 +112,14 @@ ax.add_patch(
         5.7,  # height
         facecolor='white',
         edgecolor='grey',
-        clip_on=False)  # allow rectangle to be visible beyond axes
+        clip_on=False,
+    )  # allow rectangle to be visible beyond axes
 )
 
 ax.quiverkey(
     Q,  # the quiver instance
     0.935,  # x position of the key
-    .05,  # y position of the key
+    0.05,  # y position of the key
     4,  # length of the key
     '4',  # label for the key
     labelpos='N',  # position the label to the 'north' of the arrow

--- a/Gallery/Panels/NCL_panel_35.py
+++ b/Gallery/Panels/NCL_panel_35.py
@@ -25,32 +25,27 @@ import cmaps
 import geocat.viz as gv
 import geocat.datafiles as gcd
 
-import math
 
 ###############################################################################
 # Uploading random smooth 2d data from geocat.datafiles
-data1 = xr.open_dataarray(gcd.get("netcdf_files/panel_35_data1.nc"),
-                          engine='netcdf4')
-data2 = xr.open_dataarray(gcd.get("netcdf_files/panel_35_data2.nc"),
-                          engine='netcdf4')
-data3 = xr.open_dataarray(gcd.get("netcdf_files/panel_35_data3.nc"),
-                          engine='netcdf4')
+data1 = xr.open_dataarray(gcd.get("netcdf_files/panel_35_data1.nc"), engine='netcdf4')
+data2 = xr.open_dataarray(gcd.get("netcdf_files/panel_35_data2.nc"), engine='netcdf4')
+data3 = xr.open_dataarray(gcd.get("netcdf_files/panel_35_data3.nc"), engine='netcdf4')
 
 ###############################################################################
 # Create figure and axes using gv
-fig, axs = plt.subplots(1,
-                        3,
-                        figsize=(12, 6),
-                        sharex='all',
-                        sharey='all',
-                        gridspec_kw={'wspace': 0})
+fig, axs = plt.subplots(
+    1, 3, figsize=(12, 6), sharex='all', sharey='all', gridspec_kw={'wspace': 0}
+)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(axs[0],
-                             xticks=np.arange(0, 100, 20),
-                             yticks=np.arange(0, 100, 20),
-                             xticklabels=np.arange(0, 100, 20),
-                             yticklabels=np.arange(0, 100, 20))
+gv.set_axes_limits_and_ticks(
+    axs[0],
+    xticks=np.arange(0, 100, 20),
+    yticks=np.arange(0, 100, 20),
+    xticklabels=np.arange(0, 100, 20),
+    yticklabels=np.arange(0, 100, 20),
+)
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(axs[0], x_minor_per_major=4, y_minor_per_major=4)
 # Specify which edges of the subplot should have tick lines
@@ -59,20 +54,24 @@ axs[0].tick_params(axis='both', which='both', left=True, right=False)
 axs[0].set_aspect(aspect='equal')
 
 # Repeat for other subplots with a few changes
-gv.set_axes_limits_and_ticks(axs[1],
-                             xticks=np.arange(0, 100, 20),
-                             yticks=np.arange(0, 100, 20),
-                             xticklabels=np.arange(0, 100, 20),
-                             yticklabels=np.arange(0, 100, 20))
+gv.set_axes_limits_and_ticks(
+    axs[1],
+    xticks=np.arange(0, 100, 20),
+    yticks=np.arange(0, 100, 20),
+    xticklabels=np.arange(0, 100, 20),
+    yticklabels=np.arange(0, 100, 20),
+)
 gv.add_major_minor_ticks(axs[1], x_minor_per_major=4, y_minor_per_major=4)
 axs[1].tick_params(axis='both', which='both', left=False, right=False)
 axs[1].set_aspect(aspect='equal')
 
-gv.set_axes_limits_and_ticks(axs[2],
-                             xticks=np.arange(0, 100, 20),
-                             yticks=np.arange(0, 100, 20),
-                             xticklabels=np.arange(0, 100, 20),
-                             yticklabels=np.arange(0, 100, 20))
+gv.set_axes_limits_and_ticks(
+    axs[2],
+    xticks=np.arange(0, 100, 20),
+    yticks=np.arange(0, 100, 20),
+    xticklabels=np.arange(0, 100, 20),
+    yticklabels=np.arange(0, 100, 20),
+)
 gv.add_major_minor_ticks(axs[2], x_minor_per_major=4, y_minor_per_major=4)
 axs[2].tick_params(axis='both', which='both', left=False, right=True)
 axs[2].set_aspect(aspect='equal')
@@ -89,20 +88,24 @@ axs[1].contour(filled2, colors='black', linestyles='solid', linewidths=0.4)
 filled3 = axs[2].contourf(data3, cmap=newcmap, levels=contour_levels)
 axs[2].contour(filled3, colors='black', linestyles='solid', linewidths=0.4)
 
-plt.colorbar(filled3,
-             orientation='horizontal',
-             ax=axs,
-             ticks=np.arange(-28, 20, 4),
-             shrink=0.75,
-             drawedges=True,
-             pad=0.1)
+plt.colorbar(
+    filled3,
+    orientation='horizontal',
+    ax=axs,
+    ticks=np.arange(-28, 20, 4),
+    shrink=0.75,
+    drawedges=True,
+    pad=0.1,
+)
 
 # Add title
-fig.suptitle("Three dummy plots attached along Y axes",
-             horizontalalignment='center',
-             y=0.9,
-             fontsize=18,
-             fontweight='bold',
-             fontfamily='sans-serif')
+fig.suptitle(
+    "Three dummy plots attached along Y axes",
+    horizontalalignment='center',
+    y=0.9,
+    fontsize=18,
+    fontweight='bold',
+    fontfamily='sans-serif',
+)
 
 plt.show()

--- a/Gallery/Panels/NCL_panel_4.py
+++ b/Gallery/Panels/NCL_panel_4.py
@@ -23,7 +23,6 @@ See following URLs to see the reproduced NCL plot & script:
 import cartopy.crs as ccrs
 from cartopy.mpl.gridliner import LongitudeFormatter, LatitudeFormatter
 import matplotlib.pyplot as plt
-import matplotlib as mpl
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 import numpy as np
 import xarray as xr
@@ -108,9 +107,9 @@ def plot_labelled_filled_contours(data, ax=None):
     ax.coastlines(linewidth=0.5, alpha=0.75)
 
     # Use geocat.viz.util convenience function to set axes tick values
-    gv.set_axes_limits_and_ticks(ax,
-                                 xticks=np.arange(-180, 181, 30),
-                                 yticks=np.arange(-90, 91, 30))
+    gv.set_axes_limits_and_ticks(
+        ax, xticks=np.arange(-180, 181, 30), yticks=np.arange(-90, 91, 30)
+    )
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
     gv.add_major_minor_ticks(ax, labelsize=8)
@@ -122,11 +121,13 @@ def plot_labelled_filled_contours(data, ax=None):
     ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
     # Use geocat.viz.util convenience function to add main title as well as titles to left and right of the plot axes.
-    gv.set_titles_and_labels(ax,
-                             lefttitle=data.attrs['long_name'],
-                             lefttitlefontsize=10,
-                             righttitle=data.attrs['units'],
-                             righttitlefontsize=10)
+    gv.set_titles_and_labels(
+        ax,
+        lefttitle=data.attrs['long_name'],
+        lefttitlefontsize=10,
+        righttitle=data.attrs['units'],
+        righttitlefontsize=10,
+    )
 
     return handles
 
@@ -138,11 +139,13 @@ def plot_labelled_filled_contours(data, ax=None):
 # between them using gridspec_kw and hspace
 # Generate figure and axes using Cartopy projection
 projection = ccrs.PlateCarree()
-fig, ax = plt.subplots(3,
-                       1,
-                       figsize=(6, 10),
-                       gridspec_kw=dict(hspace=0.3),
-                       subplot_kw={"projection": projection})
+fig, ax = plt.subplots(
+    3,
+    1,
+    figsize=(6, 10),
+    gridspec_kw=dict(hspace=0.3),
+    subplot_kw={"projection": projection},
+)
 # Define the contour levels
 levels = np.linspace(-10, 50, 13)
 
@@ -159,31 +162,37 @@ plot_labelled_filled_contours(meridional, ax=ax[1])
 plot_labelled_filled_contours(zonal, ax=ax[2])
 
 # Create inset axes for colorbar
-cax = inset_axes(ax[2],
-                 width='100%',
-                 height='10%',
-                 loc='lower left',
-                 bbox_to_anchor=(0, -0.25, 1, 1),
-                 bbox_transform=ax[2].transAxes,
-                 borderpad=0)
+cax = inset_axes(
+    ax[2],
+    width='100%',
+    height='10%',
+    loc='lower left',
+    bbox_to_anchor=(0, -0.25, 1, 1),
+    bbox_transform=ax[2].transAxes,
+    borderpad=0,
+)
 # Add horizontal colorbar
-cbar = plt.colorbar(handles["filled"],
-                    cax=cax,
-                    orientation="horizontal",
-                    ticks=levels[:-1],
-                    drawedges=True,
-                    aspect=30,
-                    extendrect=True,
-                    extendfrac='auto',
-                    shrink=1)
+cbar = plt.colorbar(
+    handles["filled"],
+    cax=cax,
+    orientation="horizontal",
+    ticks=levels[:-1],
+    drawedges=True,
+    aspect=30,
+    extendrect=True,
+    extendfrac='auto',
+    shrink=1,
+)
 cbar.ax.tick_params(labelsize=10)
 
 # Add figure label underneath subplots
-fig.text(0.5,
-         0.015,
-         "Figure 1: A nifty panel plot",
-         horizontalalignment='center',
-         fontsize=14)
+fig.text(
+    0.5,
+    0.015,
+    "Figure 1: A nifty panel plot",
+    horizontalalignment='center',
+    fontsize=14,
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Panels/NCL_panel_41.py
+++ b/Gallery/Panels/NCL_panel_41.py
@@ -34,8 +34,18 @@ import geocat.viz as gv
 
 def convert_date(date):
     months = [
-        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sept', 'Oct',
-        'Nov', 'Dec'
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sept',
+        'Oct',
+        'Nov',
+        'Dec',
     ]
     year = date[:4]
     month = months[int(date[5:7]) - 1]
@@ -52,18 +62,18 @@ def add_axes(fig, grid_space):
     ax = fig.add_subplot(grid_space, projection=ccrs.PlateCarree())
 
     # Add land to the subplot
-    ax.add_feature(cfeature.LAND,
-                   facecolor="none",
-                   edgecolor='black',
-                   linewidths=0.5,
-                   zorder=2)
+    ax.add_feature(
+        cfeature.LAND, facecolor="none", edgecolor='black', linewidths=0.5, zorder=2
+    )
 
     # Usa geocat.viz.util convenience function to set axes parameters
-    gv.set_axes_limits_and_ticks(ax,
-                                 ylim=(-90, 90),
-                                 xlim=(-180, 180),
-                                 xticks=np.arange(-180, 181, 30),
-                                 yticks=np.arange(-90, 91, 30))
+    gv.set_axes_limits_and_ticks(
+        ax,
+        ylim=(-90, 90),
+        xlim=(-180, 180),
+        xticks=np.arange(-180, 181, 30),
+        yticks=np.arange(-90, 91, 30),
+    )
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
     gv.add_major_minor_ticks(ax, labelsize=8)
@@ -116,24 +126,26 @@ cmap = plt.get_cmap('magma')
 for i, axes in enumerate([ax1, ax2, ax3, ax4, ax5, ax6]):
     dataset = tsurf[plot_idxs[i], :, :]
     # Contourf plot data
-    contour = axes.contourf(dataset.lon,
-                            dataset.lat,
-                            dataset.data,
-                            vmin=250,
-                            vmax=310,
-                            cmap=cmap,
-                            levels=levels)
+    contour = axes.contourf(
+        dataset.lon,
+        dataset.lat,
+        dataset.data,
+        vmin=250,
+        vmax=310,
+        cmap=cmap,
+        levels=levels,
+    )
     # Add lower text box
-    axes.text(0.98,
-              0.05,
-              convert_date(str(dataset.time.data)),
-              horizontalalignment='right',
-              transform=axes.transAxes,
-              fontsize=8,
-              bbox=dict(boxstyle='square, pad=0.25',
-                        facecolor='white',
-                        edgecolor='gray'),
-              zorder=5)
+    axes.text(
+        0.98,
+        0.05,
+        convert_date(str(dataset.time.data)),
+        horizontalalignment='right',
+        transform=axes.transAxes,
+        fontsize=8,
+        bbox=dict(boxstyle='square, pad=0.25', facecolor='white', edgecolor='gray'),
+        zorder=5,
+    )
 
 # Set colorbounds of norm
 colorbounds = np.arange(249, 311, 1)
@@ -142,16 +154,18 @@ norm = mcolors.BoundaryNorm(colorbounds, cmap.N)
 mappable = cm.ScalarMappable(norm=norm, cmap=cmap)
 
 # Add colorbar for all six plots
-fig.colorbar(mappable,
-             ax=[ax1, ax2, ax3, ax4, ax5, ax6],
-             ticks=colorbounds[3:-1:3],
-             drawedges=True,
-             orientation='horizontal',
-             shrink=0.82,
-             pad=0.01,
-             aspect=35,
-             extendfrac='auto',
-             extendrect=True)
+fig.colorbar(
+    mappable,
+    ax=[ax1, ax2, ax3, ax4, ax5, ax6],
+    ticks=colorbounds[3:-1:3],
+    drawedges=True,
+    orientation='horizontal',
+    shrink=0.82,
+    pad=0.01,
+    aspect=35,
+    extendfrac='auto',
+    extendrect=True,
+)
 
 # Add figure titles
 fig.suptitle("rectilinear_grid_2D.nc", fontsize=22, fontweight='bold')

--- a/Gallery/Panels/NCL_panel_5.py
+++ b/Gallery/Panels/NCL_panel_5.py
@@ -83,9 +83,9 @@ def plot_labelled_filled_contours(data, ax=None, label=None):
     ax.coastlines(linewidth=0.5, alpha=0.75)
 
     # Use geocat.viz.util convenience function to set axes tick values
-    gv.set_axes_limits_and_ticks(ax,
-                                 xticks=np.arange(-180, 181, 30),
-                                 yticks=np.arange(-90, 91, 30))
+    gv.set_axes_limits_and_ticks(
+        ax, xticks=np.arange(-180, 181, 30), yticks=np.arange(-90, 91, 30)
+    )
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
     gv.add_major_minor_ticks(ax, labelsize=8)
@@ -97,18 +97,22 @@ def plot_labelled_filled_contours(data, ax=None, label=None):
     ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
     # Use geocat.viz.util convenience function to add main title as well as titles to left and right of the plot axes.
-    gv.set_titles_and_labels(ax,
-                             lefttitle=data.attrs['long_name'],
-                             lefttitlefontsize=10,
-                             righttitle=data.attrs['units'],
-                             righttitlefontsize=10)
+    gv.set_titles_and_labels(
+        ax,
+        lefttitle=data.attrs['long_name'],
+        lefttitlefontsize=10,
+        righttitle=data.attrs['units'],
+        righttitlefontsize=10,
+    )
 
     # Add a label in the upper left of the axes
-    ax.text(0.025,
-            0.9,
-            label,
-            transform=ax.transAxes,
-            bbox=dict(boxstyle='square, pad=0.25', facecolor='white'))
+    ax.text(
+        0.025,
+        0.9,
+        label,
+        transform=ax.transAxes,
+        bbox=dict(boxstyle='square, pad=0.25', facecolor='white'),
+    )
     return handles
 
 
@@ -119,11 +123,13 @@ def plot_labelled_filled_contours(data, ax=None, label=None):
 # between them using gridspec_kw and hspace
 # Generate figure and axes using Cartopy projection
 projection = ccrs.PlateCarree()
-fig, ax = plt.subplots(3,
-                       1,
-                       figsize=(6, 10),
-                       gridspec_kw=dict(hspace=0.3),
-                       subplot_kw={"projection": projection})
+fig, ax = plt.subplots(
+    3,
+    1,
+    figsize=(6, 10),
+    gridspec_kw=dict(hspace=0.3),
+    subplot_kw={"projection": projection},
+)
 # Define the contour levels
 levels = np.linspace(-10, 50, 13)
 
@@ -140,31 +146,37 @@ plot_labelled_filled_contours(ds.V, ax=ax[1], label='b)')
 plot_labelled_filled_contours(ds.U, ax=ax[2], label='c)')
 
 # Create inset axes for colorbar
-cax = inset_axes(ax[2],
-                 width='100%',
-                 height='7%',
-                 loc='lower left',
-                 bbox_to_anchor=(0, -0.25, 1, 1),
-                 bbox_transform=ax[2].transAxes,
-                 borderpad=0)
+cax = inset_axes(
+    ax[2],
+    width='100%',
+    height='7%',
+    loc='lower left',
+    bbox_to_anchor=(0, -0.25, 1, 1),
+    bbox_transform=ax[2].transAxes,
+    borderpad=0,
+)
 # Add horizontal colorbar
-cbar = plt.colorbar(handles["filled"],
-                    cax=cax,
-                    orientation="horizontal",
-                    ticks=levels[:-1],
-                    drawedges=True,
-                    aspect=30,
-                    extendrect=True,
-                    extendfrac='auto',
-                    shrink=0.8)
+cbar = plt.colorbar(
+    handles["filled"],
+    cax=cax,
+    orientation="horizontal",
+    ticks=levels[:-1],
+    drawedges=True,
+    aspect=30,
+    extendrect=True,
+    extendfrac='auto',
+    shrink=0.8,
+)
 cbar.ax.tick_params(labelsize=10)
 
 # Add figure label underneath subplots
-fig.text(0.5,
-         0.015,
-         "Figure 1: A nifty panel plot",
-         horizontalalignment='center',
-         fontsize=14)
+fig.text(
+    0.5,
+    0.015,
+    "Figure 1: A nifty panel plot",
+    horizontalalignment='center',
+    fontsize=14,
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Panels/NCL_panel_6.py
+++ b/Gallery/Panels/NCL_panel_6.py
@@ -36,8 +36,7 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/h_avg_Y0191_D000.00.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/h_avg_Y0191_D000.00.nc"), decode_times=False)
 
 data0 = ds.T.isel(time=0, drop=True).isel(z_t=0, drop=True)
 data1 = ds.T.isel(time=0, drop=True).isel(z_t=5, drop=True)
@@ -54,10 +53,7 @@ data = [[data0, data1], [data2, data3]]
 ###############################################################################
 # Plot without extra whitespace:
 projection = ccrs.NorthPolarStereo()
-fig, axs = plt.subplots(2,
-                        2,
-                        figsize=(8, 8),
-                        subplot_kw=dict(projection=projection))
+fig, axs = plt.subplots(2, 2, figsize=(8, 8), subplot_kw=dict(projection=projection))
 
 # Format axes and inset axes for color bars
 cax = np.empty((2, 2), dtype=plt.Axes)
@@ -66,18 +62,18 @@ for row in range(0, 2):
         # Add map features
         axs[row][col].add_feature(cfeature.LAND, facecolor='silver', zorder=2)
         axs[row][col].add_feature(cfeature.COASTLINE, linewidth=0.5, zorder=3)
-        axs[row][col].add_feature(cfeature.LAKES,
-                                  linewidth=0.5,
-                                  edgecolor='black',
-                                  facecolor='None',
-                                  zorder=4)
+        axs[row][col].add_feature(
+            cfeature.LAKES, linewidth=0.5, edgecolor='black', facecolor='None', zorder=4
+        )
 
         # Add gridlines
-        gl = axs[row][col].gridlines(ccrs.PlateCarree(),
-                                     draw_labels=False,
-                                     color='gray',
-                                     linestyle="--",
-                                     zorder=5)
+        gl = axs[row][col].gridlines(
+            ccrs.PlateCarree(),
+            draw_labels=False,
+            color='gray',
+            linestyle="--",
+            zorder=5,
+        )
         gl.xlocator = mticker.FixedLocator(np.linspace(-180, 150, 12))
 
         # Add latitude and longitude labels
@@ -86,104 +82,138 @@ for row in range(0, 2):
         # which lies at the equator
         y = np.full_like(x, -8)
         labels = [
-            '0', '30E', '60E', '90E', '120E', '150E', '180', '150W', '120W',
-            '90W', '60W', '30W'
+            '0',
+            '30E',
+            '60E',
+            '90E',
+            '120E',
+            '150E',
+            '180',
+            '150W',
+            '120W',
+            '90W',
+            '60W',
+            '30W',
         ]
         for x, y, label in zip(x, y, labels):
             if label == '180':
-                axs[row][col].text(x,
-                                   y,
-                                   label,
-                                   fontsize=7,
-                                   horizontalalignment='center',
-                                   verticalalignment='top',
-                                   transform=ccrs.Geodetic())
+                axs[row][col].text(
+                    x,
+                    y,
+                    label,
+                    fontsize=7,
+                    horizontalalignment='center',
+                    verticalalignment='top',
+                    transform=ccrs.Geodetic(),
+                )
             elif label == '0':
-                axs[row][col].text(x,
-                                   y,
-                                   label,
-                                   fontsize=7,
-                                   horizontalalignment='center',
-                                   verticalalignment='bottom',
-                                   transform=ccrs.Geodetic())
+                axs[row][col].text(
+                    x,
+                    y,
+                    label,
+                    fontsize=7,
+                    horizontalalignment='center',
+                    verticalalignment='bottom',
+                    transform=ccrs.Geodetic(),
+                )
             else:
-                axs[row][col].text(x,
-                                   y,
-                                   label,
-                                   fontsize=7,
-                                   horizontalalignment='center',
-                                   verticalalignment='center',
-                                   transform=ccrs.Geodetic())
+                axs[row][col].text(
+                    x,
+                    y,
+                    label,
+                    fontsize=7,
+                    horizontalalignment='center',
+                    verticalalignment='center',
+                    transform=ccrs.Geodetic(),
+                )
 
         # Set boundary of plot to be circular
         gv.set_map_boundary(axs[row][col], (-180, 180), (0, 90), south_pad=1)
         # Create inset axes for color bars
-        cax[row][col] = inset_axes(axs[row][col],
-                                   width='5%',
-                                   height='100%',
-                                   loc='lower right',
-                                   bbox_to_anchor=(0.175, 0, 1, 1),
-                                   bbox_transform=axs[row][col].transAxes,
-                                   borderpad=0)
+        cax[row][col] = inset_axes(
+            axs[row][col],
+            width='5%',
+            height='100%',
+            loc='lower right',
+            bbox_to_anchor=(0.175, 0, 1, 1),
+            bbox_transform=axs[row][col].transAxes,
+            borderpad=0,
+        )
 # Import color map
 cmap = "magma"
 
 # Plot filled contours
 contour = np.empty((2, 2), dtype=mcontour.ContourSet)
-contour[0][0] = data[0][0].plot.contourf(ax=axs[0][0],
-                                         cmap=cmap,
-                                         levels=np.arange(-2, 34, 2),
-                                         transform=ccrs.PlateCarree(),
-                                         add_colorbar=False,
-                                         zorder=0)
-contour[0][1] = data[0][1].plot.contourf(ax=axs[0][1],
-                                         cmap=cmap,
-                                         levels=np.arange(-4, 30, 2),
-                                         transform=ccrs.PlateCarree(),
-                                         add_colorbar=False,
-                                         zorder=0)
-contour[1][0] = data[1][0].plot.contourf(ax=axs[1][0],
-                                         cmap=cmap,
-                                         levels=15,
-                                         transform=ccrs.PlateCarree(),
-                                         add_colorbar=False,
-                                         zorder=0)
-contour[1][1] = data[1][1].plot.contourf(ax=axs[1][1],
-                                         cmap=cmap,
-                                         levels=12,
-                                         transform=ccrs.PlateCarree(),
-                                         add_colorbar=False,
-                                         zorder=0)
+contour[0][0] = data[0][0].plot.contourf(
+    ax=axs[0][0],
+    cmap=cmap,
+    levels=np.arange(-2, 34, 2),
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    zorder=0,
+)
+contour[0][1] = data[0][1].plot.contourf(
+    ax=axs[0][1],
+    cmap=cmap,
+    levels=np.arange(-4, 30, 2),
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    zorder=0,
+)
+contour[1][0] = data[1][0].plot.contourf(
+    ax=axs[1][0],
+    cmap=cmap,
+    levels=15,
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    zorder=0,
+)
+contour[1][1] = data[1][1].plot.contourf(
+    ax=axs[1][1],
+    cmap=cmap,
+    levels=12,
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    zorder=0,
+)
 
 # Plot contour lines
-data[0][0].plot.contour(ax=axs[0][0],
-                        colors='black',
-                        linestyles='solid',
-                        linewidths=0.5,
-                        levels=np.arange(-2, 34, 2),
-                        transform=ccrs.PlateCarree(),
-                        zorder=1)
-data[0][1].plot.contour(ax=axs[0][1],
-                        colors='black',
-                        linestyles='solid',
-                        linewidths=0.5,
-                        levels=np.arange(-4, 30, 2),
-                        transform=ccrs.PlateCarree(),
-                        zorder=1)
-data[1][0].plot.contour(ax=axs[1][0],
-                        colors='black',
-                        linestyles='solid',
-                        linewidths=0.5,
-                        levels=15,
-                        transform=ccrs.PlateCarree(),
-                        zorder=1)
-data[1][1].plot.contour(ax=axs[1][1],
-                        colors='black',
-                        linestyles='solid',
-                        linewidths=0.5,
-                        levels=12,
-                        transform=ccrs.PlateCarree(),
-                        zorder=1)
+data[0][0].plot.contour(
+    ax=axs[0][0],
+    colors='black',
+    linestyles='solid',
+    linewidths=0.5,
+    levels=np.arange(-2, 34, 2),
+    transform=ccrs.PlateCarree(),
+    zorder=1,
+)
+data[0][1].plot.contour(
+    ax=axs[0][1],
+    colors='black',
+    linestyles='solid',
+    linewidths=0.5,
+    levels=np.arange(-4, 30, 2),
+    transform=ccrs.PlateCarree(),
+    zorder=1,
+)
+data[1][0].plot.contour(
+    ax=axs[1][0],
+    colors='black',
+    linestyles='solid',
+    linewidths=0.5,
+    levels=15,
+    transform=ccrs.PlateCarree(),
+    zorder=1,
+)
+data[1][1].plot.contour(
+    ax=axs[1][1],
+    colors='black',
+    linestyles='solid',
+    linewidths=0.5,
+    levels=12,
+    transform=ccrs.PlateCarree(),
+    zorder=1,
+)
 
 # Create colorbars and reduce the font size
 for row in range(0, 2):
@@ -194,14 +224,10 @@ for row in range(0, 2):
 # Format titles for each subplot
 for row in range(0, 2):
     for col in range(0, 2):
-        axs[row][col].set_title(data[row][col].long_name,
-                                loc='left',
-                                fontsize=7,
-                                pad=20)
-        axs[row][col].set_title(data[row][col].units,
-                                loc='right',
-                                fontsize=7,
-                                pad=20)
+        axs[row][col].set_title(
+            data[row][col].long_name, loc='left', fontsize=7, pad=20
+        )
+        axs[row][col].set_title(data[row][col].units, loc='right', fontsize=7, pad=20)
 
 plt.show()
 
@@ -214,11 +240,13 @@ plt.show()
 # for more information on how to manipulate the gridlayout.
 
 projection = ccrs.NorthPolarStereo()
-fig, axs = plt.subplots(2,
-                        2,
-                        figsize=(8, 8),
-                        gridspec_kw=(dict(wspace=0.5)),
-                        subplot_kw=dict(projection=projection))
+fig, axs = plt.subplots(
+    2,
+    2,
+    figsize=(8, 8),
+    gridspec_kw=(dict(wspace=0.5)),
+    subplot_kw=dict(projection=projection),
+)
 #
 # Everything beyond this is the same code for the example without extra white space
 #
@@ -230,18 +258,18 @@ for row in range(0, 2):
         # Add map features
         axs[row][col].add_feature(cfeature.LAND, facecolor='silver', zorder=2)
         axs[row][col].add_feature(cfeature.COASTLINE, linewidth=0.5, zorder=3)
-        axs[row][col].add_feature(cfeature.LAKES,
-                                  linewidth=0.5,
-                                  edgecolor='black',
-                                  facecolor='None',
-                                  zorder=4)
+        axs[row][col].add_feature(
+            cfeature.LAKES, linewidth=0.5, edgecolor='black', facecolor='None', zorder=4
+        )
 
         # Add gridlines
-        gl = axs[row][col].gridlines(ccrs.PlateCarree(),
-                                     draw_labels=False,
-                                     color='gray',
-                                     linestyle="--",
-                                     zorder=5)
+        gl = axs[row][col].gridlines(
+            ccrs.PlateCarree(),
+            draw_labels=False,
+            color='gray',
+            linestyle="--",
+            zorder=5,
+        )
         gl.xlocator = mticker.FixedLocator(np.linspace(-180, 150, 12))
 
         # Add latitude and longitude labels
@@ -250,104 +278,138 @@ for row in range(0, 2):
         # which lies at the equator
         y = np.full_like(x, -8)
         labels = [
-            '0', '30E', '60E', '90E', '120E', '150E', '180', '150W', '120W',
-            '90W', '60W', '30W'
+            '0',
+            '30E',
+            '60E',
+            '90E',
+            '120E',
+            '150E',
+            '180',
+            '150W',
+            '120W',
+            '90W',
+            '60W',
+            '30W',
         ]
         for x, y, label in zip(x, y, labels):
             if label == '180':
-                axs[row][col].text(x,
-                                   y,
-                                   label,
-                                   fontsize=7,
-                                   horizontalalignment='center',
-                                   verticalalignment='top',
-                                   transform=ccrs.Geodetic())
+                axs[row][col].text(
+                    x,
+                    y,
+                    label,
+                    fontsize=7,
+                    horizontalalignment='center',
+                    verticalalignment='top',
+                    transform=ccrs.Geodetic(),
+                )
             elif label == '0':
-                axs[row][col].text(x,
-                                   y,
-                                   label,
-                                   fontsize=7,
-                                   horizontalalignment='center',
-                                   verticalalignment='bottom',
-                                   transform=ccrs.Geodetic())
+                axs[row][col].text(
+                    x,
+                    y,
+                    label,
+                    fontsize=7,
+                    horizontalalignment='center',
+                    verticalalignment='bottom',
+                    transform=ccrs.Geodetic(),
+                )
             else:
-                axs[row][col].text(x,
-                                   y,
-                                   label,
-                                   fontsize=7,
-                                   horizontalalignment='center',
-                                   verticalalignment='center',
-                                   transform=ccrs.Geodetic())
+                axs[row][col].text(
+                    x,
+                    y,
+                    label,
+                    fontsize=7,
+                    horizontalalignment='center',
+                    verticalalignment='center',
+                    transform=ccrs.Geodetic(),
+                )
 
         # Set boundary of plot to be circular
         gv.set_map_boundary(axs[row][col], (-180, 180), (0, 90), south_pad=1)
         # Create inset axes for color bars
-        cax[row][col] = inset_axes(axs[row][col],
-                                   width='5%',
-                                   height='100%',
-                                   loc='lower right',
-                                   bbox_to_anchor=(0.175, 0, 1, 1),
-                                   bbox_transform=axs[row][col].transAxes,
-                                   borderpad=0)
+        cax[row][col] = inset_axes(
+            axs[row][col],
+            width='5%',
+            height='100%',
+            loc='lower right',
+            bbox_to_anchor=(0.175, 0, 1, 1),
+            bbox_transform=axs[row][col].transAxes,
+            borderpad=0,
+        )
 # Import color map
 cmap = "magma"
 
 # Plot filled contours
 contour = np.empty((2, 2), dtype=mcontour.ContourSet)
-contour[0][0] = data[0][0].plot.contourf(ax=axs[0][0],
-                                         cmap=cmap,
-                                         levels=np.arange(-2, 34, 2),
-                                         transform=ccrs.PlateCarree(),
-                                         add_colorbar=False,
-                                         zorder=0)
-contour[0][1] = data[0][1].plot.contourf(ax=axs[0][1],
-                                         cmap=cmap,
-                                         levels=np.arange(-4, 30, 2),
-                                         transform=ccrs.PlateCarree(),
-                                         add_colorbar=False,
-                                         zorder=0)
-contour[1][0] = data[1][0].plot.contourf(ax=axs[1][0],
-                                         cmap=cmap,
-                                         levels=15,
-                                         transform=ccrs.PlateCarree(),
-                                         add_colorbar=False,
-                                         zorder=0)
-contour[1][1] = data[1][1].plot.contourf(ax=axs[1][1],
-                                         cmap=cmap,
-                                         levels=12,
-                                         transform=ccrs.PlateCarree(),
-                                         add_colorbar=False,
-                                         zorder=0)
+contour[0][0] = data[0][0].plot.contourf(
+    ax=axs[0][0],
+    cmap=cmap,
+    levels=np.arange(-2, 34, 2),
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    zorder=0,
+)
+contour[0][1] = data[0][1].plot.contourf(
+    ax=axs[0][1],
+    cmap=cmap,
+    levels=np.arange(-4, 30, 2),
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    zorder=0,
+)
+contour[1][0] = data[1][0].plot.contourf(
+    ax=axs[1][0],
+    cmap=cmap,
+    levels=15,
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    zorder=0,
+)
+contour[1][1] = data[1][1].plot.contourf(
+    ax=axs[1][1],
+    cmap=cmap,
+    levels=12,
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    zorder=0,
+)
 
 # Plot contour lines
-data[0][0].plot.contour(ax=axs[0][0],
-                        colors='black',
-                        linestyles='solid',
-                        linewidths=0.5,
-                        levels=np.arange(-2, 34, 2),
-                        transform=ccrs.PlateCarree(),
-                        zorder=1)
-data[0][1].plot.contour(ax=axs[0][1],
-                        colors='black',
-                        linestyles='solid',
-                        linewidths=0.5,
-                        levels=np.arange(-4, 30, 2),
-                        transform=ccrs.PlateCarree(),
-                        zorder=1)
-data[1][0].plot.contour(ax=axs[1][0],
-                        colors='black',
-                        linestyles='solid',
-                        linewidths=0.5,
-                        levels=15,
-                        transform=ccrs.PlateCarree(),
-                        zorder=1)
-data[1][1].plot.contour(ax=axs[1][1],
-                        colors='black',
-                        linestyles='solid',
-                        linewidths=0.5,
-                        levels=12,
-                        transform=ccrs.PlateCarree(),
-                        zorder=1)
+data[0][0].plot.contour(
+    ax=axs[0][0],
+    colors='black',
+    linestyles='solid',
+    linewidths=0.5,
+    levels=np.arange(-2, 34, 2),
+    transform=ccrs.PlateCarree(),
+    zorder=1,
+)
+data[0][1].plot.contour(
+    ax=axs[0][1],
+    colors='black',
+    linestyles='solid',
+    linewidths=0.5,
+    levels=np.arange(-4, 30, 2),
+    transform=ccrs.PlateCarree(),
+    zorder=1,
+)
+data[1][0].plot.contour(
+    ax=axs[1][0],
+    colors='black',
+    linestyles='solid',
+    linewidths=0.5,
+    levels=15,
+    transform=ccrs.PlateCarree(),
+    zorder=1,
+)
+data[1][1].plot.contour(
+    ax=axs[1][1],
+    colors='black',
+    linestyles='solid',
+    linewidths=0.5,
+    levels=12,
+    transform=ccrs.PlateCarree(),
+    zorder=1,
+)
 
 # Create colorbars and reduce the font size
 for row in range(0, 2):
@@ -358,13 +420,9 @@ for row in range(0, 2):
 # Format titles for each subplot
 for row in range(0, 2):
     for col in range(0, 2):
-        axs[row][col].set_title(data[row][col].long_name,
-                                loc='left',
-                                fontsize=7,
-                                pad=20)
-        axs[row][col].set_title(data[row][col].units,
-                                loc='right',
-                                fontsize=7,
-                                pad=20)
+        axs[row][col].set_title(
+            data[row][col].long_name, loc='left', fontsize=7, pad=20
+        )
+        axs[row][col].set_title(data[row][col].units, loc='right', fontsize=7, pad=20)
 
 plt.show()

--- a/Gallery/Panels/NCL_panel_7.py
+++ b/Gallery/Panels/NCL_panel_7.py
@@ -41,20 +41,21 @@ U = ds.U
 # See https://matplotlib.org/tutorials/intermediate/constrainedlayout_guide.html
 # Generate figure and axes using Cartopy projection
 projection = ccrs.PlateCarree()
-fig, ax = plt.subplots(3,
-                       1,
-                       constrained_layout=True,
-                       subplot_kw={"projection": projection})
+fig, ax = plt.subplots(
+    3, 1, constrained_layout=True, subplot_kw={"projection": projection}
+)
 
 # Set figure size (width, height) in inches
 fig.set_size_inches((6, 9.6))
 
 # Add continents
-continents = cartopy.feature.NaturalEarthFeature(name="coastline",
-                                                 category="physical",
-                                                 scale="50m",
-                                                 edgecolor="None",
-                                                 facecolor="lightgray")
+continents = cartopy.feature.NaturalEarthFeature(
+    name="coastline",
+    category="physical",
+    scale="50m",
+    edgecolor="None",
+    facecolor="lightgray",
+)
 [axes.add_feature(continents) for axes in ax.flat]
 
 # Specify which contour levels to draw
@@ -89,56 +90,64 @@ for axes in ax.flat:
     axes.clabel(contour, labels, fontsize="small", fmt="%.0f")
 
     # Add lower text box
-    axes.text(0.995,
-              0.03,
-              "CONTOUR FROM -10 TO 35 BY 5",
-              horizontalalignment='right',
-              transform=axes.transAxes,
-              fontsize=8,
-              bbox=dict(boxstyle='square, pad=0.25',
-                        facecolor='white',
-                        edgecolor='gray'),
-              zorder=5)
+    axes.text(
+        0.995,
+        0.03,
+        "CONTOUR FROM -10 TO 35 BY 5",
+        horizontalalignment='right',
+        transform=axes.transAxes,
+        fontsize=8,
+        bbox=dict(boxstyle='square, pad=0.25', facecolor='white', edgecolor='gray'),
+        zorder=5,
+    )
 
     # Use geocat.viz.util convenience function to add left and right title to the plot axes.
-    gv.set_titles_and_labels(axes,
-                             lefttitle="Zonal Wind",
-                             lefttitlefontsize=12,
-                             righttitle=U.units,
-                             righttitlefontsize=12)
+    gv.set_titles_and_labels(
+        axes,
+        lefttitle="Zonal Wind",
+        lefttitlefontsize=12,
+        righttitle=U.units,
+        righttitlefontsize=12,
+    )
 
 # Panel 1: Contourf-plot U data with '//' and '..' hatch styles
-U.plot.contourf(ax=ax[0],
-                transform=projection,
-                levels=levels,
-                yticks=np.arange(-90, 91, 30),
-                cmap='none',
-                hatches=['//', '//', '', '', '', '', '', '', '', '..', '..'],
-                add_colorbar=False,
-                add_labels=False,
-                zorder=4)
+U.plot.contourf(
+    ax=ax[0],
+    transform=projection,
+    levels=levels,
+    yticks=np.arange(-90, 91, 30),
+    cmap='none',
+    hatches=['//', '//', '', '', '', '', '', '', '', '..', '..'],
+    add_colorbar=False,
+    add_labels=False,
+    zorder=4,
+)
 
 # Panel 2: Contourf-plot U data (for shading)
-U.plot.contourf(ax=ax[1],
-                transform=projection,
-                levels=levels,
-                yticks=np.arange(-90, 91, 30),
-                cmap='none',
-                hatches=['//', '//', '//', '', '', '', '', '', '', '', ''],
-                add_colorbar=False,
-                add_labels=False,
-                zorder=4)
+U.plot.contourf(
+    ax=ax[1],
+    transform=projection,
+    levels=levels,
+    yticks=np.arange(-90, 91, 30),
+    cmap='none',
+    hatches=['//', '//', '//', '', '', '', '', '', '', '', ''],
+    add_colorbar=False,
+    add_labels=False,
+    zorder=4,
+)
 
 # Panel 3: Contourf-plot U data (for shading)
-U.plot.contourf(ax=ax[2],
-                transform=projection,
-                levels=levels,
-                yticks=np.arange(-90, 91, 30),
-                cmap='none',
-                hatches=['', '', '', '', '', '', '', '', '', '..', '..'],
-                add_colorbar=False,
-                add_labels=False,
-                zorder=4)
+U.plot.contourf(
+    ax=ax[2],
+    transform=projection,
+    levels=levels,
+    yticks=np.arange(-90, 91, 30),
+    cmap='none',
+    hatches=['', '', '', '', '', '', '', '', '', '..', '..'],
+    add_colorbar=False,
+    add_labels=False,
+    zorder=4,
+)
 
 # Customizing line width and dot size of shading patterns
 mpl.rcParams['hatch.linewidth'] = 0.5

--- a/Gallery/Panels/NCL_panel_9.py
+++ b/Gallery/Panels/NCL_panel_9.py
@@ -45,10 +45,7 @@ fig = plt.figure(figsize=(10, 12))
 
 # Create grid with two rows and one column
 # Use `height_ratios` to adjust the relative height of the rows
-grid = gridspec.GridSpec(nrows=2,
-                         ncols=1,
-                         height_ratios=[0.75, 0.25],
-                         figure=fig)
+grid = gridspec.GridSpec(nrows=2, ncols=1, height_ratios=[0.75, 0.25], figure=fig)
 
 # Specify the projection
 proj = ccrs.NorthPolarStereo()
@@ -65,17 +62,16 @@ gv.set_map_boundary(ax1, [-180, 180], [30, 90], south_pad=1)
 ax2 = plt.subplot(grid[1])
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax=ax2,
-                             xlim=(ds.time[0], ds.time[-1]),
-                             ylim=(-4, 3),
-                             yticks=np.arange(-4, 4, 1),
-                             yticklabels=np.arange(-4.0, 4.0, 1.0))
+gv.set_axes_limits_and_ticks(
+    ax=ax2,
+    xlim=(ds.time[0], ds.time[-1]),
+    ylim=(-4, 3),
+    yticks=np.arange(-4, 4, 1),
+    yticklabels=np.arange(-4.0, 4.0, 1.0),
+)
 
 # Use geocat.viz.util convenience function to add minor and major ticks
-gv.add_major_minor_ticks(ax=ax2,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax=ax2, x_minor_per_major=4, y_minor_per_major=5, labelsize=12)
 
 # Create list of colors based on Blue-White-Red colormap
 cmap = cmaps.BlWhRe  # select colormap
@@ -85,30 +81,32 @@ index = [98, 88, 73, 69, 66, 63, 60, 58, 55, 53, 50, 50, 47, 45, 42, 40, 37, 34]
 color_list = [cmap[i].colors for i in index]
 
 # Plot contour data (use `color` keyword vs `cmap` for lists of colors)
-contour_fill = deppat.plot.contourf(ax=ax1,
-                                    transform=ccrs.PlateCarree(),
-                                    vmin=-5.5,
-                                    vmax=3.5,
-                                    levels=19,
-                                    colors=color_list,
-                                    add_colorbar=False)
+contour_fill = deppat.plot.contourf(
+    ax=ax1,
+    transform=ccrs.PlateCarree(),
+    vmin=-5.5,
+    vmax=3.5,
+    levels=19,
+    colors=color_list,
+    add_colorbar=False,
+)
 
 # Create colorbar
-plt.colorbar(contour_fill,
-             ax=ax1,
-             ticks=np.arange(-5, 3.5, 0.5),
-             drawedges=True,
-             format='%g')  # remove trailing zeros from labels
+plt.colorbar(
+    contour_fill, ax=ax1, ticks=np.arange(-5, 3.5, 0.5), drawedges=True, format='%g'
+)  # remove trailing zeros from labels
 
 # Plot contour lines
-deppat.plot.contour(ax=ax1,
-                    transform=ccrs.PlateCarree(),
-                    vmin=-5.5,
-                    vmax=3.5,
-                    levels=19,
-                    colors='black',
-                    linewidths=0.25,
-                    linestyles='solid')
+deppat.plot.contour(
+    ax=ax1,
+    transform=ccrs.PlateCarree(),
+    vmin=-5.5,
+    vmax=3.5,
+    levels=19,
+    colors='black',
+    linewidths=0.25,
+    linestyles='solid',
+)
 
 # Add mean temperature over time data to XY plot
 line = ax2.plot(xyarr.time, xyarr, linewidth=0.25, color='black')
@@ -124,8 +122,9 @@ ax2.fill_between(x, y, where=y < 0, color='blue', interpolate=True)
 ax2.axhline(y=0, color='black', linewidth=0.5)
 
 # Array with weights for rolling average
-weight = xr.DataArray([1 / 24, 3 / 24, 5 / 24, 6 / 24, 5 / 24, 3 / 24, 1 / 24],
-                      dims=['window'])
+weight = xr.DataArray(
+    [1 / 24, 3 / 24, 5 / 24, 6 / 24, 5 / 24, 3 / 24, 1 / 24], dims=['window']
+)
 
 # Calculating the dot product of rolling average and weights
 roll_avg = xyarr.rolling(time=7, center=True).construct('window').dot(weight)
@@ -134,9 +133,6 @@ roll_avg = xyarr.rolling(time=7, center=True).construct('window').dot(weight)
 ax2.plot(xyarr.time, roll_avg, color='black', linewidth=1)
 
 # Add figure title
-fig.suptitle("North Atlantic Oscillation (DJF)",
-             fontsize=16,
-             fontweight='bold',
-             y=0.95)
+fig.suptitle("North Atlantic Oscillation (DJF)", fontsize=16, fontweight='bold', y=0.95)
 
 plt.show()

--- a/Gallery/Polygons/NCL_polyg_18.py
+++ b/Gallery/Polygons/NCL_polyg_18.py
@@ -44,11 +44,13 @@ grid = plt.GridSpec(2, 20, figure=fig)
 ax = plt.subplot(grid[:-1, 1:], projection=ccrs.PlateCarree())
 
 # Add continents
-continents = cartopy.feature.NaturalEarthFeature(name='land',
-                                                 category='physical',
-                                                 scale='50m',
-                                                 edgecolor='None',
-                                                 facecolor='lightgray')
+continents = cartopy.feature.NaturalEarthFeature(
+    name='land',
+    category='physical',
+    scale='50m',
+    edgecolor='None',
+    facecolor='lightgray',
+)
 
 ax.add_feature(continents)
 
@@ -62,54 +64,76 @@ lat = np.arange(-80, 80, 10)
 # Create array with marker symbols
 # Matplotlib provides a different set of markers than NCL, so plot appearance differs
 marker = [
-    '.', '+', '*', 'o', 'x', 's', '^', 'v', 'D', '>', '<', 'p', 'h', '8', 'X',
-    'd'
+    '.',
+    '+',
+    '*',
+    'o',
+    'x',
+    's',
+    '^',
+    'v',
+    'D',
+    '>',
+    '<',
+    'p',
+    'h',
+    '8',
+    'X',
+    'd',
 ]
 
 # Draw markers on diagonal line across graph
 for x in range(len(lon)):
-    ax.plot(lon[x],
-            lat[x],
-            marker=marker[x],
-            color='blue',
-            fillstyle='none',
-            markersize=18,
-            zorder=3)
+    ax.plot(
+        lon[x],
+        lat[x],
+        marker=marker[x],
+        color='blue',
+        fillstyle='none',
+        markersize=18,
+        zorder=3,
+    )
 
 # Draw small red box in upper center
 ax.add_patch(
-    mpatches.Rectangle(xy=[7, 47],
-                       width=9,
-                       height=7,
-                       facecolor='None',
-                       edgecolor='red',
-                       alpha=1.0,
-                       transform=ccrs.PlateCarree(),
-                       zorder=5))
+    mpatches.Rectangle(
+        xy=[7, 47],
+        width=9,
+        height=7,
+        facecolor='None',
+        edgecolor='red',
+        alpha=1.0,
+        transform=ccrs.PlateCarree(),
+        zorder=5,
+    )
+)
 
 # Draw green window in bottom right
 ax.add_patch(
-    mpatches.Rectangle(xy=[110, -45],
-                       width=50,
-                       height=35,
-                       facecolor='lime',
-                       alpha=0.3,
-                       transform=ccrs.PlateCarree(),
-                       zorder=5))
+    mpatches.Rectangle(
+        xy=[110, -45],
+        width=50,
+        height=35,
+        facecolor='lime',
+        alpha=0.3,
+        transform=ccrs.PlateCarree(),
+        zorder=5,
+    )
+)
 
 # Use gv function to set the ticks on axes
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=None,
-                             ylim=None,
-                             xticks=np.arange(-180, 210, 30),
-                             yticks=np.arange(-90, 120, 30),
-                             xticklabels=None,
-                             yticklabels=None)
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=None,
+    ylim=None,
+    xticks=np.arange(-180, 210, 30),
+    yticks=np.arange(-90, 120, 30),
+    xticklabels=None,
+    yticklabels=None,
+)
 
 # Use gv function to give ticks W/N/E/S labels
-gv.add_lat_lon_ticklabels(ax,
-                          zero_direction_label=True,
-                          dateline_direction_label=True)
+gv.add_lat_lon_ticklabels(ax, zero_direction_label=True, dateline_direction_label=True)
 
 # Took out degree symbols in latitude/longitude
 ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
@@ -118,16 +142,16 @@ ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 # Use gv function to set title of plot
 # Set title font to bold using the r"$\bf{_____}$" formatting characters
 # Spaces in title will not show up if included in curly brackets
-gv.set_titles_and_labels(ax,
-                         maintitle=r"$\bf{Big}$" + " " + r"$\bf{centered}$" +
-                         " " + r"$\bf{title}$",
-                         maintitlefontsize=25)
+gv.set_titles_and_labels(
+    ax,
+    maintitle=r"$\bf{Big}$" + " " + r"$\bf{centered}$" + " " + r"$\bf{title}$",
+    maintitlefontsize=25,
+)
 
 # Use gv function to plot three minor ticks for every major tick on axes
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=3,
-                         labelsize="small")
+gv.add_major_minor_ticks(
+    ax, x_minor_per_major=3, y_minor_per_major=3, labelsize="small"
+)
 
 # Make second subplot for legend
 ax2 = plt.subplot(grid[-1, 1:], frameon=False)
@@ -138,56 +162,61 @@ removeTicks(ax2)
 # [starting (bottom left) x coordinate of window, starting y coordinate of window, width of field, height of field]
 
 # Add circle
-axin1 = ax2.inset_axes([0.1, 0.8, .1, .1], frameon=False)
+axin1 = ax2.inset_axes([0.1, 0.8, 0.1, 0.1], frameon=False)
 removeTicks(axin1)
-axin1.add_patch(mpatches.Circle((0.1, 0.1), radius=.1, color='blue'))
+axin1.add_patch(mpatches.Circle((0.1, 0.1), radius=0.1, color='blue'))
 axin1.axis('equal')
 
 # Add label for circle
-axin2 = ax2.inset_axes([0.0, 0.65, .20, .5], frameon=False)
+axin2 = ax2.inset_axes([0.0, 0.65, 0.20, 0.5], frameon=False)
 removeTicks(axin2)
-axin2.text(0,
-           .7,
-           'Marker (left justified text)',
-           color='blue',
-           fontsize=12,
-           verticalalignment='center')
+axin2.text(
+    0,
+    0.7,
+    'Marker (left justified text)',
+    color='blue',
+    fontsize=12,
+    verticalalignment='center',
+)
 
 # Add red line
-axin3 = ax2.inset_axes([0.30, 0.6, .33, .5], frameon=False)
+axin3 = ax2.inset_axes([0.30, 0.6, 0.33, 0.5], frameon=False)
 removeTicks(axin3)
 axin3.plot([0, 4], [3, 3], color='red')
 axin1.axis('scaled')
 
 # Add label for red line
-axin4 = ax2.inset_axes([0.33, 0.65, .33, .5], frameon=False)
+axin4 = ax2.inset_axes([0.33, 0.65, 0.33, 0.5], frameon=False)
 removeTicks(axin4)
-axin4.text(0,
-           .7,
-           'Polyline (centered text)',
-           color='red',
-           fontsize=12,
-           verticalalignment='center')
+axin4.text(
+    0,
+    0.7,
+    'Polyline (centered text)',
+    color='red',
+    fontsize=12,
+    verticalalignment='center',
+)
 
 # Add green polygon
-axin5 = ax2.inset_axes([0.62, 0.6, .33, .5], frameon=False)
+axin5 = ax2.inset_axes([0.62, 0.6, 0.33, 0.5], frameon=False)
 removeTicks(axin5)
 axin5.add_patch(
-    mpatches.Rectangle(xy=[.3, .3],
-                       width=.6,
-                       height=.3,
-                       facecolor='lime',
-                       alpha=0.3))
+    mpatches.Rectangle(
+        xy=[0.3, 0.3], width=0.6, height=0.3, facecolor='lime', alpha=0.3
+    )
+)
 axin1.axis('scaled')
 
 # Add label for green polygon
-axin6 = ax2.inset_axes([0.66, 0.65, .33, .5], frameon=False)
+axin6 = ax2.inset_axes([0.66, 0.65, 0.33, 0.5], frameon=False)
 removeTicks(axin6)
-axin6.text(0,
-           .7,
-           'Polygon (right justified text)',
-           color='lime',
-           fontsize=12,
-           verticalalignment='center')
+axin6.text(
+    0,
+    0.7,
+    'Polygon (right justified text)',
+    color='lime',
+    fontsize=12,
+    verticalalignment='center',
+)
 
 plt.show()

--- a/Gallery/Polygons/NCL_polyg_19.py
+++ b/Gallery/Polygons/NCL_polyg_19.py
@@ -49,8 +49,7 @@ file11 = open(gdf.get("shape_files/gadm36_PRI_0.shx"), 'r')
 file12 = open(gdf.get("shape_files/gadm36_PRI_0.prj"), 'r')
 
 # Open the text file with the population data
-state_population_file = open(gdf.get("ascii_files/us_state_population.txt"),
-                             'r')
+state_population_file = open(gdf.get("ascii_files/us_state_population.txt"), 'r')
 # Open shapefiles
 us = shp.Reader(gdf.get("shape_files/gadm36_USA_1.dbf"))
 usdetailed = shp.Reader(gdf.get("shape_files/gadm36_USA_2.dbf"))
@@ -59,11 +58,24 @@ pr = shp.Reader(gdf.get("shape_files/gadm36_PRI_0.dbf"))
 ###############################################################################
 # Set colormap data and colormap bounds:
 
-colormap = colors.ListedColormap([
-    'lightpink', 'wheat', 'palegreen', 'powderblue', 'thistle', 'lightcoral',
-    'peru', 'dodgerblue', 'slateblue', 'firebrick', 'sienna', 'olivedrab',
-    'steelblue', 'navy'
-])
+colormap = colors.ListedColormap(
+    [
+        'lightpink',
+        'wheat',
+        'palegreen',
+        'powderblue',
+        'thistle',
+        'lightcoral',
+        'peru',
+        'dodgerblue',
+        'slateblue',
+        'firebrick',
+        'sienna',
+        'olivedrab',
+        'steelblue',
+        'navy',
+    ]
+)
 
 colorbounds = [0, 1, 2.5, 3, 4, 5, 6, 7, 8, 9, 10, 12, 25, 38, 40]
 
@@ -74,7 +86,6 @@ norm = colors.BoundaryNorm(colorbounds, colormap.N)
 
 
 def getStatePopulations(state_population_file):
-
     population_dict = {}
     Lines = state_population_file.read().splitlines()
     for line in Lines:
@@ -91,9 +102,7 @@ def getStatePopulations(state_population_file):
 
 
 def findDivColor(colorbounds, pdata):
-
     for x in range(len(colorbounds)):
-
         if pdata >= colorbounds[len(colorbounds) - 1]:
             return colormap.colors[x - 1]
         if pdata >= colorbounds[x]:
@@ -108,7 +117,6 @@ def findDivColor(colorbounds, pdata):
 
 
 def removeTicks(axis):
-
     axis.get_xaxis().set_visible(False)
     axis.get_yaxis().set_visible(False)
 
@@ -118,14 +126,12 @@ def removeTicks(axis):
 
 
 def plotRegion(region, axis, xlim, puertoRico, waterBody):
-
     # Create empty lists for filled polygons or" patches" and "water_patches"
     patches = []
     water_patches = []
 
     # Plot each shape within a region (ex. mainland Alaska and all of it's surrounding Alaskan islands)
     for i in range(len(region.shape.parts)):
-
         i_start = region.shape.parts[i]
         if i == len(region.shape.parts) - 1:
             i_end = len(region.shape.points)
@@ -164,33 +170,25 @@ def plotRegion(region, axis, xlim, puertoRico, waterBody):
             color = findDivColor(colorbounds, pop)
             # Set characteristics and measurements of each filled polygon "patch"
             patches.append(
-                Polygon(np.vstack((x, y)).T,
-                        closed=True,
-                        color=color,
-                        linewidth=0.1))
+                Polygon(np.vstack((x, y)).T, closed=True, color=color, linewidth=0.1)
+            )
 
         # If the region being plotted is a body of water with no population
         else:
             # Set characteristics and measurements of each filled polygon "patch"
             water_patches.append(
-                Polygon(np.vstack((x, y)).T,
-                        closed=True,
-                        color='white',
-                        linewidth=.7))
+                Polygon(np.vstack((x, y)).T, closed=True, color='white', linewidth=0.7)
+            )
 
-    pc = PatchCollection(patches,
-                         match_original=True,
-                         edgecolor='k',
-                         linewidths=0.1,
-                         zorder=2)
+    pc = PatchCollection(
+        patches, match_original=True, edgecolor='k', linewidths=0.1, zorder=2
+    )
     # Plot filled region on axis
     axis.add_collection(pc)
 
-    wpc = PatchCollection(water_patches,
-                          match_original=True,
-                          edgecolor='white',
-                          linewidth=.8,
-                          zorder=3)
+    wpc = PatchCollection(
+        water_patches, match_original=True, edgecolor='white', linewidth=0.8, zorder=3
+    )
     # Plot filled region on axis
     axis.add_collection(wpc)
 
@@ -200,12 +198,9 @@ def plotRegion(region, axis, xlim, puertoRico, waterBody):
 
 # Create figure
 fig = plt.figure(figsize=(8, 8))
-spec = gridspec.GridSpec(ncols=1,
-                         nrows=2,
-                         hspace=0.05,
-                         wspace=0.1,
-                         figure=fig,
-                         height_ratios=[2, 1])
+spec = gridspec.GridSpec(
+    ncols=1, nrows=2, hspace=0.05, wspace=0.1, figure=fig, height_ratios=[2, 1]
+)
 
 # Create upper axis
 ax1 = fig.add_subplot(spec[0, 0], frameon=False)
@@ -228,14 +223,10 @@ population_dict = getStatePopulations(state_population_file)
 
 # Plot every shape in the US shapefile
 for shape in us.shapeRecords():
-
     if shape.record[3] == 'Alaska':
         plotRegion(shape, axin1, [None, 100], puertoRico=False, waterBody=False)
     elif shape.record[3] == 'Hawaii':
-        plotRegion(shape,
-                   axin2, [-161, None],
-                   puertoRico=False,
-                   waterBody=False)
+        plotRegion(shape, axin2, [-161, None], puertoRico=False, waterBody=False)
     else:
         plotRegion(shape, ax1, [None, None], puertoRico=False, waterBody=False)
 
@@ -249,18 +240,28 @@ for shape in usdetailed.shapeRecords():
         plotRegion(shape, ax1, [None, None], puertoRico=False, waterBody=True)
 
 # Set title using helper function from geocat-viz
-title = r"$\bf{Population}$" + " " + r"$\bf{in}$" + " " + r"$\bf{Millions}$" + " " + r"$\bf{(2014)}$"
+title = (
+    r"$\bf{Population}$"
+    + " "
+    + r"$\bf{in}$"
+    + " "
+    + r"$\bf{Millions}$"
+    + " "
+    + r"$\bf{(2014)}$"
+)
 gv.set_titles_and_labels(ax1, maintitle=title, maintitlefontsize=18)
 
 # Create fourth inset axis for colorbar
 axin4 = inset_axes(ax2, width="115%", height="12%", loc='center')
 
 # Create colorbar
-cb = fig.colorbar(cm.ScalarMappable(cmap=colormap, norm=norm),
-                  cax=axin4,
-                  boundaries=colorbounds,
-                  ticks=colorbounds[1:-1],
-                  spacing='uniform',
-                  orientation='horizontal')
+cb = fig.colorbar(
+    cm.ScalarMappable(cmap=colormap, norm=norm),
+    cax=axin4,
+    boundaries=colorbounds,
+    ticks=colorbounds[1:-1],
+    spacing='uniform',
+    orientation='horizontal',
+)
 
 plt.show()

--- a/Gallery/Polygons/NCL_polyg_2.py
+++ b/Gallery/Polygons/NCL_polyg_2.py
@@ -38,17 +38,31 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 # Read in data
 
 # Open climate division datafile and add to xarray
-ds = xr.open_dataset(gdf.get("netcdf_files/climdiv_prcp_1899-1999.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(
+    gdf.get("netcdf_files/climdiv_prcp_1899-1999.nc"), decode_times=False
+)
 
 ###############################################################################
 # Initialize color map and bounds for each color
 
-colormap = colors.ListedColormap([
-    'mediumpurple', 'mediumblue', 'royalblue', 'cornflowerblue', 'lightblue',
-    'lightseagreen', 'yellowgreen', 'green', 'wheat', 'tan', 'gold', 'orange',
-    'red', 'firebrick'
-])
+colormap = colors.ListedColormap(
+    [
+        'mediumpurple',
+        'mediumblue',
+        'royalblue',
+        'cornflowerblue',
+        'lightblue',
+        'lightseagreen',
+        'yellowgreen',
+        'green',
+        'wheat',
+        'tan',
+        'gold',
+        'orange',
+        'red',
+        'firebrick',
+    ]
+)
 
 # Values represent average number of inches of rain
 colorbounds = [0, 5, 10, 15, 20, 25, 30, 35, 40, 50, 60, 70, 80, 90, 100]
@@ -58,9 +72,7 @@ colorbounds = [0, 5, 10, 15, 20, 25, 30, 35, 40, 50, 60, 70, 80, 90, 100]
 
 
 def findDivColor(colorbounds, pdata):
-
     for x in range(len(colorbounds)):
-
         if pdata >= colorbounds[len(colorbounds) - 1]:
             return colormap.colors[x - 1]
         if pdata >= colorbounds[x]:
@@ -78,40 +90,35 @@ fig = plt.figure(figsize=(8, 8))
 
 # Add axes for lambert conformal map
 # Set dimensions of axes with [X0, Y0, width, height] argument. Each value is a fraction of total figure size.
-ax = plt.axes([.05, -.05, .9, 1],
-              projection=ccrs.LambertConformal(),
-              frameon=False)
+ax = plt.axes([0.05, -0.05, 0.9, 1], projection=ccrs.LambertConformal(), frameon=False)
 
 # Set latitude and longitude extent of map
 ax.set_extent([-119, -74, 18, 50], ccrs.Geodetic())
 
 # Set shape name of map (which depicts the United States)
 shapename = 'admin_1_states_provinces_lakes'
-states_shp = shpreader.natural_earth(resolution='110m',
-                                     category='cultural',
-                                     name=shapename)
+states_shp = shpreader.natural_earth(
+    resolution='110m', category='cultural', name=shapename
+)
 
 # Set title and title fontsize of plot using gv function instead of matplotlib function call
 gv.set_titles_and_labels(
     ax,
-    maintitle=
-    "Average Annual Precipiation \n Computed for the period 1899-1999 \n NCDC climate division data \n",
-    maintitlefontsize=18)
+    maintitle="Average Annual Precipiation \n Computed for the period 1899-1999 \n NCDC climate division data \n",
+    maintitlefontsize=18,
+)
 
 # Add outlines of each state within the United States
 for state in shpreader.Reader(states_shp).geometries():
-
     facecolor = 'white'
     edgecolor = 'black'
 
-    ax.add_geometries([state],
-                      ccrs.PlateCarree(),
-                      facecolor=facecolor,
-                      edgecolor=edgecolor)
+    ax.add_geometries(
+        [state], ccrs.PlateCarree(), facecolor=facecolor, edgecolor=edgecolor
+    )
 
 # For each variable (climate division) in data set, create outline on map and fill with random color
 for varname, da in ds.data_vars.items():
-
     # This condition is included because first item in xarray only has one attribute, 'current date'
     if hasattr(da, 'state_name'):
         # Get number of years of data by dividing number of months recorded (length of array) by 12 (12 months per year)
@@ -134,11 +141,13 @@ for varname, da in ds.data_vars.items():
         track = sgeom.LineString(zip(lon, lat))
 
         # Add division outlines to map
-        im = ax.add_geometries([track],
-                               ccrs.PlateCarree(),
-                               facecolor=color,
-                               edgecolor='black',
-                               linewidths=.5)
+        im = ax.add_geometries(
+            [track],
+            ccrs.PlateCarree(),
+            facecolor=color,
+            edgecolor='black',
+            linewidths=0.5,
+        )
 
 # Create and plot colorbar
 
@@ -149,12 +158,14 @@ norm = colors.BoundaryNorm(colorbounds, colormap.N)
 axins1 = inset_axes(ax, width="75%", height="3%", loc='lower center')
 
 # Add colorbar to plot
-cb = fig.colorbar(cm.ScalarMappable(cmap=colormap, norm=norm),
-                  cax=axins1,
-                  boundaries=colorbounds,
-                  ticks=colorbounds,
-                  spacing='uniform',
-                  orientation='horizontal',
-                  label='inches')
+cb = fig.colorbar(
+    cm.ScalarMappable(cmap=colormap, norm=norm),
+    cax=axins1,
+    boundaries=colorbounds,
+    ticks=colorbounds,
+    spacing='uniform',
+    orientation='horizontal',
+    label='inches',
+)
 
 plt.show()

--- a/Gallery/Polygons/NCL_polyg_4.py
+++ b/Gallery/Polygons/NCL_polyg_4.py
@@ -45,7 +45,6 @@ ds = xr.open_dataset(gdf.get("netcdf_files/uv300.nc")).isel(time=1)
 # Define a utility function to create the basic contour plot, which will get used twice to create two slightly
 # different plots
 def make_base_plot():
-
     # Generate axes using Cartopy projection
     ax = plt.axes(projection=ccrs.PlateCarree())
 
@@ -105,7 +104,8 @@ def make_base_plot():
         colors="black",
         fmt="%.0f",  # Turn off decimal points
         manual=label_locations,  # Manual label locations
-        inline=False)  # Don't remove the contour line where labels are located.
+        inline=False,
+    )  # Don't remove the contour line where labels are located.
 
     # Create a rectangle patch, to color the border of the rectangle a different color.
     # Specify the rectangle as a corner point with width and height, to help place border text more easily.
@@ -122,7 +122,8 @@ def make_base_plot():
         fill=False,
         zorder=3,  # Plot on top of the purple box border.
         edgecolor='red',
-        alpha=0.5)  # Lower color intensity.
+        alpha=0.5,
+    )  # Lower color intensity.
     ax.add_patch(p)
 
     # Draw text labels around the box.
@@ -130,18 +131,18 @@ def make_base_plot():
     # Create "text_args" to keep from repeating code when drawing text.
     text_shared_args = dict(
         fontsize=8,
-        bbox=dict(boxstyle='square, pad=0',
-                  facecolor='white',
-                  edgecolor='white'),
+        bbox=dict(boxstyle='square, pad=0', facecolor='white', edgecolor='white'),
     )
 
     # Draw top text
-    ax.text(left + 0.6 * width,
-            top,
-            'test',
-            horizontalalignment='right',
-            verticalalignment='center',
-            **text_shared_args)
+    ax.text(
+        left + 0.6 * width,
+        top,
+        'test',
+        horizontalalignment='right',
+        verticalalignment='center',
+        **text_shared_args,
+    )
 
     # Draw bottom text.   Change text background to match the map.
     ax.text(
@@ -151,47 +152,53 @@ def make_base_plot():
         horizontalalignment='right',
         verticalalignment='center',
         fontsize=8,
-        bbox=dict(boxstyle='square, pad=0',
-                  facecolor='lightgrey',
-                  edgecolor='lightgrey'),
+        bbox=dict(
+            boxstyle='square, pad=0', facecolor='lightgrey', edgecolor='lightgrey'
+        ),
     )
 
     # Draw left text
-    ax.text(left,
-            top,
-            'test',
-            horizontalalignment='center',
-            verticalalignment='top',
-            rotation=90,
-            **text_shared_args)
+    ax.text(
+        left,
+        top,
+        'test',
+        horizontalalignment='center',
+        verticalalignment='top',
+        rotation=90,
+        **text_shared_args,
+    )
 
     # Draw right text
-    ax.text(right,
-            bottom,
-            'test',
-            horizontalalignment='center',
-            verticalalignment='bottom',
-            rotation=-90,
-            **text_shared_args)
+    ax.text(
+        right,
+        bottom,
+        'test',
+        horizontalalignment='center',
+        verticalalignment='bottom',
+        rotation=-90,
+        **text_shared_args,
+    )
 
     # Add lower text box.  Box appears off-center, but this is to leave room
     # for lower-case letters that drop lower.
-    ax.text(1.0,
-            -0.20,
-            "CONTOUR FROM -12 TO 40 BY 4",
-            fontname='Helvetica',
-            horizontalalignment='right',
-            transform=ax.transAxes,
-            bbox=dict(boxstyle='square, pad=0.15',
-                      facecolor='white',
-                      edgecolor='black'))
+    ax.text(
+        1.0,
+        -0.20,
+        "CONTOUR FROM -12 TO 40 BY 4",
+        fontname='Helvetica',
+        horizontalalignment='right',
+        transform=ax.transAxes,
+        bbox=dict(boxstyle='square, pad=0.15', facecolor='white', edgecolor='black'),
+    )
 
     # Use geocat.viz.util convenience function to add main title as well as titles to left and right of the plot axes.
-    gv.set_titles_and_labels(ax,
-                             lefttitle="Zonal Wind",
-                             lefttitlefontsize=12,
-                             righttitle="m/s",
-                             righttitlefontsize=12)
+    gv.set_titles_and_labels(
+        ax,
+        lefttitle="Zonal Wind",
+        lefttitlefontsize=12,
+        righttitle="m/s",
+        righttitlefontsize=12,
+    )
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
     gv.add_major_minor_ticks(ax, y_minor_per_major=4)
@@ -228,12 +235,11 @@ def draw_hatch_polygon(xvals, yvals, hatchcolor, hatchpattern):
         xvals,
         yvals,
         edgecolor=hatchcolor,
-        zorder=
-        -1,  # Place underneath contour map (larger zorder is closer to viewer).
+        zorder=-1,  # Place underneath contour map (larger zorder is closer to viewer).
         fill=False,
         linewidth=0.5,
         hatch=hatchpattern,
-        alpha=0.3  # Reduce color intensity
+        alpha=0.3,  # Reduce color intensity
     )
 
     # Hatch color and polygon edge color are tied together, so we have to draw a white polygon edge
@@ -242,10 +248,9 @@ def draw_hatch_polygon(xvals, yvals, hatchcolor, hatchpattern):
         xvals,
         yvals,
         edgecolor='white',
-        zorder=
-        0,  # Place on top of other polygon (larger zorder is closer to viewer).
+        zorder=0,  # Place on top of other polygon (larger zorder is closer to viewer).
         fill=False,
-        linewidth=1  # Slightly larger linewidth removes ghost edges.
+        linewidth=1,  # Slightly larger linewidth removes ghost edges.
     )
 
 
@@ -272,7 +277,7 @@ ax.fill(
     fill=False,
     hatch='...',  # Adding more or fewer dots to '...' will change hatch density.
     linewidth=0.5,  # Make each dot smaller
-    alpha=0.2  # Make hatch semi-transparent using alpha level in range [0, 1].
+    alpha=0.2,  # Make hatch semi-transparent using alpha level in range [0, 1].
 )
 
 # Draw some triangles with various hatch pattern densities.

--- a/Gallery/Polygons/NCL_polyg_8.py
+++ b/Gallery/Polygons/NCL_polyg_8.py
@@ -38,8 +38,14 @@ r = random.uniform(low=-1.2, high=35, size=npts)
 
 bins = [0, 5, 10, 15, 20, 23, 26]
 colors = [
-    'mediumpurple', 'mediumblue', 'blue', 'green', 'limegreen', 'greenyellow',
-    'gold', 'orangered'
+    'mediumpurple',
+    'mediumblue',
+    'blue',
+    'green',
+    'limegreen',
+    'greenyellow',
+    'gold',
+    'orangered',
 ]
 # increasing sizes for the markers in each bin
 sizes = np.linspace(15, 25, len(bins))
@@ -56,9 +62,9 @@ ax.add_feature(cfeature.LAND, color='silver', zorder=0)
 ax.add_feature(cfeature.LAKES, color='white', zorder=0)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-120, -80, 3),
-                             yticks=np.linspace(30, 50, 3))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.linspace(-120, -80, 3), yticks=np.linspace(30, 50, 3)
+)
 
 # Use geocat.viz.util convenience function to make latitude and longitude tick
 # labels
@@ -68,28 +74,20 @@ ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=12)
 
 # Use geocat.viz.util convenience function to add titles
 gv.set_titles_and_labels(
     ax,
     maintitlefontsize=16,
-    maintitle=
-    "Dummy station data colored and\nsized according to range of values")
+    maintitle="Dummy station data colored and\nsized according to range of values",
+)
 
 # Plot markers with values less than first bin value
 masked_lon = np.where(r < bins[0], lon, np.nan)
 masked_lat = np.where(r < bins[0], lat, np.nan)
 label = "x < " + str(bins[0])
-plt.scatter(masked_lon,
-            masked_lat,
-            label=label,
-            s=sizes[0],
-            color=colors[0],
-            zorder=1)
+plt.scatter(masked_lon, masked_lat, label=label, s=sizes[0], color=colors[0], zorder=1)
 
 # Plot all other markers but those in the last bin
 label_format = "{} <= x < {}"
@@ -99,29 +97,25 @@ for x in range(1, len(bins)):
     masked_lat = np.where(bins[x - 1] <= r, lat, np.nan)
     masked_lat = np.where(r < bins[x], masked_lat, np.nan)
     label = label_format.format(bins[x - 1], bins[x])
-    plt.scatter(masked_lon,
-                masked_lat,
-                label=label,
-                s=sizes[x],
-                color=colors[x],
-                zorder=1)
+    plt.scatter(
+        masked_lon, masked_lat, label=label, s=sizes[x], color=colors[x], zorder=1
+    )
 
 # Plot markers with values greater than or equal to last bin value
 masked_lon = np.where(r >= bins[-1], lon, np.nan)
 masked_lat = np.where(r >= bins[-1], lat, np.nan)
 label = "x >= " + str(bins[-1])
-plt.scatter(masked_lon,
-            masked_lat,
-            label=label,
-            s=sizes[-1],
-            color=colors[-1],
-            zorder=1)
+plt.scatter(
+    masked_lon, masked_lat, label=label, s=sizes[-1], color=colors[-1], zorder=1
+)
 
 # `ncol` being equal to half of the number of labels makes the legend appear
 # horizontal with two rows
-legend = ax.legend(bbox_to_anchor=(-0.05, -0.3),
-                   ncol=4,
-                   loc='lower left',
-                   columnspacing=4.75,
-                   frameon=False)
+legend = ax.legend(
+    bbox_to_anchor=(-0.05, -0.3),
+    ncol=4,
+    loc='lower left',
+    columnspacing=4.75,
+    frameon=False,
+)
 plt.show()

--- a/Gallery/Polygons/NCL_polyg_8_lbar.py
+++ b/Gallery/Polygons/NCL_polyg_8_lbar.py
@@ -69,19 +69,16 @@ ax.add_feature(cfeature.LAND, color='silver', zorder=0)
 ax.add_feature(cfeature.LAKES, color='white', zorder=0)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-120, -70, 6),
-                             yticks=np.linspace(25, 50, 6))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.linspace(-120, -70, 6), yticks=np.linspace(25, 50, 6)
+)
 
 # Use geocat.viz.util convenience function to make latitude and longitude tick
 # labels
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=1,
-                         y_minor_per_major=1,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=1, y_minor_per_major=1, labelsize=12)
 
 # Remove ticks on the top and right sides of the plot
 ax.tick_params(axis='both', which='both', top=False, right=False)
@@ -90,17 +87,13 @@ ax.tick_params(axis='both', which='both', top=False, right=False)
 gv.set_titles_and_labels(
     ax,
     maintitlefontsize=16,
-    maintitle=
-    "Dummy station data colored and\nsized according to range of values")
+    maintitle="Dummy station data colored and\nsized according to range of values",
+)
 
 # Plot markers with values less than first bin value
 masked_lon = np.where(r < bins[0], lon, np.nan)
 masked_lat = np.where(r < bins[0], lat, np.nan)
-plt.scatter(masked_lon,
-            masked_lat,
-            s=sizes[0],
-            color=marker_colors[0],
-            zorder=1)
+plt.scatter(masked_lon, masked_lat, s=sizes[0], color=marker_colors[0], zorder=1)
 
 # Plot all other markers but those in the last bin
 for x in range(1, len(bins)):
@@ -108,27 +101,21 @@ for x in range(1, len(bins)):
     masked_lon = np.where(r < bins[x], masked_lon, np.nan)
     masked_lat = np.where(bins[x - 1] <= r, lat, np.nan)
     masked_lat = np.where(r < bins[x], masked_lat, np.nan)
-    plt.scatter(masked_lon,
-                masked_lat,
-                s=sizes[x],
-                color=marker_colors[x],
-                zorder=1)
+    plt.scatter(masked_lon, masked_lat, s=sizes[x], color=marker_colors[x], zorder=1)
 
 # Plot markers with values greater than or equal to last bin value
 masked_lon = np.where(r >= bins[-1], lon, np.nan)
 masked_lat = np.where(r >= bins[-1], lat, np.nan)
-plt.scatter(masked_lon,
-            masked_lat,
-            s=sizes[-1],
-            color=marker_colors[-1],
-            zorder=1)
+plt.scatter(masked_lon, masked_lat, s=sizes[-1], color=marker_colors[-1], zorder=1)
 
 # Create colorbar
-plt.colorbar(mappable=mappable,
-             ax=ax,
-             orientation='horizontal',
-             drawedges=True,
-             format='%.2f',
-             ticks=bins)
+plt.colorbar(
+    mappable=mappable,
+    ax=ax,
+    orientation='horizontal',
+    drawedges=True,
+    format='%.2f',
+    ticks=bins,
+)
 
 plt.show()

--- a/Gallery/ProbabilityDistributions/NCL_pdf_1.py
+++ b/Gallery/ProbabilityDistributions/NCL_pdf_1.py
@@ -30,8 +30,7 @@ import geocat.viz as gv
 mu = 0
 sigma = 50
 normalpdf = stats.norm.rvs(mu, sigma, size=(64, 128))
-normalhist, normalbins = np.histogram(normalpdf,
-                                      bins=np.linspace(-200, 200, 25))
+normalhist, normalbins = np.histogram(normalpdf, bins=np.linspace(-200, 200, 25))
 normalhist = normalhist / (64 * 128) * 100
 normalbincenters = 0.5 * (normalbins[1:] + normalbins[:-1])
 
@@ -76,32 +75,37 @@ ax3.plot(gammabincenters, gammahist, color='k', linewidth=0.5)
 plt.suptitle("Univariate PDFs of Three Variables", fontsize=15)
 
 # Use the geocat.viz function to set tile of centered top plot
-gv.set_titles_and_labels(ax1,
-                         maintitle='Univariate PDF: Normal',
-                         maintitlefontsize=8,
-                         ylabel='PDF (%)',
-                         labelfontsize=10)
+gv.set_titles_and_labels(
+    ax1,
+    maintitle='Univariate PDF: Normal',
+    maintitlefontsize=8,
+    ylabel='PDF (%)',
+    labelfontsize=10,
+)
 
 # Use the geocat.viz function to set tile of centered bottom left plot
-gv.set_titles_and_labels(ax2,
-                         maintitle='Univariate PDF: Chi (df=2)',
-                         maintitlefontsize=8,
-                         ylabel='PDF (%)',
-                         labelfontsize=10)
+gv.set_titles_and_labels(
+    ax2,
+    maintitle='Univariate PDF: Chi (df=2)',
+    maintitlefontsize=8,
+    ylabel='PDF (%)',
+    labelfontsize=10,
+)
 
 # Use the geocat.viz function to set tile of centered bottom left plot
-gv.set_titles_and_labels(ax3,
-                         maintitle='Univariate PDF: Gamma',
-                         maintitlefontsize=8,
-                         ylabel='PDF (%)',
-                         labelfontsize=10)
+gv.set_titles_and_labels(
+    ax3,
+    maintitle='Univariate PDF: Gamma',
+    maintitlefontsize=8,
+    ylabel='PDF (%)',
+    labelfontsize=10,
+)
 
 # Use geocat.viz.util convenience function to set axes parameters
 # Set axes limits, and tick values on x-axes.
-gv.set_axes_limits_and_ticks(ax1,
-                             xlim=(-200, 200),
-                             ylim=(0, 14),
-                             yticks=np.arange(0, 15, 2))
+gv.set_axes_limits_and_ticks(
+    ax1, xlim=(-200, 200), ylim=(0, 14), yticks=np.arange(0, 15, 2)
+)
 
 # Use matplotlib.ticker to ensure ticks count by 5 (base), but not specify an
 # upper limit to allow for variability in x axis upper limit
@@ -126,21 +130,12 @@ ax3.yaxis.set_major_locator(ticker.MultipleLocator(base=3))
 ax3.set_ylim(bottom=0)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax1,
-                         x_minor_per_major=5,
-                         y_minor_per_major=4,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax1, x_minor_per_major=5, y_minor_per_major=4, labelsize=12)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax2,
-                         x_minor_per_major=3,
-                         y_minor_per_major=4,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax2, x_minor_per_major=3, y_minor_per_major=4, labelsize=12)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax3,
-                         x_minor_per_major=3,
-                         y_minor_per_major=3,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax3, x_minor_per_major=3, y_minor_per_major=3, labelsize=12)
 
 plt.show()

--- a/Gallery/Regression/NCL_regress_1.py
+++ b/Gallery/Regression/NCL_regress_1.py
@@ -27,10 +27,9 @@ import geocat.viz as gv
 # Open a ascii data file using numpy's loadtxt
 # Specify the delimiter from the file
 # Read in the data as a floats
-x, y = np.loadtxt(gdf.get("ascii_files/regress_1.txt"),
-                  delimiter=',',
-                  unpack=True,
-                  dtype=float)
+x, y = np.loadtxt(
+    gdf.get("ascii_files/regress_1.txt"), delimiter=',', unpack=True, dtype=float
+)
 
 ###############################################################################
 # Calculate regression:
@@ -69,17 +68,16 @@ plt.ylim([266, 274])
 gv.set_titles_and_labels(ax=ax, maintitle="Regression 1")
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=4,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=4, labelsize=12)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(6000, 9000),
-                             xticks=np.arange(6000, 9001, 500),
-                             ylim=(266, 274),
-                             yticks=np.arange(266, 275, 2))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(6000, 9000),
+    xticks=np.arange(6000, 9001, 500),
+    ylim=(266, 274),
+    yticks=np.arange(266, 275, 2),
+)
 
 # Show plot
 plt.tight_layout()

--- a/Gallery/Scatter/NCL_scatter_1.py
+++ b/Gallery/Scatter/NCL_scatter_1.py
@@ -37,17 +37,12 @@ ax = plt.axes()
 plt.plot(data, marker='o', linewidth=0, color='darkblue')
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(0, 50),
-                             ylim=(0, 10),
-                             xticks=range(0, 51, 10),
-                             yticks=range(0, 11, 2))
+gv.set_axes_limits_and_ticks(
+    ax, xlim=(0, 50), ylim=(0, 10), xticks=range(0, 51, 10), yticks=range(0, 11, 2)
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=4,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=4, labelsize=14)
 
 # Use geocat.viz.util convenience function to set titles and labels
 gv.set_titles_and_labels(ax, maintitle="Scatter Plot")

--- a/Gallery/Scatter/NCL_scatter_10.py
+++ b/Gallery/Scatter/NCL_scatter_10.py
@@ -59,7 +59,8 @@ ax.scatter(
     s=1350,
     alpha=0.75,
     zorder=2,
-    marker='s')
+    marker='s',
+)
 
 # Use geocat-viz utility function to format latitude/longitude labels
 gv.add_lat_lon_ticklabels(ax)
@@ -72,11 +73,13 @@ ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 gv.add_major_minor_ticks(ax, labelsize=14)
 
 # Use geocat-viz utility function to format tick labels
-gv.set_axes_limits_and_ticks(ax=ax,
-                             xlim=(-180, 181),
-                             ylim=(-90, 91),
-                             xticks=np.arange(-180, 190, 30),
-                             yticks=np.arange(-90, 100, 30))
+gv.set_axes_limits_and_ticks(
+    ax=ax,
+    xlim=(-180, 181),
+    ylim=(-90, 91),
+    xticks=np.arange(-180, 190, 30),
+    yticks=np.arange(-90, 100, 30),
+)
 
 # Add title
 plt.title('Dummy markers over a map', fontweight='bold', fontsize=20, pad=20)

--- a/Gallery/Scatter/NCL_scatter_3.py
+++ b/Gallery/Scatter/NCL_scatter_3.py
@@ -27,8 +27,7 @@ import geocat.datafiles as gdf
 ###############################################################################
 # Open a netCDF data file using xarray default engine and load the data into xarrays
 
-ds = xr.open_dataset(gdf.get("netcdf_files/95031800_sao.cdf"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/95031800_sao.cdf"), decode_times=False)
 lat = ds.lat.isel()
 lon = ds.lon.isel()
 
@@ -70,43 +69,36 @@ def Plots(xlim, ylim, xtic, ytic, xminor, yminor, size, color):
     ax = plt.axes(projection=ccrs.PlateCarree())
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
-    gv.add_major_minor_ticks(ax,
-                             x_minor_per_major=xminor,
-                             y_minor_per_major=yminor,
-                             labelsize=14)
+    gv.add_major_minor_ticks(
+        ax, x_minor_per_major=xminor, y_minor_per_major=yminor, labelsize=14
+    )
 
     # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
     gv.add_lat_lon_ticklabels(ax)
 
     # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-    gv.set_axes_limits_and_ticks(ax,
-                                 xlim=xlim,
-                                 ylim=ylim,
-                                 xticks=range(-180, 180, xtic),
-                                 yticks=range(-90, 90, ytic))
+    gv.set_axes_limits_and_ticks(
+        ax,
+        xlim=xlim,
+        ylim=ylim,
+        xticks=range(-180, 180, xtic),
+        yticks=range(-90, 90, ytic),
+    )
 
     # Remove the degree symbol from tick labels
     ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
     ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
     # Turn on continent shading
-    ax.add_feature(cfeature.LAND,
-                   edgecolor='lightgray',
-                   facecolor='lightgray',
-                   zorder=0)
-    ax.add_feature(cfeature.LAKES,
-                   edgecolor='white',
-                   facecolor='white',
-                   zorder=0)
+    ax.add_feature(
+        cfeature.LAND, edgecolor='lightgray', facecolor='lightgray', zorder=0
+    )
+    ax.add_feature(cfeature.LAKES, edgecolor='white', facecolor='white', zorder=0)
 
     # Scatter-plot the location data on the map
     plt.scatter(lon, lat, s=size, c=color, marker='+', linewidth=0.5, zorder=1)
 
-    plt.title("Locations of stations",
-              loc="center",
-              y=1.03,
-              size=15,
-              fontweight="bold")
+    plt.title("Locations of stations", loc="center", y=1.03, size=15, fontweight="bold")
 
     plt.show()
 

--- a/Gallery/Scatter/NCL_scatter_4.py
+++ b/Gallery/Scatter/NCL_scatter_4.py
@@ -29,8 +29,7 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/b003_TS_200-299.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/b003_TS_200-299.nc"), decode_times=False)
 # Extract variable
 ts = ds.TS.sel(lat=60, lon=180, method='nearest')
 
@@ -63,16 +62,15 @@ plt.xlim([6000, 9500])
 plt.ylim([268.0, 271.5])
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=5,
-                         labelsize=12)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=5, labelsize=12)
 
 # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-gv.set_titles_and_labels(ax,
-                         maintitle="Output from regline",
-                         xlabel="simulation time",
-                         ylabel="Surface temperature")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Output from regline",
+    xlabel="simulation time",
+    ylabel="Surface temperature",
+)
 
 # Show the plot
 plt.tight_layout()

--- a/Gallery/Scatter/NCL_scatter_5.py
+++ b/Gallery/Scatter/NCL_scatter_5.py
@@ -36,8 +36,14 @@ data = random.normal(loc=10, scale=3, size=npts)
 ##############################################################################
 # Specify colors and markers
 colors = [
-    'darkgoldenrod', 'darkgreen', 'coral', 'cyan', 'firebrick', 'darkslateblue',
-    'limegreen', 'goldenrod'
+    'darkgoldenrod',
+    'darkgreen',
+    'coral',
+    'cyan',
+    'firebrick',
+    'darkslateblue',
+    'limegreen',
+    'goldenrod',
 ]
 markers = ['+', '*', 'o', 'x', 's', '^', 'v', 'D']
 
@@ -58,23 +64,27 @@ label = "{start:g}:{end:g}"
 for x in range(0, numBins):
     bins = np.where(data > partitions[x], data, np.nan)
     with np.errstate(
-            invalid='ignore'
+        invalid='ignore'
     ):  # Indeed not needed, just to get rid of warnings about numpy's NaN comparisons
         bins = np.where(bins < partitions[x + 1], bins, np.nan)
     indices = np.where(bins != np.nan, indices, np.nan)
-    plt.plot(indices,
-             bins,
-             marker=markers[x],
-             fillstyle='none',
-             linewidth=0,
-             label=label.format(start=partitions[x], end=partitions[x + 1]))
+    plt.plot(
+        indices,
+        bins,
+        marker=markers[x],
+        fillstyle='none',
+        linewidth=0,
+        label=label.format(start=partitions[x], end=partitions[x + 1]),
+    )
 
 # `ncol` being equal to the number of labels makes it appear horizontal
-legend = ax.legend(bbox_to_anchor=(-0.075, -0.2),
-                   ncol=numBins,
-                   loc='lower left',
-                   columnspacing=0.5,
-                   frameon=False)
+legend = ax.legend(
+    bbox_to_anchor=(-0.075, -0.2),
+    ncol=numBins,
+    loc='lower left',
+    columnspacing=0.5,
+    frameon=False,
+)
 for txt in legend.get_texts():
     txt.set_ha("center")  # horizontal alignment of text item
     txt.set_va("center")  # vertical alignment of text item
@@ -83,17 +93,12 @@ for txt in legend.get_texts():
     txt.set_y(-20)  # y-position
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(0, 300),
-                             ylim=(0, 21),
-                             xticks=range(0, 301, 50),
-                             yticks=range(0, 22, 3))
+gv.set_axes_limits_and_ticks(
+    ax, xlim=(0, 300), ylim=(0, 21), xticks=range(0, 301, 50), yticks=range(0, 22, 3)
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=3,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=3, labelsize=14)
 
 # Use geocat.viz.util convenience function to set titles and labels
 gv.set_titles_and_labels(ax, maintitle="Scatter plot with grouped markers")

--- a/Gallery/Scatter/NCL_scatter_6.py
+++ b/Gallery/Scatter/NCL_scatter_6.py
@@ -40,8 +40,19 @@ ax.set_ylim([0, 90])
 ax.set_theta_zero_location("S")
 
 # Create array of marker colors
-colors = ("limegreen", "orange", "green", "red", "yellow", "purple", "blue",
-          "red", "brown", "crimson", "skyblue")
+colors = (
+    "limegreen",
+    "orange",
+    "green",
+    "red",
+    "yellow",
+    "purple",
+    "blue",
+    "red",
+    "brown",
+    "crimson",
+    "skyblue",
+)
 
 # Create array of marker sizes
 bins = np.linspace(100, 2000, 10)
@@ -50,18 +61,32 @@ bins = np.linspace(100, 2000, 10)
 # longitude points must be transformed from degrees to radians
 # to be plotted on polar projection
 for x in range(numpoints):
-    ax.scatter((np.pi / 180.0) * lon[x],
-               lat[x],
-               color=colors[x % 10],
-               s=bins[x % 10],
-               edgecolors='black',
-               linewidths=1,
-               alpha=0.9,
-               zorder=2)
+    ax.scatter(
+        (np.pi / 180.0) * lon[x],
+        lat[x],
+        color=colors[x % 10],
+        s=bins[x % 10],
+        edgecolors='black',
+        linewidths=1,
+        alpha=0.9,
+        zorder=2,
+    )
 
 # set the labels and locations of the angular gridlines
-linelabels = ('0', '30E', '60E', '90E', '120E', '150E', '180', '150W', '120W',
-              '90E', '60E', '30E')
+linelabels = (
+    '0',
+    '30E',
+    '60E',
+    '90E',
+    '120E',
+    '150E',
+    '180',
+    '150W',
+    '120W',
+    '90E',
+    '60E',
+    '30E',
+)
 lines, labels = plt.thetagrids(range(0, 360, 30), linelabels, fontsize=12)
 
 # Create distance between the x tick labels and the axis

--- a/Gallery/Shapefiles/NCL_shapefiles_1.py
+++ b/Gallery/Shapefiles/NCL_shapefiles_1.py
@@ -68,21 +68,22 @@ def color_assignment(record):
     population = record.PERSONS
     unempolyment = record.UNEMPLOY
     percent = unempolyment / population
-    if (0.01 <= percent and percent < 0.02):
+    if 0.01 <= percent and percent < 0.02:
         return colormap.colors[0]
-    elif (0.02 <= percent and percent < 0.03):
+    elif 0.02 <= percent and percent < 0.03:
         return colormap.colors[1]
-    elif (0.03 <= percent and percent < 0.04):
+    elif 0.03 <= percent and percent < 0.04:
         return colormap.colors[2]
-    elif (0.04 <= percent):
+    elif 0.04 <= percent:
         return colormap.colors[3]
 
 
 ###############################################################################
 # Plot:
 plt.figure(figsize=(10, 8))
-ax = plt.axes(projection=ccrs.LambertConformal(standard_parallels=(33, 45),
-                                               central_longitude=-98))
+ax = plt.axes(
+    projection=ccrs.LambertConformal(standard_parallels=(33, 45), central_longitude=-98)
+)
 ax.set_extent([-125, -74, 22, 50])
 
 ax.add_feature(cfeature.LAND, color='silver', zorder=0)
@@ -97,41 +98,49 @@ for i in range(0, len(shapefile.shapes())):
         for j in range(0, len(shape.parts)):
             start_index = shape.parts[j]
             # the last part uses the remaining points and doesn't require and end_index
-            if (j is (len(shape.parts) - 1)):
-                patch = mpatches.Polygon(shape.points[start_index:],
-                                         facecolor=color,
-                                         edgecolor='black',
-                                         linewidth=0.5,
-                                         transform=ccrs.PlateCarree(),
-                                         zorder=2)
+            if j is (len(shape.parts) - 1):
+                patch = mpatches.Polygon(
+                    shape.points[start_index:],
+                    facecolor=color,
+                    edgecolor='black',
+                    linewidth=0.5,
+                    transform=ccrs.PlateCarree(),
+                    zorder=2,
+                )
             else:
                 end_index = shape.parts[j + 1]
-                patch = mpatches.Polygon(shape.points[start_index:end_index],
-                                         facecolor=color,
-                                         edgecolor='black',
-                                         linewidth=0.5,
-                                         transform=ccrs.PlateCarree(),
-                                         zorder=2)
+                patch = mpatches.Polygon(
+                    shape.points[start_index:end_index],
+                    facecolor=color,
+                    edgecolor='black',
+                    linewidth=0.5,
+                    transform=ccrs.PlateCarree(),
+                    zorder=2,
+                )
             ax.add_patch(patch)
     else:
-        patch = mpatches.Polygon(shape.points,
-                                 facecolor=color,
-                                 edgecolor='black',
-                                 linewidth=0.5,
-                                 transform=ccrs.PlateCarree(),
-                                 zorder=2)
+        patch = mpatches.Polygon(
+            shape.points,
+            facecolor=color,
+            edgecolor='black',
+            linewidth=0.5,
+            transform=ccrs.PlateCarree(),
+            zorder=2,
+        )
         ax.add_patch(patch)
 
 # Create colorbar
-plt.colorbar(cm.ScalarMappable(cmap=colormap, norm=norm),
-             ax=ax,
-             boundaries=colorbounds,
-             orientation='horizontal',
-             shrink=0.75,
-             ticks=[1, 2, 3, 4],
-             label='percent',
-             aspect=30,
-             pad=0.075)
+plt.colorbar(
+    cm.ScalarMappable(cmap=colormap, norm=norm),
+    ax=ax,
+    boundaries=colorbounds,
+    orientation='horizontal',
+    shrink=0.75,
+    ticks=[1, 2, 3, 4],
+    label='percent',
+    aspect=30,
+    pad=0.075,
+)
 
 # Add latitude and longitude labels
 gl = ax.gridlines(draw_labels=True, x_inline=False, y_inline=False)

--- a/Gallery/Skew-T/NCL_skewt_1.py
+++ b/Gallery/Skew-T/NCL_skewt_1.py
@@ -55,12 +55,7 @@ x1 = np.linspace(-100, 40, 8)  # The starting x values for the shaded regions
 x2 = np.linspace(-90, 50, 8)  # The ending x values for the shaded regions
 y = [1050, 100]  # The range of y values that the shades regions should cover
 for i in range(0, 8):
-    skew.shade_area(y=y,
-                    x1=x1[i],
-                    x2=x2[i],
-                    color='limegreen',
-                    alpha=0.25,
-                    zorder=1)
+    skew.shade_area(y=y, x1=x1[i], x2=x2[i], color='limegreen', alpha=0.25, zorder=1)
 
 # Choose starting temperatures in Kelvin for the dry adiabats
 t0 = units.K * np.arange(243.15, 444.15, 10)
@@ -68,10 +63,7 @@ skew.plot_dry_adiabats(t0=t0, linestyles='solid', colors='tan', linewidths=1.5)
 
 # Choose starting temperatures in Kelvin for the moist adiabats
 t0 = units.K * np.arange(281.15, 306.15, 4)
-skew.plot_moist_adiabats(t0=t0,
-                         linestyles='solid',
-                         colors='lime',
-                         linewidth=1.5)
+skew.plot_moist_adiabats(t0=t0, linestyles='solid', colors='lime', linewidth=1.5)
 
 # Choose mixing ratios
 w = np.array([0.001, 0.002, 0.003, 0.005, 0.008, 0.012, 0.020]).reshape(-1, 1)
@@ -80,17 +72,14 @@ w = np.array([0.001, 0.002, 0.003, 0.005, 0.008, 0.012, 0.020]).reshape(-1, 1)
 p = units.hPa * np.linspace(1000, 400, 7)
 
 # Plot mixing ratio lines
-skew.plot_mixing_lines(mixing_ratio=w,
-                       pressure=p,
-                       linestyle='dashed',
-                       colors='lime',
-                       linewidths=1)
+skew.plot_mixing_lines(
+    mixing_ratio=w, pressure=p, linestyle='dashed', colors='lime', linewidths=1
+)
 
 # Use geocat.viz utility functions to set axes limits and ticks
 gv.set_axes_limits_and_ticks(
-    ax=ax,
-    xlim=[-32, 38],
-    yticks=[1000, 850, 700, 500, 400, 300, 250, 200, 150, 100])
+    ax=ax, xlim=[-32, 38], yticks=[1000, 850, 700, 500, 400, 300, 250, 200, 150, 100]
+)
 
 # Use geocat.viz utility functions to add a main title
 gv.set_titles_and_labels(ax=ax, maintitle="NCL Style Plot")
@@ -99,28 +88,28 @@ gv.set_titles_and_labels(ax=ax, maintitle="NCL Style Plot")
 u = np.zeros(22)
 v = u
 p = np.linspace(1010, 110, 22)
-skew.plot_barbs(pressure=p,
-                u=u,
-                v=v,
-                xloc=1.05,
-                fill_empty=True,
-                sizes=dict(emptybarb=0.075, width=0.1, height=0.2))
+skew.plot_barbs(
+    pressure=p,
+    u=u,
+    v=v,
+    xloc=1.05,
+    fill_empty=True,
+    sizes=dict(emptybarb=0.075, width=0.1, height=0.2),
+)
 
 # Draw line underneath wind barbs
-line = mlines.Line2D([1.05, 1.05], [0, 1],
-                     color='gray',
-                     linewidth=0.5,
-                     transform=ax.transAxes,
-                     clip_on=False,
-                     zorder=1)
+line = mlines.Line2D(
+    [1.05, 1.05],
+    [0, 1],
+    color='gray',
+    linewidth=0.5,
+    transform=ax.transAxes,
+    clip_on=False,
+    zorder=1,
+)
 ax.add_line(line)
 
 # Change the style of the gridlines
-plt.grid(True,
-         which='major',
-         axis='both',
-         color='tan',
-         linewidth=1.5,
-         alpha=0.5)
+plt.grid(True, which='major', axis='both', color='tan', linewidth=1.5, alpha=0.5)
 
 plt.show()

--- a/Gallery/Skew-T/NCL_skewt_2_2.py
+++ b/Gallery/Skew-T/NCL_skewt_2_2.py
@@ -28,9 +28,9 @@ import geocat.datafiles as gdf
 # Read in data:
 
 # Open a ascii data file using pandas' read_csv function
-ds = pd.read_csv(gdf.get('ascii_files/sounding.testdata'),
-                 delimiter='\\s+',
-                 header=None)
+ds = pd.read_csv(
+    gdf.get('ascii_files/sounding.testdata'), delimiter='\\s+', header=None
+)
 
 # Extract the data
 p = ds[1].values * units.hPa  # Pressure [mb/hPa]
@@ -71,24 +71,28 @@ parcel_prof = mpcalc.parcel_profile(p, tc[0], tdc[0]).to('degC')
 skew.plot(p, parcel_prof, color='red', linestyle='--')
 u = np.where(p >= 100 * units.hPa, u, np.nan)
 v = np.where(p >= 100 * units.hPa, v, np.nan)
-p = np.where(ds[1].values >= 100, ds[1].values,
-             np.nan)  # unitless for plot_barbs
+p = np.where(ds[1].values >= 100, ds[1].values, np.nan)  # unitless for plot_barbs
 
 # Add wind barbs
-skew.plot_barbs(pressure=p[::2],
-                u=u[::2],
-                v=v[::2],
-                xloc=1.05,
-                fill_empty=True,
-                sizes=dict(emptybarb=0.075, width=0.1, height=0.2))
+skew.plot_barbs(
+    pressure=p[::2],
+    u=u[::2],
+    v=v[::2],
+    xloc=1.05,
+    fill_empty=True,
+    sizes=dict(emptybarb=0.075, width=0.1, height=0.2),
+)
 
 # Draw line underneath wind barbs
-line = mlines.Line2D([1.05, 1.05], [0, 1],
-                     color='gray',
-                     linewidth=0.5,
-                     transform=ax.transAxes,
-                     clip_on=False,
-                     zorder=1)
+line = mlines.Line2D(
+    [1.05, 1.05],
+    [0, 1],
+    color='gray',
+    linewidth=0.5,
+    transform=ax.transAxes,
+    clip_on=False,
+    zorder=1,
+)
 ax.add_line(line)
 
 # Shade every other section between isotherms
@@ -96,12 +100,7 @@ x1 = np.linspace(-100, 40, 8)  # The starting x values for the shaded regions
 x2 = np.linspace(-90, 50, 8)  # The ending x values for the shaded regions
 y = [1050, 100]  # The range of y values that the shades regions should cover
 for i in range(0, 8):
-    skew.shade_area(y=y,
-                    x1=x1[i],
-                    x2=x2[i],
-                    color='limegreen',
-                    alpha=0.25,
-                    zorder=1)
+    skew.shade_area(y=y, x1=x1[i], x2=x2[i], color='limegreen', alpha=0.25, zorder=1)
 
 # Choose starting temperatures in Kelvin for the dry adiabats
 t0 = units.K * np.arange(243.15, 444.15, 10)
@@ -109,10 +108,7 @@ skew.plot_dry_adiabats(t0=t0, linestyles='solid', colors='tan', linewidths=1.5)
 
 # Choose starting temperatures in Kelvin for the moist adiabats
 t0 = units.K * np.arange(281.15, 306.15, 4)
-skew.plot_moist_adiabats(t0=t0,
-                         linestyles='solid',
-                         colors='lime',
-                         linewidth=1.5)
+skew.plot_moist_adiabats(t0=t0, linestyles='solid', colors='lime', linewidth=1.5)
 
 # Choose mixing ratios
 w = np.array([0.001, 0.002, 0.003, 0.005, 0.008, 0.012, 0.020]).reshape(-1, 1)
@@ -121,43 +117,31 @@ w = np.array([0.001, 0.002, 0.003, 0.005, 0.008, 0.012, 0.020]).reshape(-1, 1)
 p_levs = units.hPa * np.linspace(1000, 400, 7)
 
 # Plot mixing ratio lines
-skew.plot_mixing_lines(mixing_ratio=w,
-                       pressure=p_levs,
-                       linestyle='dashed',
-                       colors='lime',
-                       linewidths=1)
+skew.plot_mixing_lines(
+    mixing_ratio=w, pressure=p_levs, linestyle='dashed', colors='lime', linewidths=1
+)
 
 # Use geocat.viz utility functions to set axes limits and ticks
 gv.set_axes_limits_and_ticks(
-    ax=ax,
-    xlim=[-32, 38],
-    yticks=[1000, 850, 700, 500, 400, 300, 250, 200, 150, 100])
+    ax=ax, xlim=[-32, 38], yticks=[1000, 850, 700, 500, 400, 300, 250, 200, 150, 100]
+)
 
 # Use geocat.viz utility function to change the look of ticks and ticklabels
-gv.add_major_minor_ticks(ax=ax,
-                         x_minor_per_major=1,
-                         y_minor_per_major=1,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax=ax, x_minor_per_major=1, y_minor_per_major=1, labelsize=14)
 # The utility function draws tickmarks all around the plot. We only need ticks
 # on the left and bottom edges
 ax.tick_params('both', which='both', top=False, right=False)
 
 # Use geocat.viz utility functions to add labels
-gv.set_titles_and_labels(ax=ax,
-                         xlabel='Temperature (C)',
-                         ylabel='P (hPa)',
-                         labelfontsize=14)
+gv.set_titles_and_labels(
+    ax=ax, xlabel='Temperature (C)', ylabel='P (hPa)', labelfontsize=14
+)
 
 # Manually add suptitle and subtitle for appropriate positioning
 fig.suptitle('Raob; [Wind Reports]', fontsize=24, y=0.92)
 ax.set_title(subtitle, color='darkgoldenrod')
 
 # Change the style of the gridlines
-plt.grid(True,
-         which='major',
-         axis='both',
-         color='tan',
-         linewidth=1.5,
-         alpha=0.5)
+plt.grid(True, which='major', axis='both', color='tan', linewidth=1.5, alpha=0.5)
 
 plt.show()

--- a/Gallery/Skew-T/NCL_skewt_3_2.py
+++ b/Gallery/Skew-T/NCL_skewt_3_2.py
@@ -55,31 +55,31 @@ x2 = np.linspace(-90, 50, 8)  # The ending x values for the shaded regions
 y = [1050, 100]  # The range of y values that the shaded regions should cover
 
 for i in range(0, 8):
-    skew.shade_area(y=y,
-                    x1=x1[i],
-                    x2=x2[i],
-                    color='limegreen',
-                    alpha=0.25,
-                    zorder=1)
+    skew.shade_area(y=y, x1=x1[i], x2=x2[i], color='limegreen', alpha=0.25, zorder=1)
 
 skew.plot(p, tc, 'black')
 skew.plot(p, tdc, 'blue')
 # Plot only every third windbarb
-skew.plot_barbs(pressure=p[::3],
-                u=u[::3],
-                v=v[::3],
-                xloc=1.05,
-                fill_empty=True,
-                sizes=dict(emptybarb=0.075, width=0.1, height=0.2))
+skew.plot_barbs(
+    pressure=p[::3],
+    u=u[::3],
+    v=v[::3],
+    xloc=1.05,
+    fill_empty=True,
+    sizes=dict(emptybarb=0.075, width=0.1, height=0.2),
+)
 
 # Draw line underneath wind barbs
-line = mlines.Line2D([1.05, 1.05], [0, 1],
-                     color='gray',
-                     linewidth=0.5,
-                     transform=ax.transAxes,
-                     dash_joinstyle='round',
-                     clip_on=False,
-                     zorder=0)
+line = mlines.Line2D(
+    [1.05, 1.05],
+    [0, 1],
+    color='gray',
+    linewidth=0.5,
+    transform=ax.transAxes,
+    dash_joinstyle='round',
+    clip_on=False,
+    zorder=0,
+)
 ax.add_line(line)
 
 # Add relevant special lines
@@ -89,10 +89,7 @@ skew.plot_dry_adiabats(t0=t0, linestyles='solid', colors='gray', linewidth=1.5)
 
 # Choose temperatures for moist adiabats
 t0 = units.K * np.arange(281.15, 306.15, 4)
-msa = skew.plot_moist_adiabats(t0=t0,
-                               linestyles='solid',
-                               colors='lime',
-                               linewidths=1.5)
+msa = skew.plot_moist_adiabats(t0=t0, linestyles='solid', colors='lime', linewidths=1.5)
 
 # Choose mixing ratios
 w = np.array([0.001, 0.002, 0.003, 0.005, 0.008, 0.012, 0.020]).reshape(-1, 1)
@@ -107,17 +104,11 @@ gv.set_titles_and_labels(ax, maintitle="ATS Rawinsonde: degC + Thin wind")
 
 # Set axes limits and ticks
 gv.set_axes_limits_and_ticks(
-    ax=ax,
-    xlim=[-30, 50],
-    yticks=[1000, 850, 700, 500, 400, 300, 250, 200, 150, 100])
+    ax=ax, xlim=[-30, 50], yticks=[1000, 850, 700, 500, 400, 300, 250, 200, 150, 100]
+)
 
 # Change the style of the gridlines
-plt.grid(True,
-         which='major',
-         axis='both',
-         color='tan',
-         linewidth=1.5,
-         alpha=0.5)
+plt.grid(True, which='major', axis='both', color='tan', linewidth=1.5, alpha=0.5)
 plt.xlabel("Temperature (C)")
 plt.ylabel("P (hPa)")
 plt.show()

--- a/Gallery/Station/NCL_station_1.py
+++ b/Gallery/Station/NCL_station_1.py
@@ -51,52 +51,46 @@ clevels = np.arange(25, 51, 5)
 flevels = np.arange(16, 51, 1)
 
 # Plot contour lines
-contour = ax.tricontour(pwv_lon1d,
-                        pwv_lat1d,
-                        pwv,
-                        levels=clevels,
-                        colors='black',
-                        linewidths=0.6,
-                        zorder=4)
+contour = ax.tricontour(
+    pwv_lon1d, pwv_lat1d, pwv, levels=clevels, colors='black', linewidths=0.6, zorder=4
+)
 
 # Label the contours and set axes title
 ax.clabel(contour, clevels, fontsize=25, fmt="%.0f")
 
 # Plot filled contours
-color = ax.tricontourf(pwv_lon1d,
-                       pwv_lat1d,
-                       pwv,
-                       cmap='magma',
-                       alpha=0.85,
-                       levels=flevels,
-                       antialiased=True,
-                       zorder=3)
+color = ax.tricontourf(
+    pwv_lon1d,
+    pwv_lat1d,
+    pwv,
+    cmap='magma',
+    alpha=0.85,
+    levels=flevels,
+    antialiased=True,
+    zorder=3,
+)
 
 # Add coordinate markers on the plot
 ax.plot(pwv_lon1d, pwv_lat1d, marker='o', linewidth=0, color='black', zorder=4)
 
 # Add state boundaries other lake features
-ax.add_feature(cfeature.STATES,
-               edgecolor='gray',
-               linestyle=(0, (5, 10)),
-               zorder=2)
+ax.add_feature(cfeature.STATES, edgecolor='gray', linestyle=(0, (5, 10)), zorder=2)
 ax.add_feature(cfeature.LAKES, facecolor='white', edgecolor='black', zorder=2)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(min(pwv_lat1d) - .5, max(pwv_lat1d) + .5),
-                             xlim=(min(pwv_lon1d) - .5, max(pwv_lon1d) + .5),
-                             yticks=np.array([34, 36, 38, 40]),
-                             xticks=np.arange(-101, -93, 1))
+gv.set_axes_limits_and_ticks(
+    ax,
+    ylim=(min(pwv_lat1d) - 0.5, max(pwv_lat1d) + 0.5),
+    xlim=(min(pwv_lon1d) - 0.5, max(pwv_lon1d) + 0.5),
+    yticks=np.array([34, 36, 38, 40]),
+    xticks=np.arange(-101, -93, 1),
+)
 
 # Use geocat.viz.util convenience function to set latitude, longitude tick labels
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=1,
-                         y_minor_per_major=1,
-                         labelsize=18)
+gv.add_major_minor_ticks(ax, x_minor_per_major=1, y_minor_per_major=1, labelsize=18)
 
 # Manually turn off ticks on top and right spines
 ax.tick_params(axis='x', top=False)
@@ -115,11 +109,7 @@ plt.tight_layout()
 cax = fig.add_axes([0.9, 0.065, 0.04, 0.83])
 
 # Add colorbar
-cab = plt.colorbar(color,
-                   cax=cax,
-                   ticks=flevels[::2],
-                   drawedges=False,
-                   extendrect=True)
+cab = plt.colorbar(color, cax=cax, ticks=flevels[::2], drawedges=False, extendrect=True)
 
 # Set colorbar ticklabel font size
 cab.ax.yaxis.set_tick_params(length=0, labelsize=20)

--- a/Gallery/Station/NCL_station_2.py
+++ b/Gallery/Station/NCL_station_2.py
@@ -50,10 +50,8 @@ dummy_data = np.random.uniform(-1.2, 35, npts)
 # color[-1] => dummy_data => bin_bounds[-1]
 # color[j] => bin_bounds[j-1] <= dummy_data < bin_bounds[j]
 
-bin_bounds = [0., 5., 10., 15., 20., 23., 26.]
-colors = [
-    'purple', 'darkblue', 'blue', 'lightblue', 'yellow', 'orange', 'red', 'pink'
-]
+bin_bounds = [0.0, 5.0, 10.0, 15.0, 20.0, 23.0, 26.0]
+colors = ['purple', 'darkblue', 'blue', 'lightblue', 'yellow', 'orange', 'red', 'pink']
 
 nbins = len(colors)  # One bin for each color
 
@@ -69,44 +67,35 @@ norm = mpl.colors.BoundaryNorm([-1.2] + bin_bounds + [35], len(colors))
 # Define a utility function to create the basic contour plot that will be used twice to create two slightly
 # different plots, both of which rely on same base figure
 def make_shared_plot(title):
-
     # Generate figure (set its size (width, height) in inches) and axes using Cartopy projection
     plt.figure(figsize=(10, 5.5))
     ax = plt.axes(projection=ccrs.PlateCarree())
 
     # Use geocat.viz.util convenience function to add minor and major tick lines
-    gv.add_major_minor_ticks(ax,
-                             x_minor_per_major=4,
-                             y_minor_per_major=5,
-                             labelsize=14)
+    gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=14)
 
     # Use geocat.viz.util convenience function to make plots look like NCL plots by using latitude, longitude tick labels
     gv.add_lat_lon_ticklabels(ax)
 
     # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-    gv.set_axes_limits_and_ticks(ax,
-                                 xlim=(-125, -70),
-                                 ylim=(25, 50),
-                                 xticks=range(-120, -75, 20),
-                                 yticks=range(30, 51, 10))
+    gv.set_axes_limits_and_ticks(
+        ax,
+        xlim=(-125, -70),
+        ylim=(25, 50),
+        xticks=range(-120, -75, 20),
+        yticks=range(30, 51, 10),
+    )
 
     # Turn on continent shading
-    ax.add_feature(cartopy.feature.LAND,
-                   edgecolor='lightgray',
-                   facecolor='lightgray',
-                   zorder=0)
-    ax.add_feature(cartopy.feature.LAKES,
-                   edgecolor='white',
-                   facecolor='white',
-                   zorder=0)
+    ax.add_feature(
+        cartopy.feature.LAND, edgecolor='lightgray', facecolor='lightgray', zorder=0
+    )
+    ax.add_feature(
+        cartopy.feature.LAKES, edgecolor='white', facecolor='white', zorder=0
+    )
 
     # Scatter-plot the location data on the map
-    scatter = plt.scatter(lon,
-                          lat,
-                          c=dummy_data,
-                          cmap=cmap,
-                          norm=norm,
-                          zorder=1)
+    scatter = plt.scatter(lon, lat, c=dummy_data, cmap=cmap, norm=norm, zorder=1)
 
     plt.title(title, fontsize=16, y=1.04)
 
@@ -119,7 +108,8 @@ def make_shared_plot(title):
 
 # Draw the base plot
 scatter1, ax = make_shared_plot(
-    "Dummy station data colored according to range of values")
+    "Dummy station data colored according to range of values"
+)
 
 # Add a legend to the bottom outside of the plot
 # Given how we generated the plot, adding a legend is a little kludgy. Basically, we draw a second plot where no data
@@ -137,7 +127,7 @@ for n, color in enumerate(colors):
     elif n == nbins - 1:
         label = f'x >= {bin_bounds[-1]:.0f}'
     else:
-        label = f'{bin_bounds[n-1]:.0f} <= x < {bin_bounds[n]:.0f}'
+        label = f'{bin_bounds[n - 1]:.0f} <= x < {bin_bounds[n]:.0f}'
 
     # Plotting data at (-10, -10) which is not in the plotting window
     scatter = plt.scatter(-10, -10, color=color, label=label)
@@ -153,17 +143,18 @@ plt.show()
 # ----------------------------------------------
 
 # Draw the base plot
-scatter2 = make_shared_plot(
-    "Dummy station data colored according to range of values")
+scatter2 = make_shared_plot("Dummy station data colored according to range of values")
 
 # Add a horizontal colorbar
 cax = plt.axes((0.225, 0.05, 0.55, 0.025))
-mpl.colorbar.ColorbarBase(cax,
-                          cmap=cmap,
-                          orientation='horizontal',
-                          norm=norm,
-                          boundaries=[-1.2] + bin_bounds + [35],
-                          ticks=bin_bounds)
+mpl.colorbar.ColorbarBase(
+    cax,
+    cmap=cmap,
+    orientation='horizontal',
+    norm=norm,
+    boundaries=[-1.2] + bin_bounds + [35],
+    ticks=bin_bounds,
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Station/NCL_station_3.py
+++ b/Gallery/Station/NCL_station_3.py
@@ -30,7 +30,8 @@ import geocat.datafiles as gdf
 ds = pd.read_csv(
     gdf.get('ascii_files/istasyontablosu_son.txt'),
     delimiter='\\s+',
-    names=['index', 'station', 'year1', 'year2', 'number', 'lat', 'lon'])
+    names=['index', 'station', 'year1', 'year2', 'number', 'lat', 'lon'],
+)
 
 # Get number of stations
 npts = len(ds)
@@ -45,7 +46,6 @@ lon = ds.lon
 
 
 def create_axes(maintitle):
-
     # Generate figure (set its size (width, height) in inches)
     fig = plt.figure(figsize=(12, 6.5))
 
@@ -59,14 +59,16 @@ def create_axes(maintitle):
     ax.add_feature(cfeature.LAND, facecolor='none', edgecolor='gray')
 
     # Draw gridlines
-    gl = ax.gridlines(crs=ccrs.PlateCarree(),
-                      draw_labels=True,
-                      dms=False,
-                      x_inline=False,
-                      y_inline=False,
-                      linewidth=1,
-                      color="gray",
-                      alpha=0.25)
+    gl = ax.gridlines(
+        crs=ccrs.PlateCarree(),
+        draw_labels=True,
+        dms=False,
+        x_inline=False,
+        y_inline=False,
+        linewidth=1,
+        color="gray",
+        alpha=0.25,
+    )
 
     # Set frequency of gridlines in the x and y directions
     gl.xlocator = mticker.FixedLocator(np.arange(26, 45, 2))
@@ -97,14 +99,16 @@ fig, ax = create_axes('Overlapping text strings')
 
 # Add all station number texts
 for i in range(npts):
-    ax.text(lon[i],
-            lat[i],
-            no[i],
-            fontsize=8,
-            fontweight='bold',
-            va='center',
-            ha='center',
-            transform=ccrs.PlateCarree())
+    ax.text(
+        lon[i],
+        lat[i],
+        no[i],
+        fontsize=8,
+        fontweight='bold',
+        va='center',
+        ha='center',
+        transform=ccrs.PlateCarree(),
+    )
 
 # Show the plot
 plt.tight_layout()
@@ -139,14 +143,16 @@ for i in range(npts):
 # Add text if it is not tagged to be removed
 for i in range(npts):
     if not remove[i]:
-        ax.text(lon[i],
-                lat[i],
-                no[i],
-                fontsize=8,
-                fontweight='bold',
-                va='center',
-                ha='center',
-                transform=ccrs.PlateCarree())
+        ax.text(
+            lon[i],
+            lat[i],
+            no[i],
+            fontsize=8,
+            fontweight='bold',
+            va='center',
+            ha='center',
+            transform=ccrs.PlateCarree(),
+        )
 
 # Show the plot
 plt.tight_layout()

--- a/Gallery/Streamlines/NCL_stream_1.py
+++ b/Gallery/Streamlines/NCL_stream_1.py
@@ -50,14 +50,16 @@ ax.set_global()
 # Stream-plot the data
 # There is no Xarray streamplot function, yet. So need to call matplotlib.streamplot directly. Not sure why, but can't
 # pass xarray.DataArray objects directly: fetch NumPy arrays via 'data' attribute'
-ax.streamplot(U.lon.data,
-              U.lat.data,
-              U.data,
-              V.data,
-              linewidth=1,
-              density=4,
-              color='black',
-              zorder=1)
+ax.streamplot(
+    U.lon.data,
+    U.lat.data,
+    U.data,
+    V.data,
+    linewidth=1,
+    density=4,
+    color='black',
+    zorder=1,
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, labelsize=16)
@@ -66,23 +68,25 @@ gv.add_major_minor_ticks(ax, labelsize=16)
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to set axes tick values without calling two different matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-180, 180, 13),
-                             yticks=np.linspace(-90, 90, 7))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.linspace(-180, 180, 13), yticks=np.linspace(-90, 90, 7)
+)
 
 # Draw filled polygons for land
 ax.add_feature(cfeature.LAND, zorder=0, edgecolor='black', color='lightgray')
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         maintitle="Example of a streamline plot",
-                         maintitlefontsize=22,
-                         lefttitle=U.long_name,
-                         lefttitlefontsize=18,
-                         righttitle=U.units,
-                         righttitlefontsize=18,
-                         xlabel="",
-                         ylabel="")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Example of a streamline plot",
+    maintitlefontsize=22,
+    lefttitle=U.long_name,
+    lefttitlefontsize=18,
+    righttitle=U.units,
+    righttitlefontsize=18,
+    xlabel="",
+    ylabel="",
+)
 
 # Show the plot
 plt.tight_layout()

--- a/Gallery/Streamlines/NCL_stream_9.py
+++ b/Gallery/Streamlines/NCL_stream_9.py
@@ -30,10 +30,23 @@ import geocat.viz as gv
 ################################################################################
 # Make color map
 
-colormap = colors.ListedColormap([
-    'darkblue', 'mediumblue', 'blue', 'cornflowerblue', 'skyblue', 'aquamarine',
-    'lime', 'greenyellow', 'gold', 'orange', 'orangered', 'red', 'maroon'
-])
+colormap = colors.ListedColormap(
+    [
+        'darkblue',
+        'mediumblue',
+        'blue',
+        'cornflowerblue',
+        'skyblue',
+        'aquamarine',
+        'lime',
+        'greenyellow',
+        'gold',
+        'orange',
+        'orangered',
+        'red',
+        'maroon',
+    ]
+)
 
 colorbounds = np.arange(0, 56, 4)
 
@@ -53,11 +66,14 @@ ds2 = xr.open_dataset(gdf.get('netcdf_files/V500storm.cdf'))
 fig = plt.figure(figsize=(10, 10))
 
 # Create first subplot on figure for map
-ax = fig.add_axes([.1, .2, .8, .6],
-                  projection=ccrs.LambertAzimuthalEqualArea(
-                      central_longitude=-100, central_latitude=40),
-                  frameon=False,
-                  aspect='auto')
+ax = fig.add_axes(
+    [0.1, 0.2, 0.8, 0.6],
+    projection=ccrs.LambertAzimuthalEqualArea(
+        central_longitude=-100, central_latitude=40
+    ),
+    frameon=False,
+    aspect='auto',
+)
 
 # Set axis projection
 ax.set_extent([-128, -58, 18, 65], crs=ccrs.PlateCarree())
@@ -76,39 +92,51 @@ V = ds2.v.isel(timestep=0)
 magnitude = np.sqrt(np.square(U.data) + np.square(V.data))
 
 # Plot streamline data
-streams = ax.streamplot(U.lon,
-                        U.lat,
-                        U.data,
-                        V.data,
-                        transform=ccrs.PlateCarree(),
-                        arrowstyle='->',
-                        linewidth=1,
-                        density=2.0,
-                        color=magnitude,
-                        cmap=colormap)
+streams = ax.streamplot(
+    U.lon,
+    U.lat,
+    U.data,
+    V.data,
+    transform=ccrs.PlateCarree(),
+    arrowstyle='->',
+    linewidth=1,
+    density=2.0,
+    color=magnitude,
+    cmap=colormap,
+)
 
 # Set streamlines and arrows to partially transparent
-streams.lines.set_alpha(.5)
-streams.arrows.set_alpha(.5)
+streams.lines.set_alpha(0.5)
+streams.arrows.set_alpha(0.5)
 
 # Create second subplot on figure for colorbar
-ax2 = fig.add_axes([.1, .1, .8, .05])
+ax2 = fig.add_axes([0.1, 0.1, 0.8, 0.05])
 
 # Set title of plot
 # Make title font bold using r"$\bf{_______}$" formatting
-gv.set_titles_and_labels(ax,
-                         maintitle=r"$\bf{Assigning}$" + " " + r"$\bf{color}$" +
-                         " " + r"$\bf{palette}$" + " " + r"$\bf{to}$" + " " +
-                         r"$\bf{streamlines}$",
-                         maintitlefontsize=25)
+gv.set_titles_and_labels(
+    ax,
+    maintitle=r"$\bf{Assigning}$"
+    + " "
+    + r"$\bf{color}$"
+    + " "
+    + r"$\bf{palette}$"
+    + " "
+    + r"$\bf{to}$"
+    + " "
+    + r"$\bf{streamlines}$",
+    maintitlefontsize=25,
+)
 
 # Plot colorbar on subplot
-cb = fig.colorbar(cm.ScalarMappable(cmap=colormap, norm=norm),
-                  cax=ax2,
-                  boundaries=colorbounds,
-                  ticks=np.arange(4, 52, 4),
-                  spacing='uniform',
-                  orientation='horizontal')
+cb = fig.colorbar(
+    cm.ScalarMappable(cmap=colormap, norm=norm),
+    cax=ax2,
+    boundaries=colorbounds,
+    ticks=np.arange(4, 52, 4),
+    spacing='uniform',
+    orientation='horizontal',
+)
 
 # Change size of colorbar tick font
 ax2.tick_params(labelsize=20)

--- a/Gallery/Tables/NCL_table_2.py
+++ b/Gallery/Tables/NCL_table_2.py
@@ -21,36 +21,91 @@ import matplotlib.pyplot as plt
 
 # Set row headers (first column)
 row_text = [
-    "", "", "SLP_ERA40", "Tsfc_ERA40", "Prc_GPCP", "Prc 30S-30N_GPCP", "LW_ERS",
-    "SW_ERS", "U300_ERA40", "Guess_BOGUS", "RH_NCEP", "LHFLX_ERA40",
-    "TWP_ERA40", "CLDTOT_NCEP", "O3_NASA", "Q_JMA", "PBLH_JMA", "Omega_CAS"
+    "",
+    "",
+    "SLP_ERA40",
+    "Tsfc_ERA40",
+    "Prc_GPCP",
+    "Prc 30S-30N_GPCP",
+    "LW_ERS",
+    "SW_ERS",
+    "U300_ERA40",
+    "Guess_BOGUS",
+    "RH_NCEP",
+    "LHFLX_ERA40",
+    "TWP_ERA40",
+    "CLDTOT_NCEP",
+    "O3_NASA",
+    "Q_JMA",
+    "PBLH_JMA",
+    "Omega_CAS",
 ]
 
 # Set colors of row headers (first column)
 rowcolors = [
-    'skyblue', 'skyblue', 'lightgray', 'lightgray', 'lightgray', 'lightgray',
-    'lightgray', 'lightgray', 'lightgray', 'lightgray', 'lightgray',
-    'lightgray', 'lightgray', 'lightgray', 'lightgray', 'lightgray',
-    'lightgray', 'lightgray'
+    'skyblue',
+    'skyblue',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
+    'lightgray',
 ]
 
 # Set cell values (second and third column)
-cell_text = [["Case A", "Case B"], ["ANN", "ANN"], ["1.230", "1.129"],
-             ["0.988", "0.996"], ["1.092", "1.016"], ["1.172", "1.134"],
-             ["1.064", "1.023"], ["0.966", "0.962"], ["1.079", "1.048"],
-             ["0.781", "0.852"], ["1.122", "0.911"], ["1.000", "0.835"],
-             ["0.998", "0.712"], ["1.321", "1.122"], ["0.842", "0.956"],
-             ["0.978", "0.832"], ["0.998", "0.900"], ["0.811", "1.311"]]
+cell_text = [
+    ["Case A", "Case B"],
+    ["ANN", "ANN"],
+    ["1.230", "1.129"],
+    ["0.988", "0.996"],
+    ["1.092", "1.016"],
+    ["1.172", "1.134"],
+    ["1.064", "1.023"],
+    ["0.966", "0.962"],
+    ["1.079", "1.048"],
+    ["0.781", "0.852"],
+    ["1.122", "0.911"],
+    ["1.000", "0.835"],
+    ["0.998", "0.712"],
+    ["1.321", "1.122"],
+    ["0.842", "0.956"],
+    ["0.978", "0.832"],
+    ["0.998", "0.900"],
+    ["0.811", "1.311"],
+]
 
 # Set colors of cells (second and third columns)
-colors = [['lightgray', 'lightgray'], ['lightgray', 'lightgray'],
-          ["White", "palegreen"], ["White", "hotpink"], ["White", "palegreen"],
-          ["White", "palegreen"], ["White",
-                                   "palegreen"], ["White", "palegreen"],
-          ["White", "palegreen"], ["White", "hotpink"], ["White", "palegreen"],
-          ["White", "palegreen"], ["White", "palegreen"],
-          ["White", "palegreen"], ["White", "hotpink"], ["White", "palegreen"],
-          ["White", "palegreen"], ["White", "hotpink"]]
+colors = [
+    ['lightgray', 'lightgray'],
+    ['lightgray', 'lightgray'],
+    ["White", "palegreen"],
+    ["White", "hotpink"],
+    ["White", "palegreen"],
+    ["White", "palegreen"],
+    ["White", "palegreen"],
+    ["White", "palegreen"],
+    ["White", "palegreen"],
+    ["White", "hotpink"],
+    ["White", "palegreen"],
+    ["White", "palegreen"],
+    ["White", "palegreen"],
+    ["White", "palegreen"],
+    ["White", "hotpink"],
+    ["White", "palegreen"],
+    ["White", "palegreen"],
+    ["White", "hotpink"],
+]
 
 ###############################################################################
 # Plot:
@@ -66,19 +121,23 @@ fig.patch.set_visible(False)
 ax.axis('off')
 
 # Plot first table
-table = ax.table(rowLabels=row_text,
-                 rowColours=rowcolors,
-                 rowLoc='center',
-                 cellText=cell_text,
-                 cellColours=colors,
-                 cellLoc='center',
-                 loc='center')
+table = ax.table(
+    rowLabels=row_text,
+    rowColours=rowcolors,
+    rowLoc='center',
+    cellText=cell_text,
+    cellColours=colors,
+    cellLoc='center',
+    loc='center',
+)
 
 # Plot single-cell table in upper left of first table
-plt.table(cellText=[['CAM METRICS']],
-          cellColours=[['skyblue']],
-          cellLoc='center',
-          bbox=[-.694, .815, 0.694, 0.091])
+plt.table(
+    cellText=[['CAM METRICS']],
+    cellColours=[['skyblue']],
+    cellLoc='center',
+    bbox=[-0.694, 0.815, 0.694, 0.091],
+)
 
 # Give plot a tight layout
 fig.tight_layout()

--- a/Gallery/TaylorDiagrams/NCL_taylor_2.py
+++ b/Gallery/TaylorDiagrams/NCL_taylor_2.py
@@ -49,7 +49,8 @@ dia.add_model_set(
     color='red',
     marker='o',
     facecolors='none',
-    s=100)  # marker size
+    s=100,
+)  # marker size
 dia.add_model_set(
     tstddev,
     tcorrcoef,
@@ -58,12 +59,11 @@ dia.add_model_set(
     color='blue',
     marker='D',
     facecolors='none',
-    s=100)
+    s=100,
+)
 
 # Add RMS contours, and label them
-dia.add_contours(levels=np.arange(0, 1.1, 0.25),
-                 colors='lightgrey',
-                 linewidths=0.5)
+dia.add_contours(levels=np.arange(0, 1.1, 0.25), colors='lightgrey', linewidths=0.5)
 
 # Add standard deviation axis grid
 dia.add_std_grid(np.array([0.5, 1.5]), color='grey')

--- a/Gallery/TaylorDiagrams/NCL_taylor_3.py
+++ b/Gallery/TaylorDiagrams/NCL_taylor_3.py
@@ -24,16 +24,48 @@ import geocat.viz as gv
 # Create dummy data:
 
 # Case A
-CA_ratio = [1.230, 0.988, 1.092, 1.172, 1.064, 0.966, 1.079,
-            0.781]  # standard deviation
-CA_cc = [0.958, 0.973, 0.740, 0.743, 0.922, 0.982, 0.952,
-         0.433]  # correlation coefficient
+CA_ratio = [
+    1.230,
+    0.988,
+    1.092,
+    1.172,
+    1.064,
+    0.966,
+    1.079,
+    0.781,
+]  # standard deviation
+CA_cc = [
+    0.958,
+    0.973,
+    0.740,
+    0.743,
+    0.922,
+    0.982,
+    0.952,
+    0.433,
+]  # correlation coefficient
 
 # Case B
-CB_ratio = [1.129, 0.996, 1.016, 1.134, 1.023, 0.962, 1.048,
-            0.852]  # standard deviation
-CB_cc = [0.963, 0.975, 0.801, 0.814, 0.946, 0.984, 0.968,
-         0.647]  # correlation coefficient
+CB_ratio = [
+    1.129,
+    0.996,
+    1.016,
+    1.134,
+    1.023,
+    0.962,
+    1.048,
+    0.852,
+]  # standard deviation
+CB_cc = [
+    0.963,
+    0.975,
+    0.801,
+    0.814,
+    0.946,
+    0.984,
+    0.968,
+    0.647,
+]  # correlation coefficient
 
 ###############################################################################
 # Plot:
@@ -43,19 +75,11 @@ fig = plt.figure(figsize=(10, 10))
 dia = gv.TaylorDiagram(fig=fig, label='REF')
 
 # Add models to Taylor diagram
-dia.add_model_set(CA_ratio,
-                  CA_cc,
-                  color='red',
-                  marker='o',
-                  label='Case A',
-                  fontsize=16)
+dia.add_model_set(CA_ratio, CA_cc, color='red', marker='o', label='Case A', fontsize=16)
 
-dia.add_model_set(CB_ratio,
-                  CB_cc,
-                  color='blue',
-                  marker='o',
-                  label='Case B',
-                  fontsize=16)
+dia.add_model_set(
+    CB_ratio, CB_cc, color='blue', marker='o', label='Case B', fontsize=16
+)
 
 # Create model name list
 namearr = ['SLP', 'Tsfc', 'Prc', 'Prc 30S-30N', 'LW', 'SW', 'U300', 'Guess']

--- a/Gallery/TaylorDiagrams/NCL_taylor_6.py
+++ b/Gallery/TaylorDiagrams/NCL_taylor_6.py
@@ -53,13 +53,15 @@ for i in range(4):
 
     # Add models case by case
     for j in range(stddev.shape[0]):
-        da.add_model_set(stddev[j],
-                         corrcoef[j],
-                         xytext=(-4, 5),
-                         fontsize=10,
-                         color=colors[j],
-                         label=labels[j],
-                         marker='o')
+        da.add_model_set(
+            stddev[j],
+            corrcoef[j],
+            xytext=(-4, 5),
+            fontsize=10,
+            color=colors[j],
+            label=labels[j],
+            marker='o',
+        )
     # Add legend
     da.add_legend(1.1, 1.05, fontsize=9, zorder=10)
 

--- a/Gallery/TaylorDiagrams/NCL_taylor_8.py
+++ b/Gallery/TaylorDiagrams/NCL_taylor_8.py
@@ -49,36 +49,36 @@ modelTextsA, _ = dia.add_model_set(
     CA_corr,
     fontsize=13,
     xytext=(-5, 13),  # marker label position
-    model_outlier_on=
-    True,  # plots models with negative correlations and/or standard deviations at bottom of diagram
+    model_outlier_on=True,  # plots models with negative correlations and/or standard deviations at bottom of diagram
     percent_bias_on=True,  # model marker and size plotted based on bias array
     bias_array=BA,
     edgecolors='red',
     facecolors='none',
     linewidths=0.5,
-    label='Data A')
+    label='Data A',
+)
 
-modelTextsB, _ = dia.add_model_set(CB_std,
-                                   CB_corr,
-                                   fontsize=13,
-                                   xytext=(-5, 13),
-                                   model_outlier_on=True,
-                                   percent_bias_on=True,
-                                   bias_array=BB,
-                                   edgecolors='blue',
-                                   facecolors='none',
-                                   linewidths=0.5,
-                                   label='Data B')
+modelTextsB, _ = dia.add_model_set(
+    CB_std,
+    CB_corr,
+    fontsize=13,
+    xytext=(-5, 13),
+    model_outlier_on=True,
+    percent_bias_on=True,
+    bias_array=BB,
+    edgecolors='blue',
+    facecolors='none',
+    linewidths=0.5,
+    label='Data B',
+)
 
 # Customize model labels: add background color
 for txt in modelTextsA:
-    txt.set_bbox(
-        dict(facecolor='red', edgecolor='none', pad=0.05, boxstyle='square'))
+    txt.set_bbox(dict(facecolor='red', edgecolor='none', pad=0.05, boxstyle='square'))
     txt.set_color('white')
 
 for txt in modelTextsB:
-    txt.set_bbox(
-        dict(facecolor='blue', edgecolor='none', pad=0.05, boxstyle='square'))
+    txt.set_bbox(dict(facecolor='blue', edgecolor='none', pad=0.05, boxstyle='square'))
     txt.set_color('white')
 
 # Add legend

--- a/Gallery/Topography/NCL_topo_1.py
+++ b/Gallery/Topography/NCL_topo_1.py
@@ -31,24 +31,25 @@ import geocat.viz as gv
 nlat = 2160
 nlon = 4320
 
-elevation_data = np.fromfile(gdf.get("binary_files/ETOPO5.DAT"),
-                             dtype='>i2').reshape((nlat, nlon))
+elevation_data = np.fromfile(gdf.get("binary_files/ETOPO5.DAT"), dtype='>i2').reshape(
+    (nlat, nlon)
+)
 
 # Create numpy arrays for latitude and longitude
 lat = np.linspace(90, -90, nlat)
 lon = np.linspace(0, 360, nlon)
 
 # Create an xarray DataArray
-da = xr.DataArray(data=elevation_data,
-                  dims=["lat", "lon"],
-                  coords=dict(lat=(["lat"], lat, {
-                      "long_name": "latitude"
-                  }),
-                              lon=(["lon"], lon, {
-                                  "long_name": "longitude"
-                              })),
-                  name="elevation",
-                  attrs={"units": "m"})
+da = xr.DataArray(
+    data=elevation_data,
+    dims=["lat", "lon"],
+    coords=dict(
+        lat=(["lat"], lat, {"long_name": "latitude"}),
+        lon=(["lon"], lon, {"long_name": "longitude"}),
+    ),
+    name="elevation",
+    attrs={"units": "m"},
+)
 
 ###############################################################################
 # Plot
@@ -64,16 +65,15 @@ ax = plt.axes(projection=projection)
 ax.coastlines(zorder=10)
 
 # Plot the elevation data
-elev = da.plot.imshow(ax=ax,
-                      transform=projection,
-                      cmap=cmaps.GMT_relief,
-                      add_colorbar=False)
+elev = da.plot.imshow(
+    ax=ax, transform=projection, cmap=cmaps.GMT_relief, add_colorbar=False
+)
 
 # Add colorbar
 cbar = plt.colorbar(ax=ax, mappable=elev, orientation='horizontal', pad=0.1)
 cbar.ax.tick_params(
-    size=0,
-    labelsize=14)  # Remove the tick marks from the colorbar, set label size
+    size=0, labelsize=14
+)  # Remove the tick marks from the colorbar, set label size
 cbar.ax.xaxis.set_tick_params(pad=10)
 
 # Use geocat-viz utility function to format major and minor tick marks
@@ -85,11 +85,13 @@ plt.xlabel("")
 plt.ylabel("")
 
 # Use geocat-viz utility function to format x and y tick labels
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=[-180, 180],
-                             ylim=[-90, 90],
-                             xticks=np.arange(-180, 181, 30),
-                             yticks=np.arange(-90, 91, 30))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=[-180, 180],
+    ylim=[-90, 90],
+    xticks=np.arange(-180, 181, 30),
+    yticks=np.arange(-90, 91, 30),
+)
 
 # Use geocat-viz utility function to add lat/lon formatting for tick labels
 gv.add_lat_lon_ticklabels(ax)

--- a/Gallery/Topography/NCL_topo_4.py
+++ b/Gallery/Topography/NCL_topo_4.py
@@ -58,7 +58,8 @@ states_provinces = cfeature.NaturalEarthFeature(
     category='cultural',
     name='admin_1_states_provinces_lines',
     scale='50m',
-    facecolor='none')
+    facecolor='none',
+)
 
 ax.add_feature(states_provinces, zorder=5, linewidth=0.4)
 
@@ -67,12 +68,9 @@ cmap = cmaps.OceanLakeLandSnow
 newcmap = gv.truncate_colormap(cmap=cmap, minval=0.01, maxval=1)
 
 # Plot the elevation data
-elev = ds.plot.imshow(ax=ax,
-                      transform=projection,
-                      cmap=newcmap,
-                      vmin=0,
-                      vmax=4000,
-                      add_colorbar=False)
+elev = ds.plot.imshow(
+    ax=ax, transform=projection, cmap=newcmap, vmin=0, vmax=4000, add_colorbar=False
+)
 
 # Set extent of the plot
 ax.set_extent([110, 155, -45, -5])
@@ -81,12 +79,14 @@ ax.set_extent([110, 155, -45, -5])
 ax.add_feature(cfeature.OCEAN, zorder=2)
 
 # Add colorbar
-cbar = plt.colorbar(ax=ax,
-                    mappable=elev,
-                    orientation='horizontal',
-                    pad=0.1,
-                    shrink=0.85,
-                    ticks=np.arange(0, 4500, 500))
+cbar = plt.colorbar(
+    ax=ax,
+    mappable=elev,
+    orientation='horizontal',
+    pad=0.1,
+    shrink=0.85,
+    ticks=np.arange(0, 4500, 500),
+)
 
 # Remove the tick marks from the colorbar and set tick label size
 cbar.ax.tick_params(size=0, labelsize=14)
@@ -95,20 +95,24 @@ cbar.ax.tick_params(size=0, labelsize=14)
 cbar.ax.xaxis.set_tick_params(pad=10)
 
 # Use geocat-viz utility function to add left and right titles
-gv.set_titles_and_labels(ax,
-                         lefttitle='elevation',
-                         righttitle='m',
-                         maintitle='ETOPO1',
-                         maintitlefontsize=23,
-                         xlabel="",
-                         ylabel="")
+gv.set_titles_and_labels(
+    ax,
+    lefttitle='elevation',
+    righttitle='m',
+    maintitle='ETOPO1',
+    maintitlefontsize=23,
+    xlabel="",
+    ylabel="",
+)
 
 # Use geocat-viz utility function to format x and y tick labels
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=[110, 155],
-                             ylim=[-45, -6],
-                             xticks=np.arange(110, 160, 10),
-                             yticks=np.arange(-45, 10, 5))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=[110, 155],
+    ylim=[-45, -6],
+    xticks=np.arange(110, 160, 10),
+    yticks=np.arange(-45, 10, 5),
+)
 
 # Use geocat-viz utility function to add lat/lon formatting for tick labels
 gv.add_lat_lon_ticklabels(ax)

--- a/Gallery/Topography/NCL_topo_8.py
+++ b/Gallery/Topography/NCL_topo_8.py
@@ -64,54 +64,41 @@ cmap = cmaps.OceanLakeLandSnow
 newcmap = gv.truncate_colormap(cmap=cmap, minval=0.01, maxval=1)
 
 # Plot the elevation data
-elev = ds.plot.imshow(ax=ax,
-                      transform=projection,
-                      cmap=newcmap,
-                      add_colorbar=False)
+elev = ds.plot.imshow(ax=ax, transform=projection, cmap=newcmap, add_colorbar=False)
 
 # Add colorbar
-cbar = plt.colorbar(ax=ax,
-                    mappable=elev,
-                    orientation='horizontal',
-                    pad=0.13,
-                    shrink=0.85)
+cbar = plt.colorbar(
+    ax=ax, mappable=elev, orientation='horizontal', pad=0.13, shrink=0.85
+)
 cbar.ax.tick_params(size=0)  # Remove tick marks from colorbar
 cbar.ax.xaxis.set_tick_params(
-    pad=10, labelsize=16)  # Pad between colorbar and tick labels
-cbar.set_label("elevation (meters)", fontsize=20,
-               labelpad=15)  # Add colorbar label
+    pad=10, labelsize=16
+)  # Pad between colorbar and tick labels
+cbar.set_label("elevation (meters)", fontsize=20, labelpad=15)  # Add colorbar label
 
 # Add counties
 counties = list(shapefile_counties.geometries())
 COUNTIES = cfeature.ShapelyFeature(counties, ccrs.PlateCarree())
-ax.add_feature(COUNTIES,
-               facecolor='none',
-               edgecolor='black',
-               linewidth=0.4,
-               zorder=5)
+ax.add_feature(COUNTIES, facecolor='none', edgecolor='black', linewidth=0.4, zorder=5)
 
 # Add rivers
 rivers = list(shapefile_rivers.geometries())
 RIVERS = cfeature.ShapelyFeature(rivers, ccrs.PlateCarree())
-ax.add_feature(RIVERS,
-               facecolor='none',
-               edgecolor='blue',
-               linewidth=0.6,
-               zorder=6)
+ax.add_feature(RIVERS, facecolor='none', edgecolor='blue', linewidth=0.6, zorder=6)
 
 # Use geocat-viz utility function to customize titles and labels
-gv.set_titles_and_labels(ax,
-                         xlabel="",
-                         ylabel="",
-                         maintitle="Rivers of Colorado",
-                         maintitlefontsize=28)
+gv.set_titles_and_labels(
+    ax, xlabel="", ylabel="", maintitle="Rivers of Colorado", maintitlefontsize=28
+)
 
 # Use geocat-viz utility function to format x and y axes
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=[-109.1, -102],
-                             ylim=[36.9, 41.2],
-                             xticks=np.arange(-109, 102),
-                             yticks=np.arange(37, 42))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=[-109.1, -102],
+    ylim=[36.9, 41.2],
+    xticks=np.arange(-109, 102),
+    yticks=np.arange(37, 42),
+)
 
 # Customize ticks and labels
 ax.tick_params(length=10, width=1.2, labelsize=16, pad=10)

--- a/Gallery/Trajectories/NCL_polyg_14.py
+++ b/Gallery/Trajectories/NCL_polyg_14.py
@@ -103,11 +103,9 @@ def Plot(color, ext, xext, yext, npts, title, subt, style, pt):
     gv.add_major_minor_ticks(ax, labelsize=12)
 
     # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-    gv.set_titles_and_labels(ax,
-                             maintitle=subt,
-                             maintitlefontsize=12,
-                             xlabel="",
-                             ylabel="")
+    gv.set_titles_and_labels(
+        ax, maintitle=subt, maintitlefontsize=12, xlabel="", ylabel=""
+    )
     plt.show()
 
 

--- a/Gallery/Trajectories/NCL_traj_1.py
+++ b/Gallery/Trajectories/NCL_traj_1.py
@@ -35,9 +35,7 @@ sdata = ds.get('sdata')
 
 
 def plot_nth_timestep(nparrayy, nparrayx, n):
-
     for x in range(0, len(nparrayx)):
-
         # Plot green starting point of each trajectory
         if x == 0:
             y, x = nparrayy[x], nparrayx[x]
@@ -69,9 +67,9 @@ ax.add_feature(cfeature.LAND, color='lightgrey')
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=np.linspace(-70, -30, 5),
-                             yticks=np.linspace(-60, -20, 5))
+gv.set_axes_limits_and_ticks(
+    ax, xticks=np.linspace(-70, -30, 5), yticks=np.linspace(-60, -20, 5)
+)
 
 # Select trajectories to plot
 traj = [1, 10, 53, 67, 80]
@@ -81,9 +79,8 @@ trajlinecolors = ["red", "blue", "green", "grey", "magenta"]
 
 # Plot each trajectory
 for i in range(len(traj)):
-
     # Extract latitude
-    ypt = (np.array(sdata[1, :, traj[i]]) - 360)
+    ypt = np.array(sdata[1, :, traj[i]]) - 360
 
     # Extract longitude
     xpt = np.array(sdata[2, :, traj[i]])

--- a/Gallery/Vectors/NCL_vector_1.py
+++ b/Gallery/Vectors/NCL_vector_1.py
@@ -95,41 +95,38 @@ Q = plt.quiver(
     v,
     color='white',
     pivot='middle',
-    width=.0025,
+    width=0.0025,
     scale=75,
 )
 
 # Use geocat-viz utility function to format title
-gv.set_titles_and_labels(ax,
-                         maintitle='',
-                         maintitlefontsize=18,
-                         lefttitle="Sea Surface Temperature",
-                         lefttitlefontsize=18,
-                         righttitle="C",
-                         righttitlefontsize=18,
-                         xlabel=None,
-                         ylabel=None,
-                         labelfontsize=16)
+gv.set_titles_and_labels(
+    ax,
+    maintitle='',
+    maintitlefontsize=18,
+    lefttitle="Sea Surface Temperature",
+    lefttitlefontsize=18,
+    righttitle="C",
+    righttitlefontsize=18,
+    xlabel=None,
+    ylabel=None,
+    labelfontsize=16,
+)
 
 # Format tick labels as latitude and longitudes
 gv.add_lat_lon_ticklabels(ax=ax)
 
 # Use geocat-viz utility function to customize tick marks
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(65, 95),
-                             ylim=(5, 25),
-                             xticks=range(70, 95, 10),
-                             yticks=range(5, 27, 5))
+gv.set_axes_limits_and_ticks(
+    ax, xlim=(65, 95), ylim=(5, 25), xticks=range(70, 95, 10), yticks=range(5, 27, 5)
+)
 
 # Remove degree symbol from tick labels
 ax.yaxis.set_major_formatter(LatitudeFormatter(degree_symbol=''))
 ax.xaxis.set_major_formatter(LongitudeFormatter(degree_symbol=''))
 
 # Add minor tick marks
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=4,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=4, labelsize=14)
 
 # Draw the key for the quiver plot as a rectangle patch
 rect = mpl.patches.Rectangle(
@@ -155,15 +152,17 @@ qk = ax.quiverkey(
 )
 
 # Add and customize colorbar
-cbar_ticks = np.arange(24, 28.8, .3)
-plt.colorbar(ax=ax,
-             mappable=sst_plot,
-             extendrect=True,
-             extendfrac='auto',
-             shrink=0.75,
-             aspect=10,
-             ticks=cbar_ticks,
-             drawedges=True)
+cbar_ticks = np.arange(24, 28.8, 0.3)
+plt.colorbar(
+    ax=ax,
+    mappable=sst_plot,
+    extendrect=True,
+    extendfrac='auto',
+    shrink=0.75,
+    aspect=10,
+    ticks=cbar_ticks,
+    drawedges=True,
+)
 
 # Show the plot
 plt.show()

--- a/Gallery/Vectors/NCL_vector_3.py
+++ b/Gallery/Vectors/NCL_vector_3.py
@@ -55,46 +55,35 @@ z = gv.set_vector_density(ds, 10)
 #    Note that it uses a minimum distance threshold specified as a integer in degrees rather than the NCL normalized device coordinates.
 #
 # 2. There is no matplotlib equivalent to "CurlyVector"
-Q = plt.quiver(z['lon'],
-               z['lat'],
-               z['U'].data,
-               z['V'].data,
-               color='black',
-               zorder=1,
-               pivot="middle",
-               width=0.0007,
-               headwidth=10)
+Q = plt.quiver(
+    z['lon'],
+    z['lat'],
+    z['U'].data,
+    z['V'].data,
+    color='black',
+    zorder=1,
+    pivot="middle",
+    width=0.0007,
+    headwidth=10,
+)
 
 # Draw legend for vector plot
-qk = ax.quiverkey(Q,
-                  167.5,
-                  72.5,
-                  20,
-                  r'20',
-                  labelpos='N',
-                  coordinates='data',
-                  color='black',
-                  zorder=2)
+qk = ax.quiverkey(
+    Q, 167.5, 72.5, 20, r'20', labelpos='N', coordinates='data', color='black', zorder=2
+)
 
 # Turn on continent shading
-ax.add_feature(cartopy.feature.LAND,
-               edgecolor='lightgray',
-               facecolor='lightgray',
-               zorder=0)
+ax.add_feature(
+    cartopy.feature.LAND, edgecolor='lightgray', facecolor='lightgray', zorder=0
+)
 
 # Draw the key for the quiver plot as a rectangle patch
 ax.add_patch(
-    plt.Rectangle((155, 65),
-                  25,
-                  25,
-                  facecolor='white',
-                  edgecolor='black',
-                  zorder=1))
+    plt.Rectangle((155, 65), 25, 25, facecolor='white', edgecolor='black', zorder=1)
+)
 
 # Use geocat.viz.util convenience function to set axes tick values
-gv.set_axes_limits_and_ticks(ax,
-                             xticks=range(-180, 181, 30),
-                             yticks=range(-90, 91, 30))
+gv.set_axes_limits_and_ticks(ax, xticks=range(-180, 181, 30), yticks=range(-90, 91, 30))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, labelsize=12)
@@ -103,9 +92,7 @@ gv.add_major_minor_ticks(ax, labelsize=12)
 gv.add_lat_lon_ticklabels(ax)
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         lefttitle=ds['U'].long_name,
-                         righttitle=ds['U'].units)
+gv.set_titles_and_labels(ax, lefttitle=ds['U'].long_name, righttitle=ds['U'].units)
 
 # Add timestamp
 ax.text(-200, -115, f'Created: {datetime.now()}')

--- a/Gallery/Vectors/NCL_vector_4.py
+++ b/Gallery/Vectors/NCL_vector_4.py
@@ -46,40 +46,32 @@ fig = plt.figure(figsize=(10, 7.25))
 ax = plt.axes(projection=ccrs.PlateCarree())
 
 # Import an NCL colormap and truncate it for a range and color levels
-cmap = gv.truncate_colormap(cmaps.BlAqGrYeOrReVi200,
-                            minval=0.03,
-                            maxval=0.95,
-                            n=16)
+cmap = gv.truncate_colormap(cmaps.BlAqGrYeOrReVi200, minval=0.03, maxval=0.95, n=16)
 
 # Draw vector plot
 # (there is no matplotlib equivalent to "CurlyVector" yet)
-Q = plt.quiver(ds['lon'],
-               ds['lat'],
-               ds['U'].data,
-               ds['V'].data,
-               ds['T'].data,
-               cmap=cmap,
-               zorder=1,
-               pivot="middle",
-               width=0.001)
+Q = plt.quiver(
+    ds['lon'],
+    ds['lat'],
+    ds['U'].data,
+    ds['V'].data,
+    ds['T'].data,
+    cmap=cmap,
+    zorder=1,
+    pivot="middle",
+    width=0.001,
+)
 plt.clim(228, 292)
 
 # Draw legend for vector plot
 ax.add_patch(
-    plt.Rectangle((150, -140),
-                  30,
-                  30,
-                  facecolor='white',
-                  edgecolor='black',
-                  clip_on=False))
-qk = ax.quiverkey(Q,
-                  0.93,
-                  0.06,
-                  10,
-                  r'10 $m/s$',
-                  labelpos='N',
-                  coordinates='figure',
-                  color='black')
+    plt.Rectangle(
+        (150, -140), 30, 30, facecolor='white', edgecolor='black', clip_on=False
+    )
+)
+qk = ax.quiverkey(
+    Q, 0.93, 0.06, 10, r'10 $m/s$', labelpos='N', coordinates='figure', color='black'
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, labelsize=12)
@@ -92,24 +84,27 @@ plt.xticks(range(-180, 181, 30))
 plt.yticks(range(-90, 91, 30))
 
 # Use geocat.viz.util convenience function to add titles to left and right of the plot axis.
-gv.set_titles_and_labels(ax,
-                         maintitle="Vectors colored by a scalar map",
-                         lefttitle="Temperature",
-                         righttitle="$^{\circ}$K")
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Vectors colored by a scalar map",
+    lefttitle="Temperature",
+    righttitle="$^{\circ}$K",
+)
 
 cax = plt.axes((0.225, 0.075, 0.55, 0.025))
-cbar = fig.colorbar(Q,
-                    ax=ax,
-                    cax=cax,
-                    orientation='horizontal',
-                    ticks=range(232, 289, 8),
-                    drawedges=True)
+cbar = fig.colorbar(
+    Q,
+    ax=ax,
+    cax=cax,
+    orientation='horizontal',
+    ticks=range(232, 289, 8),
+    drawedges=True,
+)
 
 # Turn on continent shading
-ax.add_feature(cartopy.feature.LAND,
-               edgecolor='lightgray',
-               facecolor='lightgray',
-               zorder=0)
+ax.add_feature(
+    cartopy.feature.LAND, edgecolor='lightgray', facecolor='lightgray', zorder=0
+)
 
 # Generate plot!
 plt.tight_layout()

--- a/Gallery/WRF/NCL_WRF_zoom_1_2.py
+++ b/Gallery/WRF/NCL_WRF_zoom_1_2.py
@@ -22,14 +22,13 @@ import matplotlib.ticker as mticker
 import cartopy.crs as ccrs
 from cartopy.feature import NaturalEarthFeature
 
-from wrf import (getvar, to_np, latlon_coords, get_cartopy)
+from wrf import getvar, to_np, latlon_coords, get_cartopy
 import geocat.datafiles as gdf
 
 ###############################################################################
 # Read in the data
 
-wrfin = Dataset(
-    gdf.get("netcdf_files/wrfout_d03_2012-04-22_23_00_00_subset.nc"))
+wrfin = Dataset(gdf.get("netcdf_files/wrfout_d03_2012-04-22_23_00_00_subset.nc"))
 td2 = getvar(wrfin, "td2")
 
 # Set attributes for creating plot titles later
@@ -71,55 +70,62 @@ fig = plt.figure(figsize=(12, 12))
 ax = plt.axes(projection=cart_proj)
 
 # Add features to the projection
-states = NaturalEarthFeature(category="cultural",
-                             scale="50m",
-                             facecolor="none",
-                             name="admin_1_states_provinces")
+states = NaturalEarthFeature(
+    category="cultural", scale="50m", facecolor="none", name="admin_1_states_provinces"
+)
 
 ax.add_feature(states, linewidth=0.5, edgecolor="black")
 ax.coastlines('50m', linewidth=0.8)
 
 # Add filled dew point temperature contours
-plt.contourf(to_np(lons),
-             to_np(lats),
-             to_np(td2_zoom),
-             levels=13,
-             cmap="magma",
-             transform=ccrs.PlateCarree(),
-             vmin=-8,
-             vmax=18)
+plt.contourf(
+    to_np(lons),
+    to_np(lats),
+    to_np(td2_zoom),
+    levels=13,
+    cmap="magma",
+    transform=ccrs.PlateCarree(),
+    vmin=-8,
+    vmax=18,
+)
 
 # Add a colorbar
-cbar = plt.colorbar(ax=ax,
-                    orientation="horizontal",
-                    ticks=np.arange(-6, 18, 2),
-                    drawedges=True,
-                    extendrect=True,
-                    pad=0.08,
-                    shrink=0.75,
-                    aspect=30)
+cbar = plt.colorbar(
+    ax=ax,
+    orientation="horizontal",
+    ticks=np.arange(-6, 18, 2),
+    drawedges=True,
+    extendrect=True,
+    pad=0.08,
+    shrink=0.75,
+    aspect=30,
+)
 
 # Format location of colorbar text to look like NCL version
-cbar.ax.text(0.5,
-             1.5,
-             '2m Dewpoint Temperature (C)',
-             horizontalalignment='center',
-             verticalalignment='center',
-             transform=cbar.ax.transAxes)
+cbar.ax.text(
+    0.5,
+    1.5,
+    '2m Dewpoint Temperature (C)',
+    horizontalalignment='center',
+    verticalalignment='center',
+    transform=cbar.ax.transAxes,
+)
 
 # Format colorbar ticks and labels
 cbar.ax.tick_params(labelsize=10)
 cbar.ax.get_xaxis().labelpad = -48
 
 # Draw gridlines
-gl = ax.gridlines(crs=ccrs.PlateCarree(),
-                  draw_labels=True,
-                  dms=False,
-                  x_inline=False,
-                  y_inline=False,
-                  linewidth=1,
-                  color="k",
-                  alpha=0.25)
+gl = ax.gridlines(
+    crs=ccrs.PlateCarree(),
+    draw_labels=True,
+    dms=False,
+    x_inline=False,
+    y_inline=False,
+    linewidth=1,
+    color="k",
+    alpha=0.25,
+)
 
 # Manipulate latitude and longitude gridline numbers and spacing
 gl.top_labels = False
@@ -132,15 +138,12 @@ gl.xlines = False
 gl.ylines = False
 
 # Add titles to the plot
-plt.title("Zoomed in plot", loc='center', x=.13, y=1.1, size=15)
+plt.title("Zoomed in plot", loc='center', x=0.13, y=1.1, size=15)
 plt.title("2m Dewpoint Temperature (C)", loc='left', y=1.02, size=10)
 plt.title(sd_frmt.format(s_date), loc='right', y=1.1, size=10)
 
 # Add lower text using attributes from the dataset
 fig.text(0.25, 0.1, getattr(wrfin, 'TITLE'), size=12)
-fig.text(0.252,
-         0.08,
-         str_format.format(we, sn, lvl, dis, phys, pbl, cu),
-         size=12)
+fig.text(0.252, 0.08, str_format.format(we, sn, lvl, dis, phys, pbl, cu), size=12)
 
 plt.show()

--- a/Gallery/WRF/NCL_dataonmap_10.py
+++ b/Gallery/WRF/NCL_dataonmap_10.py
@@ -21,7 +21,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import cartopy.crs as ccrs
-from wrf import (getvar, to_np, latlon_coords)
+from wrf import getvar, to_np, latlon_coords
 
 import geocat.datafiles as gdf
 import geocat.viz as gv
@@ -29,8 +29,9 @@ import geocat.viz as gv
 ###############################################################################
 # Read in the data
 
-wrfin = Dataset(gdf.get("netcdf_files/wrfout_d01_2003-07-15_00_00_00"),
-                decode_times=True)
+wrfin = Dataset(
+    gdf.get("netcdf_files/wrfout_d01_2003-07-15_00_00_00"), decode_times=True
+)
 q2 = getvar(wrfin, "Q2")
 
 ###############################################################################
@@ -46,36 +47,42 @@ fig = plt.figure(figsize=(10, 10))
 ax = plt.axes(projection=ccrs.PlateCarree())
 
 # Add filled contours
-plt.contourf(to_np(lons),
-             to_np(lats),
-             q2,
-             levels=np.linspace(0.01125, 0.05, 32),
-             cmap="magma",
-             vmin=0,
-             vmax=0.05,
-             zorder=4)
+plt.contourf(
+    to_np(lons),
+    to_np(lats),
+    q2,
+    levels=np.linspace(0.01125, 0.05, 32),
+    cmap="magma",
+    vmin=0,
+    vmax=0.05,
+    zorder=4,
+)
 
 # Add a colorbar
-cbar = plt.colorbar(ax=ax,
-                    orientation="vertical",
-                    ticks=np.arange(0.0125, 0.0476, 0.0025),
-                    drawedges=True,
-                    extendrect=True,
-                    shrink=0.65)
+cbar = plt.colorbar(
+    ax=ax,
+    orientation="vertical",
+    ticks=np.arange(0.0125, 0.0476, 0.0025),
+    drawedges=True,
+    extendrect=True,
+    shrink=0.65,
+)
 
 # Format colorbar ticks and labels
 cbar.ax.tick_params(size=0, labelsize=10)
 
 # Draw gridlines
-gl = ax.gridlines(crs=ccrs.PlateCarree(),
-                  draw_labels=True,
-                  dms=False,
-                  x_inline=False,
-                  y_inline=False,
-                  linewidth=1,
-                  color="k",
-                  alpha=0.25,
-                  zorder=4)
+gl = ax.gridlines(
+    crs=ccrs.PlateCarree(),
+    draw_labels=True,
+    dms=False,
+    x_inline=False,
+    y_inline=False,
+    linewidth=1,
+    color="k",
+    alpha=0.25,
+    zorder=4,
+)
 
 # Manipulate latitude and longitude gridline numbers and spacing
 gl.top_labels = False
@@ -88,10 +95,12 @@ gl.xlines = True
 gl.ylines = True
 
 # Add titles and labels to projection
-gv.set_titles_and_labels(ax,
-                         maintitle="WRF data on native grid",
-                         lefttitle="QV at 2 M",
-                         maintitlefontsize=16,
-                         lefttitlefontsize=14)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="WRF data on native grid",
+    lefttitle="QV at 2 M",
+    maintitlefontsize=16,
+    lefttitlefontsize=14,
+)
 
 plt.show()

--- a/Gallery/WRF/NCL_wrf_interp_3.py
+++ b/Gallery/WRF/NCL_wrf_interp_3.py
@@ -21,7 +21,7 @@ import matplotlib.pyplot as plt
 import xarray as xr
 import os
 
-from wrf import (to_np, getvar, CoordPair, vertcross, latlon_coords)
+from wrf import to_np, getvar, CoordPair, vertcross, latlon_coords
 import geocat.datafiles as gdf
 import geocat.viz as gv
 
@@ -31,10 +31,12 @@ import geocat.viz as gv
 # Specify the necessary variables needed from the data set in order to use 'z' and 'QVAPOR'
 toinclude = ['PH', 'P', 'HGT', 'PHB', 'QVAPOR']
 # Read in necessary datasets
-ds = xr.open_mfdataset([
-    gdf.get('netcdf_files/wrfout_d03_2012-04-22_23_00_00_Z.nc'),
-    gdf.get('netcdf_files/wrfout_d03_2012-04-22_23_00_00_QV.nc')
-])
+ds = xr.open_mfdataset(
+    [
+        gdf.get('netcdf_files/wrfout_d03_2012-04-22_23_00_00_Z.nc'),
+        gdf.get('netcdf_files/wrfout_d03_2012-04-22_23_00_00_QV.nc'),
+    ]
+)
 
 # specify a unique output file name to use to read in combined dataset later
 file3 = 'wrfout_d03_2012-04-22_23.nc'
@@ -55,12 +57,9 @@ lats, lons = latlon_coords(qv)
 start_point = CoordPair(lat=38, lon=-118)
 end_point = CoordPair(lat=40, lon=-115)
 
-qv_cross = vertcross(qv,
-                     z,
-                     wrfin=wrfin,
-                     start_point=start_point,
-                     end_point=end_point,
-                     latlon=True)
+qv_cross = vertcross(
+    qv, z, wrfin=wrfin, start_point=start_point, end_point=end_point, latlon=True
+)
 
 # Close 'wrfin' to prevent PermissionError if code is run more than once locally
 wrfin.close()
@@ -78,24 +77,23 @@ coord_pairs = to_np(qv_cross.coords["xy_loc"])
 x_ticks = np.arange(coord_pairs.shape[0])
 
 # Plot filled contours
-qv_contours = qv_cross.plot.contourf(ax=ax,
-                                     levels=17,
-                                     cmap='magma',
-                                     vmin=0,
-                                     vmax=0.004,
-                                     zorder=4,
-                                     add_labels=False,
-                                     add_colorbar=False,
-                                     yticks=np.arange(0, 20000, 3000),
-                                     xticks=x_ticks[::20])
+qv_contours = qv_cross.plot.contourf(
+    ax=ax,
+    levels=17,
+    cmap='magma',
+    vmin=0,
+    vmax=0.004,
+    zorder=4,
+    add_labels=False,
+    add_colorbar=False,
+    yticks=np.arange(0, 20000, 3000),
+    xticks=x_ticks[::20],
+)
 # Add colorbar
-plt.colorbar(qv_contours, ax=ax, ticks=np.arange(0.00025, 0.004, .00025))
+plt.colorbar(qv_contours, ax=ax, ticks=np.arange(0.00025, 0.004, 0.00025))
 
 # Add minor ticks to the yaxis
-gv.add_major_minor_ticks(ax=ax,
-                         x_minor_per_major=1,
-                         y_minor_per_major=3,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax=ax, x_minor_per_major=1, y_minor_per_major=3, labelsize=14)
 
 # Format the xtick labels
 x_labels = [

--- a/Gallery/XY/NCL_axes_3.py
+++ b/Gallery/XY/NCL_axes_3.py
@@ -34,54 +34,50 @@ y = 500 + 0.9 * np.arange(0, npts) * np.sin(np.pi / 100 * np.arange(0, npts))
 # Plot:
 
 # Create subplots
-fig, axes = plt.subplots(nrows=2,
-                         ncols=2,
-                         figsize=(10, 10),
-                         gridspec_kw=dict(wspace=0.5, hspace=0.5))
+fig, axes = plt.subplots(
+    nrows=2, ncols=2, figsize=(10, 10), gridspec_kw=dict(wspace=0.5, hspace=0.5)
+)
 
 # Subplot(0, 0): Create plot with linear axes and full perimeter
 axes[0][0].plot(x, y, color='orange')
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(axes[0][0],
-                         maintitle="Perimeter Background",
-                         xlabel="Linear",
-                         ylabel="Linear")
+gv.set_titles_and_labels(
+    axes[0][0], maintitle="Perimeter Background", xlabel="Linear", ylabel="Linear"
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(axes[0][0],
-                         x_minor_per_major=2,
-                         y_minor_per_major=2,
-                         labelsize=10)
+gv.add_major_minor_ticks(
+    axes[0][0], x_minor_per_major=2, y_minor_per_major=2, labelsize=10
+)
 
 # Use geocat.viz.util convenience function to set axes limits and tick labels
-gv.set_axes_limits_and_ticks(axes[0][0],
-                             xlim=(0, 900),
-                             ylim=(100, 1000),
-                             xticks=range(0, 901, 100),
-                             yticks=range(100, 1001, 100))
+gv.set_axes_limits_and_ticks(
+    axes[0][0],
+    xlim=(0, 900),
+    ylim=(100, 1000),
+    xticks=range(0, 901, 100),
+    yticks=range(100, 1001, 100),
+)
 
 # Subplot(0, 1): Create plot with log y-axis and gridlines
 axes[0][1].set_yscale('log')
 axes[0][1].plot(x, y, color='limegreen')
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(axes[0][1],
-                         maintitle="Grid Background",
-                         xlabel="Linear",
-                         ylabel="Logarithmic")
+gv.set_titles_and_labels(
+    axes[0][1], maintitle="Grid Background", xlabel="Linear", ylabel="Logarithmic"
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(axes[0][1],
-                         x_minor_per_major=2,
-                         y_minor_per_major=2,
-                         labelsize=10)
+gv.add_major_minor_ticks(
+    axes[0][1], x_minor_per_major=2, y_minor_per_major=2, labelsize=10
+)
 
 # Use geocat.viz.util convenience function to set axes limits and tick labels
-gv.set_axes_limits_and_ticks(axes[0][1],
-                             xlim=(0, 900),
-                             ylim=(100, 1000),
-                             xticks=range(0, 901, 100))
+gv.set_axes_limits_and_ticks(
+    axes[0][1], xlim=(0, 900), ylim=(100, 1000), xticks=range(0, 901, 100)
+)
 
 # Remove labels for minor ticks on log scale
 axes[0][1].yaxis.set_minor_formatter(NullFormatter())
@@ -94,22 +90,19 @@ axes[1][0].set_xscale('log')
 axes[1][0].plot(x, y, color='blueviolet')
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(axes[1][0],
-                         maintitle="Half-Axis Background",
-                         xlabel="Logarithmic",
-                         ylabel="Linear")
+gv.set_titles_and_labels(
+    axes[1][0], maintitle="Half-Axis Background", xlabel="Logarithmic", ylabel="Linear"
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(axes[1][0],
-                         x_minor_per_major=2,
-                         y_minor_per_major=2,
-                         labelsize=10)
+gv.add_major_minor_ticks(
+    axes[1][0], x_minor_per_major=2, y_minor_per_major=2, labelsize=10
+)
 
 # Use geocat.viz.util convenience function to set axes limits and tick labels
-gv.set_axes_limits_and_ticks(axes[1][0],
-                             xlim=(10, 1000),
-                             ylim=(100, 1000),
-                             yticks=range(100, 1001, 100))
+gv.set_axes_limits_and_ticks(
+    axes[1][0], xlim=(10, 1000), ylim=(100, 1000), yticks=range(100, 1001, 100)
+)
 
 # Remove labels for minor ticks on log scale
 axes[1][0].xaxis.set_minor_formatter(NullFormatter())
@@ -128,10 +121,9 @@ axes[1][1].set_yscale('log')
 axes[1][1].plot(x, y, color='firebrick')
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(axes[1][1],
-                         maintitle="No Background",
-                         xlabel="Logarithmic",
-                         ylabel="Logarithmic")
+gv.set_titles_and_labels(
+    axes[1][1], maintitle="No Background", xlabel="Logarithmic", ylabel="Logarithmic"
+)
 
 # Use geocat.viz.util convenience function to set axes limits and tick labels
 gv.set_axes_limits_and_ticks(axes[1][1], xlim=(31.628, 1000), ylim=(100, 1000))
@@ -140,15 +132,17 @@ gv.set_axes_limits_and_ticks(axes[1][1], xlim=(31.628, 1000), ylim=(100, 1000))
 axes[1][1].set_frame_on(False)
 
 # Remove all tick marks and their labels
-axes[1][1].tick_params(which='both',
-                       top=False,
-                       bottom=False,
-                       left=False,
-                       right=False,
-                       labeltop=False,
-                       labelbottom=False,
-                       labelleft=False,
-                       labelright=False)
+axes[1][1].tick_params(
+    which='both',
+    top=False,
+    bottom=False,
+    left=False,
+    right=False,
+    labeltop=False,
+    labelbottom=False,
+    labelleft=False,
+    labelright=False,
+)
 
 # Show plot
 plt.show()

--- a/Gallery/XY/NCL_corel_1.py
+++ b/Gallery/XY/NCL_corel_1.py
@@ -25,8 +25,7 @@ import geocat.viz as gv
 
 # Open a netCDF data file using xarray default engine and load the data into
 # xarrays
-ds = xr.open_dataset(gdf.get("netcdf_files/b003_TS_200-299.nc"),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get("netcdf_files/b003_TS_200-299.nc"), decode_times=False)
 
 # Extract time series from 3d data
 ts = ds.TS
@@ -86,19 +85,14 @@ ccr = LeadLagCorr(ts1, ts2)
 ax.plot(x, ccr, color='gray', linewidth=0.5)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=16)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, tick values, and tick labels to show latitude & longitude (i.e. North (N) - South (S))
 gv.set_axes_limits_and_ticks(ax, xlim=(0, 24), ylim=(-1.2, 1.2), xticks=x[::4])
 
 # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-gv.set_titles_and_labels(ax,
-                         maintitle="37.7N 180E vs 23.72S 149W",
-                         xlabel="LAG")
+gv.set_titles_and_labels(ax, maintitle="37.7N 180E vs 23.72S 149W", xlabel="LAG")
 
 # Set major and minor tick directions and padding
 ax.tick_params(which='both', direction='in', pad=9)

--- a/Gallery/XY/NCL_time_labels_1.py
+++ b/Gallery/XY/NCL_time_labels_1.py
@@ -40,7 +40,7 @@ for year in range(tstart, tend + 1):
         i += 1
 
 # Create random 1D array
-arr = np.random.uniform(-5., 10., t_size)
+arr = np.random.uniform(-5.0, 10.0, t_size)
 
 ###############################################################################
 # Plot:
@@ -58,37 +58,42 @@ ax[0].xaxis.set_major_formatter(FormatStrFormatter('%.1f'))
 
 for axes in [ax[0], ax[1]]:
     # Use geocat.viz.util convenience function to add minor and major tick lines
-    gv.add_major_minor_ticks(axes,
-                             x_minor_per_major=5,
-                             y_minor_per_major=3,
-                             labelsize=14)
+    gv.add_major_minor_ticks(
+        axes, x_minor_per_major=5, y_minor_per_major=3, labelsize=14
+    )
 
     # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
     # Set axes limits
-    gv.set_axes_limits_and_ticks(axes,
-                                 xlim=(tstart, tend + 1),
-                                 ylim=(-6, 12),
-                                 yticks=np.arange(-6, 13, 3))
+    gv.set_axes_limits_and_ticks(
+        axes, xlim=(tstart, tend + 1), ylim=(-6, 12), yticks=np.arange(-6, 13, 3)
+    )
 
 # Add minor and major tick lines for plot 3
-gv.add_major_minor_ticks(ax[2],
-                         x_minor_per_major=1,
-                         y_minor_per_major=4,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax[2], x_minor_per_major=1, y_minor_per_major=4, labelsize=14)
 
 # Set axes limits, ticks and tick labels for plot 3
-gv.set_axes_limits_and_ticks(ax[2],
-                             xlim=(date[0], date[12]),
-                             ylim=(-4, 10),
-                             xticks=date[0:13],
-                             xticklabels=[
-                                 'Jan\n2000', "Feb\n2000", "Mar\n2000",
-                                 "Apr\n2000", "May\n2000", "Jun\n2000",
-                                 "Jul\n2000", " Aug\n2000", " Sep\n2000",
-                                 " Oct\n2000", " Nov\n2000", " Dec\n2000",
-                                 " Jan\n2001"
-                             ],
-                             yticks=np.arange(-4, 11, 2))
+gv.set_axes_limits_and_ticks(
+    ax[2],
+    xlim=(date[0], date[12]),
+    ylim=(-4, 10),
+    xticks=date[0:13],
+    xticklabels=[
+        'Jan\n2000',
+        "Feb\n2000",
+        "Mar\n2000",
+        "Apr\n2000",
+        "May\n2000",
+        "Jun\n2000",
+        "Jul\n2000",
+        " Aug\n2000",
+        " Sep\n2000",
+        " Oct\n2000",
+        " Nov\n2000",
+        " Dec\n2000",
+        " Jan\n2001",
+    ],
+    yticks=np.arange(-4, 11, 2),
+)
 
 # Add main title for plot 2 and 3
 ax[1].set_title('time', fontsize=16, y=1.04)

--- a/Gallery/XY/NCL_tm_1.py
+++ b/Gallery/XY/NCL_tm_1.py
@@ -34,9 +34,7 @@ nyears = x_data.size
 y_data = np.random.uniform(-4, 4, nyears)
 
 # Print out a formatted message; note the starting 'f' for the string.
-print(
-    f"There are { len(x_data) } values in x_data, and { len(y_data) } values in y_data."
-)
+print(f"There are {len(x_data)} values in x_data, and {len(y_data)} values in y_data.")
 
 ###############################################################################
 # Plot 1
@@ -49,19 +47,16 @@ ax = plt.gca()
 ax.yaxis.set_major_formatter(FormatStrFormatter('%.1f'))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=4,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=4, labelsize=16)
 
 # Plot data and set the X axis limits.
 plt.plot(x_data, y_data, color='grey', linewidth=0.5)
 
 # Usa geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(min(x_data) - 1, max(x_data) + 1),
-                             ylim=(-4.5, 4.5))
+gv.set_axes_limits_and_ticks(
+    ax, xlim=(min(x_data) - 1, max(x_data) + 1), ylim=(-4.5, 4.5)
+)
 
 # Draw plot on the screen
 plt.tight_layout()
@@ -82,19 +77,16 @@ ax.xaxis.set_major_locator(FixedLocator(xticks))
 ax.yaxis.set_major_formatter(FormatStrFormatter('%.1f'))
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=4,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=4, labelsize=16)
 
 # Line-plot data
 plt.plot(x_data, y_data, color='grey', linewidth=0.5)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, and tick values on x-axes.
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(min(x_data) - 1, max(x_data) + 1),
-                             ylim=(-4.5, 4.5))
+gv.set_axes_limits_and_ticks(
+    ax, xlim=(min(x_data) - 1, max(x_data) + 1), ylim=(-4.5, 4.5)
+)
 
 # Draw plot on the screen
 plt.tight_layout()

--- a/Gallery/XY/NCL_tm_2.py
+++ b/Gallery/XY/NCL_tm_2.py
@@ -36,9 +36,7 @@ x_data = np.arange(1950, 2006)
 y_data = np.random.uniform(-4, 4, 56)
 
 # Print out a formatted message; note the starting 'f' for the string.
-print(
-    f"There are { len(x_data) } values in x_data, and { len(y_data) } values in y_data."
-)
+print(f"There are {len(x_data)} values in x_data, and {len(y_data)} values in y_data.")
 
 ###############################################################################
 # Plot:
@@ -105,21 +103,19 @@ ax2.xaxis.set_minor_locator(MultipleLocator(1))
 ax2.yaxis.set_minor_locator(MultipleLocator(0.5))
 
 # Add a descriptive text to the top left corner of the axes.
-ax2.text(0.01,
-         1.1,
-         "Ticks Set Explicitly",
-         transform=ax2.transAxes,
-         fontweight='bold')
+ax2.text(0.01, 1.1, "Ticks Set Explicitly", transform=ax2.transAxes, fontweight='bold')
 
 # Line-plot data
 plt.plot(x_data, y_data, color='black', linewidth=0.5)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, and tick values on x-axes.
-gv.set_axes_limits_and_ticks(ax2,
-                             xlim=(1949, 2006),
-                             ylim=(-4.2, 4.2),
-                             xticks=[1950, 1960, 1970, 1980, 1990, 2000, 2005])
+gv.set_axes_limits_and_ticks(
+    ax2,
+    xlim=(1949, 2006),
+    ylim=(-4.2, 4.2),
+    xticks=[1950, 1960, 1970, 1980, 1990, 2000, 2005],
+)
 
 # Create more space between subplots
 plt.subplots_adjust(hspace=0.4)

--- a/Gallery/XY/NCL_xy_1.py
+++ b/Gallery/XY/NCL_xy_1.py
@@ -34,15 +34,12 @@ plt.figure(figsize=(7, 6.5))
 ax = plt.gca()
 
 # Plot the specific slice of the data with the correct color and linewidth
-U.isel(time=0).sel(lon=82, method='nearest').plot(x="lat",
-                                                  color="#afafaf",
-                                                  linewidth=1.1)
+U.isel(time=0).sel(lon=82, method='nearest').plot(
+    x="lat", color="#afafaf", linewidth=1.1
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=5,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=5, labelsize=16)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, tick values, and tick labels to show latitude & longitude (i.e. North (N) - South (S))
@@ -52,13 +49,11 @@ gv.set_axes_limits_and_ticks(
     ylim=(-10, 50),
     xticks=np.linspace(-90, 90, 7),
     yticks=np.linspace(-10, 50, 7),
-    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'])
+    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'],
+)
 
 # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-gv.set_titles_and_labels(ax,
-                         maintitle="Basic XY plot",
-                         xlabel="",
-                         ylabel="Zonal Wind")
+gv.set_titles_and_labels(ax, maintitle="Basic XY plot", xlabel="", ylabel="Zonal Wind")
 
 # Show the plot
 plt.tight_layout()

--- a/Gallery/XY/NCL_xy_10.py
+++ b/Gallery/XY/NCL_xy_10.py
@@ -56,10 +56,7 @@ plt.plot(TS.lat, bottom, color='SlateBlue')
 ax.fill_between(TS.lat, top, bottom, color='SlateBlue')
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=4,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=4, labelsize=14)
 
 # Use geocat.viz.util convenience function to set axes parameters
 gv.set_axes_limits_and_ticks(
@@ -67,13 +64,15 @@ gv.set_axes_limits_and_ticks(
     ylim=(220, 320),
     xlim=(-90, 90),
     xticks=np.arange(-90, 91, 30),
-    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'])
+    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'],
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
 gv.set_titles_and_labels(
     ax,
     maintitle="A Title with $\\eta\epsilon\lambda\\alpha\sigma$ Characters",
-    ylabel=TS.long_name)
+    ylabel=TS.long_name,
+)
 
 # Draw sigma on axes
 ax.text(0.15, 0.15, "$\sigma$", fontsize=40, transform=ax.transAxes)

--- a/Gallery/XY/NCL_xy_12.py
+++ b/Gallery/XY/NCL_xy_12.py
@@ -38,13 +38,13 @@ bins = [0, 5, 20]
 # Slicing data in Python excludes the last value. To include the last value we
 # can increment it by 1. This ensures that the different colored line segments
 # touch
-start = U.data[bins[0]:bins[1] + 1]
-highlight = U.data[bins[1]:bins[2] + 1]
-end = U.data[bins[2]:]
+start = U.data[bins[0] : bins[1] + 1]
+highlight = U.data[bins[1] : bins[2] + 1]
+end = U.data[bins[2] :]
 
-ax.plot(U.lat[bins[0]:bins[1] + 1], start, color='black', linewidth=0.5)
-ax.plot(U.lat[bins[1]:bins[2] + 1], highlight, color='red', linewidth=1)
-ax.plot(U.lat[bins[2]:], end, color='black', linewidth=0.5)
+ax.plot(U.lat[bins[0] : bins[1] + 1], start, color='black', linewidth=0.5)
+ax.plot(U.lat[bins[1] : bins[2] + 1], highlight, color='red', linewidth=1)
+ax.plot(U.lat[bins[2] :], end, color='black', linewidth=0.5)
 
 # Use geocat.viz.util convenience function to set axes parameters
 gv.set_axes_limits_and_ticks(
@@ -53,18 +53,16 @@ gv.set_axes_limits_and_ticks(
     xlim=(-90, 90),
     xticks=np.arange(-90, 91, 30),
     yticks=np.arange(-10, 41, 10),
-    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'])
+    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'],
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=5,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=5, labelsize=14)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Highlight Part of a Line",
-                         ylabel=U.long_name + " " + U.units)
+gv.set_titles_and_labels(
+    ax, maintitle="Highlight Part of a Line", ylabel=U.long_name + " " + U.units
+)
 
 plt.show()
 
@@ -79,7 +77,7 @@ bins = [5, 24]
 # Slicing data in Python excludes the last value. To include the last value we
 # can increment it by 1. This ensures that the highlight extends through the
 # last bin value
-highlight = U.data[bins[0]:bins[1] + 1]
+highlight = U.data[bins[0] : bins[1] + 1]
 
 # Define bounds for region centered on the data with a width of 4
 nlat = np.shape(highlight)[0]
@@ -91,11 +89,11 @@ for k in range(0, nlat):
     bottom[k] = highlight[k] - 2
 
 # Plot curves that bound the region to be colored
-ax.plot(U.lat[bins[0]:bins[1] + 1], top, color='salmon')
-ax.plot(U.lat[bins[0]:bins[1] + 1], bottom, color='salmon')
+ax.plot(U.lat[bins[0] : bins[1] + 1], top, color='salmon')
+ax.plot(U.lat[bins[0] : bins[1] + 1], bottom, color='salmon')
 
 # Fill the area between the bounds
-ax.fill_between(U.lat[bins[0]:bins[1] + 1], top, bottom, color='salmon')
+ax.fill_between(U.lat[bins[0] : bins[1] + 1], top, bottom, color='salmon')
 
 ax.plot(U.lat, U.data, color='black', linewidth=0.5)
 
@@ -106,17 +104,15 @@ gv.set_axes_limits_and_ticks(
     xlim=(-90, 90),
     xticks=np.arange(-90, 91, 30),
     yticks=np.arange(-10, 51, 10),
-    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'])
+    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'],
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=5,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=5, labelsize=14)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Highlight Part of a Line",
-                         ylabel=U.long_name + " " + U.units)
+gv.set_titles_and_labels(
+    ax, maintitle="Highlight Part of a Line", ylabel=U.long_name + " " + U.units
+)
 
 plt.show()

--- a/Gallery/XY/NCL_xy_13.py
+++ b/Gallery/XY/NCL_xy_13.py
@@ -59,22 +59,21 @@ plt.plot(x, V.data, color='black', linewidth=0.5, marker='.')
 ax.add_collection(bars)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(0, 70),
-                             ylim=(-9, 9),
-                             xticks=np.arange(0, 71, 10),
-                             yticks=np.arange(-9, 10, 3),
-                             yticklabels=np.arange(-9.0, 10.0, 3.0))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(0, 70),
+    ylim=(-9, 9),
+    xticks=np.arange(0, 71, 10),
+    yticks=np.arange(-9, 10, 3),
+    yticklabels=np.arange(-9.0, 10.0, 3.0),
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=3,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=3, labelsize=14)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Example of error bars",
-                         ylabel=V.long_name + " " + V.units)
+gv.set_titles_and_labels(
+    ax, maintitle="Example of error bars", ylabel=V.long_name + " " + V.units
+)
 
 plt.show()

--- a/Gallery/XY/NCL_xy_16.py
+++ b/Gallery/XY/NCL_xy_16.py
@@ -20,7 +20,7 @@ See following URLs to see the reproduced NCL plot & script:
 import numpy as np
 import xarray as xr
 import matplotlib.pyplot as plt
-from matplotlib.ticker import (ScalarFormatter, NullFormatter)
+from matplotlib.ticker import ScalarFormatter, NullFormatter
 import matplotlib.ticker as tic
 
 import geocat.datafiles as gdf
@@ -47,63 +47,47 @@ plt.figure(figsize=(8, 8))
 ax = plt.axes()
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=4,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=4, labelsize=14)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(-20, 40),
-                             ylim=(1000, 0),
-                             xticks=np.arange(-20, 60, 10),
-                             yticks=np.arange(0, 1200, 200))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(-20, 40),
+    ylim=(1000, 0),
+    xticks=np.arange(-20, 60, 10),
+    yticks=np.arange(0, 1200, 200),
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle='Profile Plot',
-                         xlabel=U.long_name,
-                         ylabel=U['lev'].long_name)
+gv.set_titles_and_labels(
+    ax, maintitle='Profile Plot', xlabel=U.long_name, ylabel=U['lev'].long_name
+)
 
 # Add reference line x=0
 ax.axvline(x=0, color='black', linewidth=0.5)
 
 # Plot data
-plt.plot(U20.data,
-         U20.lev,
-         color='black',
-         linestyle='solid',
-         label='20N',
-         linewidth=0.5)
-plt.plot(U30.data,
-         U30.lev,
-         color='black',
-         dashes=[15, 5],
-         label='30N',
-         linewidth=0.5)
-plt.plot(U40.data,
-         U40.lev,
-         color='black',
-         dashes=[4, 5],
-         label='40N',
-         linewidth=0.5)
-plt.plot(U50.data,
-         U50.lev,
-         color='black',
-         dashes=[15, 5, 5, 5],
-         label='50N',
-         linewidth=0.5)
+plt.plot(
+    U20.data, U20.lev, color='black', linestyle='solid', label='20N', linewidth=0.5
+)
+plt.plot(U30.data, U30.lev, color='black', dashes=[15, 5], label='30N', linewidth=0.5)
+plt.plot(U40.data, U40.lev, color='black', dashes=[4, 5], label='40N', linewidth=0.5)
+plt.plot(
+    U50.data, U50.lev, color='black', dashes=[15, 5, 5, 5], label='50N', linewidth=0.5
+)
 
 # Add legend
 handles, labels = ax.get_legend_handles_labels()
 
-plt.legend(handles,
-           labels,
-           loc='center right',
-           frameon=False,
-           fontsize=14,
-           labelspacing=1,
-           reverse=True)
+plt.legend(
+    handles,
+    labels,
+    loc='center right',
+    frameon=False,
+    fontsize=14,
+    labelspacing=1,
+    reverse=True,
+)
 
 plt.show()
 
@@ -125,70 +109,62 @@ ax.xaxis.set_minor_locator(tic.AutoMinorLocator(n=5))
 # Specify no minor ticks on log y axis
 ax.yaxis.set_minor_locator(tic.LogLocator())
 # Length and width are in points and may need to change depending on figure size
-ax.tick_params("both",
-               length=8,
-               width=0.9,
-               which="major",
-               bottom=True,
-               top=True,
-               left=True,
-               right=True)
-ax.tick_params("both",
-               length=4,
-               width=0.4,
-               which="minor",
-               bottom=True,
-               top=True,
-               left=True,
-               right=True)
+ax.tick_params(
+    "both",
+    length=8,
+    width=0.9,
+    which="major",
+    bottom=True,
+    top=True,
+    left=True,
+    right=True,
+)
+ax.tick_params(
+    "both",
+    length=4,
+    width=0.4,
+    which="minor",
+    bottom=True,
+    top=True,
+    left=True,
+    right=True,
+)
 
 # Use geocat.viz.util convenience function to set axes parameters
 pressure_lvls = [1, 5, 10, 30, 50, 100, 200, 300, 400, 500, 700, 1000]
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(-20, 40),
-                             ylim=(1000, 4),
-                             xticks=np.arange(-20, 60, 10),
-                             yticks=pressure_lvls)
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(-20, 40),
+    ylim=(1000, 4),
+    xticks=np.arange(-20, 60, 10),
+    yticks=pressure_lvls,
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
 gv.set_titles_and_labels(ax, maintitle='Profile Plot', xlabel=U.long_name)
 
 # Plot data
-plt.plot(U20.data,
-         U20.lev,
-         color='black',
-         linestyle='solid',
-         label='20N',
-         linewidth=0.5)
-plt.plot(U30.data,
-         U30.lev,
-         color='black',
-         dashes=[15, 5],
-         label='30N',
-         linewidth=0.5)
-plt.plot(U40.data,
-         U40.lev,
-         color='black',
-         dashes=[4, 5],
-         label='40N',
-         linewidth=0.5)
-plt.plot(U50.data,
-         U50.lev,
-         color='black',
-         dashes=[15, 5, 5, 5],
-         label='50N',
-         linewidth=0.5)
+plt.plot(
+    U20.data, U20.lev, color='black', linestyle='solid', label='20N', linewidth=0.5
+)
+plt.plot(U30.data, U30.lev, color='black', dashes=[15, 5], label='30N', linewidth=0.5)
+plt.plot(U40.data, U40.lev, color='black', dashes=[4, 5], label='40N', linewidth=0.5)
+plt.plot(
+    U50.data, U50.lev, color='black', dashes=[15, 5, 5, 5], label='50N', linewidth=0.5
+)
 
 # Add legend
 handles, labels = ax.get_legend_handles_labels()
 # Default order is the order in which the data was plotted
 
-plt.legend(handles,
-           labels,
-           loc='center right',
-           frameon=False,
-           fontsize=14,
-           labelspacing=1,
-           reverse=True)
+plt.legend(
+    handles,
+    labels,
+    loc='center right',
+    frameon=False,
+    fontsize=14,
+    labelspacing=1,
+    reverse=True,
+)
 
 plt.show()

--- a/Gallery/XY/NCL_xy_18.py
+++ b/Gallery/XY/NCL_xy_18.py
@@ -86,26 +86,30 @@ nfiles = [
     gdf.get("netcdf_files/TREFHT.B06.66.atm.1890-1999ANN.nc"),
     gdf.get("netcdf_files/TREFHT.B06.67.atm.1890-1999ANN.nc"),
     gdf.get("netcdf_files/TREFHT.B06.68.atm.1890-1999ANN.nc"),
-    gdf.get("netcdf_files/TREFHT.B06.69.atm.1890-1999ANN.nc")
+    gdf.get("netcdf_files/TREFHT.B06.69.atm.1890-1999ANN.nc"),
 ]
-nds = xr.open_mfdataset(nfiles,
-                        concat_dim='case',
-                        combine='nested',
-                        preprocess=assume_noleap_calendar,
-                        decode_times=False)
+nds = xr.open_mfdataset(
+    nfiles,
+    concat_dim='case',
+    combine='nested',
+    preprocess=assume_noleap_calendar,
+    decode_times=False,
+)
 
 # Create a dataset for the "natural + anthropogenic" data
 vfiles = [
     gdf.get("netcdf_files/TREFHT.B06.61.atm.1890-1999ANN.nc"),
     gdf.get("netcdf_files/TREFHT.B06.59.atm.1890-1999ANN.nc"),
     gdf.get("netcdf_files/TREFHT.B06.60.atm.1890-1999ANN.nc"),
-    gdf.get("netcdf_files/TREFHT.B06.57.atm.1890-1999ANN.nc")
+    gdf.get("netcdf_files/TREFHT.B06.57.atm.1890-1999ANN.nc"),
 ]
-vds = xr.open_mfdataset(vfiles,
-                        concat_dim='case',
-                        combine='nested',
-                        preprocess=assume_noleap_calendar,
-                        decode_times=False)
+vds = xr.open_mfdataset(
+    vfiles,
+    concat_dim='case',
+    combine='nested',
+    preprocess=assume_noleap_calendar,
+    decode_times=False,
+)
 
 # Read the "weights" file
 # (The xarray.Dataset.expand_dims call adds the longitude dimension to the
@@ -124,12 +128,10 @@ gds = gds.expand_dims(dim={'lon': nds.lon})
 # ``DataArray`` explicitly, since the time values are not stored in the
 # ASCII data file (we have to know them!).
 
-obs_data = np.loadtxt(gdf.get("ascii_files/jones_glob_ann_2002.asc"),
-                      dtype=float)
-obs_time = xr.cftime_range('1856-07-16T22:00:00',
-                           freq='365D',
-                           periods=len(obs_data),
-                           calendar='noleap')
+obs_data = np.loadtxt(gdf.get("ascii_files/jones_glob_ann_2002.asc"), dtype=float)
+obs_time = xr.cftime_range(
+    '1856-07-16T22:00:00', freq='365D', periods=len(obs_data), calendar='noleap'
+)
 obs = xr.DataArray(name='TREFHT', data=obs_data, coords=[('time', obs_time)])
 
 ###############################################################################
@@ -171,7 +173,8 @@ gavav = gavv - gavv.sel(time=slice('1890', '1920')).mean(dim='time')
 # We do the same thing for the observation data.
 
 obs_avg = obs.sel(time=slice('1890', '1999')) - obs.sel(
-    time=slice('1890', '1920')).mean(dim='time')
+    time=slice('1890', '1920')
+).mean(dim='time')
 
 ###############################################################################
 # Calculate the ensemble Min. & Max. & Mean:
@@ -209,34 +212,37 @@ ax.plot(time, gavav_avg, color='red', label='Anthropogenic + Natural', zorder=2)
 ax.legend(loc='upper left', frameon=False, fontsize=18)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=3,
-                         labelsize=20)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=3, labelsize=20)
 
 # Use geocat.viz.util convenience function to set axes limits & tick values without calling several matplotlib functions
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(1890, 2000),
-                             ylim=(-0.4, 1),
-                             xticks=np.arange(1900, 2001, step=20),
-                             yticks=np.arange(-0.3, 1, step=0.3))
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(1890, 2000),
+    ylim=(-0.4, 1),
+    xticks=np.arange(1900, 2001, step=20),
+    yticks=np.arange(-0.3, 1, step=0.3),
+)
 
 # Set three titles on top of each other using axes title and texts
 ax.set_title('Parallel Climate Model Ensembles', fontsize=24, pad=60.0)
-ax.text(0.5,
-        1.125,
-        'Global Temperature Anomalies',
-        fontsize=18,
-        ha='center',
-        va='center',
-        transform=ax.transAxes)
-ax.text(0.5,
-        1.06,
-        'from 1890-1919 average',
-        fontsize=14,
-        ha='center',
-        va='center',
-        transform=ax.transAxes)
+ax.text(
+    0.5,
+    1.125,
+    'Global Temperature Anomalies',
+    fontsize=18,
+    ha='center',
+    va='center',
+    transform=ax.transAxes,
+)
+ax.text(
+    0.5,
+    1.06,
+    'from 1890-1919 average',
+    fontsize=14,
+    ha='center',
+    va='center',
+    transform=ax.transAxes,
+)
 ax.set_ylabel('$^\circ$C', fontsize=24)
 ax.fill_between(time, gavan_min, gavan_max, color='lightblue', zorder=0)
 ax.fill_between(time, gavav_min, gavav_max, color='lightpink', zorder=1)

--- a/Gallery/XY/NCL_xy_19.py
+++ b/Gallery/XY/NCL_xy_19.py
@@ -45,19 +45,20 @@ def make_axes(plot_size):
     # Use geocat.viz.util convenience function to add minor and major tick lines
     gv.add_major_minor_ticks(ax1, y_minor_per_major=5, labelsize=14)
     gv.add_major_minor_ticks(ax2, y_minor_per_major=5, labelsize=14)
-    gv.add_major_minor_ticks(ax3,
-                             x_minor_per_major=5,
-                             y_minor_per_major=4,
-                             labelsize=14)
+    gv.add_major_minor_ticks(
+        ax3, x_minor_per_major=5, y_minor_per_major=4, labelsize=14
+    )
 
     # Use geocat.viz.util convenience function to set axes tick values
     gv.set_axes_limits_and_ticks(ax1, ylim=(-3500, -2900))
     gv.set_axes_limits_and_ticks(ax2, ylim=(10, 60))
-    gv.set_axes_limits_and_ticks(ax3,
-                                 xlim=(0, 360),
-                                 ylim=(-16, 12),
-                                 xticks=[0, 100, 200, 300],
-                                 yticks=np.arange(-16, 13, 4))
+    gv.set_axes_limits_and_ticks(
+        ax3,
+        xlim=(0, 360),
+        ylim=(-16, 12),
+        xticks=[0, 100, 200, 300],
+        yticks=np.arange(-16, 13, 4),
+    )
 
     # Adjust which sides of the plot the tick marks are drawn for each axes
     ax1.tick_params('both', which='both', right=False)
@@ -109,20 +110,22 @@ gv.set_titles_and_labels(ax3, ylabel='v')
 # the `handles` for the legend. Since we only want the line objects, a comma is
 # added after t_plot to extract the first item of the list returned by
 # axes.plot()
-t_plot, = ax1.plot(lon, t, linewidth=0.5, c='r', label='t')
-u_plot, = ax2.plot(lon, u, linewidth=0.5, c='g', label='u')
-v_plot, = ax3.plot(lon, v, linewidth=0.5, c='b', label='v')
+(t_plot,) = ax1.plot(lon, t, linewidth=0.5, c='r', label='t')
+(u_plot,) = ax2.plot(lon, u, linewidth=0.5, c='g', label='u')
+(v_plot,) = ax3.plot(lon, v, linewidth=0.5, c='b', label='v')
 
 # Add a legend using the Line2D objects from before as the handles
-plt.legend(loc='lower right',
-           fancybox=False,
-           edgecolor='black',
-           borderaxespad=0,
-           borderpad=0.75,
-           handlelength=3.5,
-           handletextpad=0,
-           fontsize=14,
-           handles=[v_plot, u_plot, t_plot])
+plt.legend(
+    loc='lower right',
+    fancybox=False,
+    edgecolor='black',
+    borderaxespad=0,
+    borderpad=0.75,
+    handlelength=3.5,
+    handletextpad=0,
+    fontsize=14,
+    handles=[v_plot, u_plot, t_plot],
+)
 
 plt.tight_layout()
 plt.show()

--- a/Gallery/XY/NCL_xy_2_1.py
+++ b/Gallery/XY/NCL_xy_2_1.py
@@ -39,22 +39,20 @@ plt.figure(figsize=(7, 6.5))
 ax = plt.gca()
 
 # Plot slices of data
-U.isel(time=0).sel(lon=82, method='nearest').plot(x="lat",
-                                                  marker='',
-                                                  color='#C0C2EA',
-                                                  linewidth=1.1)
-U.isel(time=0).sel(lon=-69, method='nearest').plot(x="lat",
-                                                   marker='',
-                                                   color='#E28D90',
-                                                   linewidth=1.1,
-                                                   linestyle='--',
-                                                   dashes=[6.5, 3.7])
+U.isel(time=0).sel(lon=82, method='nearest').plot(
+    x="lat", marker='', color='#C0C2EA', linewidth=1.1
+)
+U.isel(time=0).sel(lon=-69, method='nearest').plot(
+    x="lat",
+    marker='',
+    color='#E28D90',
+    linewidth=1.1,
+    linestyle='--',
+    dashes=[6.5, 3.7],
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=3,
-                         y_minor_per_major=5,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=3, y_minor_per_major=5, labelsize=16)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, tick values, and tick labels to show latitude & longitude (i.e. North (N) - South (S))
@@ -64,13 +62,13 @@ gv.set_axes_limits_and_ticks(
     ylim=(-20, 50),
     xticks=np.linspace(-90, 90, 7),
     yticks=np.linspace(-20, 50, 8),
-    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'])
+    xticklabels=['90S', '60S', '30S', '0', '30N', '60N', '90N'],
+)
 
 # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-gv.set_titles_and_labels(ax,
-                         maintitle="Two Curve XY Plot",
-                         xlabel="",
-                         ylabel="Zonal Wind")
+gv.set_titles_and_labels(
+    ax, maintitle="Two Curve XY Plot", xlabel="", ylabel="Zonal Wind"
+)
 
 # Show the plot
 plt.tight_layout()

--- a/Gallery/XY/NCL_xy_3.py
+++ b/Gallery/XY/NCL_xy_3.py
@@ -50,10 +50,9 @@ gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=4)
 gv.set_axes_limits_and_ticks(ax, ylim=(1000, 0), xticks=np.arange(-10, 30, 5))
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Profile Plot",
-                         xlabel=ds.long_name,
-                         ylabel=ds['lev'].long_name)
+gv.set_titles_and_labels(
+    ax, maintitle="Profile Plot", xlabel=ds.long_name, ylabel=ds['lev'].long_name
+)
 
 plt.show()
 
@@ -69,12 +68,14 @@ ax = plt.gca()
 # Use keyword `linewidth` to change the line thickness
 # Use keyword `dashes` to create a custom dash pattern
 # Use keyword `dash_capstyle` to change the shape of the dash end
-plt.plot(ds.data,
-         ds.lev,
-         color='red',
-         linewidth=3,
-         dashes=[3, 2, 1, 2, 1, 2, 1, 2],
-         dash_capstyle='round')
+plt.plot(
+    ds.data,
+    ds.lev,
+    color='red',
+    linewidth=3,
+    dashes=[3, 2, 1, 2, 1, 2, 1, 2],
+    dash_capstyle='round',
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
 gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=4)
@@ -83,9 +84,11 @@ gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=4)
 gv.set_axes_limits_and_ticks(ax, ylim=(1000, 0), xticks=np.arange(-10, 30, 5))
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Make your own dash pattern",
-                         xlabel=ds.long_name,
-                         ylabel=ds['lev'].long_name)
+gv.set_titles_and_labels(
+    ax,
+    maintitle="Make your own dash pattern",
+    xlabel=ds.long_name,
+    ylabel=ds['lev'].long_name,
+)
 
 plt.show()

--- a/Gallery/XY/NCL_xy_35.py
+++ b/Gallery/XY/NCL_xy_35.py
@@ -27,7 +27,7 @@ import geocat.viz as gv
 # Create data:
 
 # Make array of x-values, 64 evenly spaced values between 0 and 1
-f = np.linspace(0., 1., 64)
+f = np.linspace(0.0, 1.0, 64)
 
 twopi = 2 * np.pi
 
@@ -41,40 +41,39 @@ z = x * y
 
 # Create figure with 6 axes
 fig, axes = plt.subplots(figsize=(7, 10), nrows=3, ncols=2)
-plt.subplots_adjust(wspace=0.3, hspace=.4)
+plt.subplots_adjust(wspace=0.3, hspace=0.4)
 
 # Plot first graph
-axesList = [
-    axes[0, 0], axes[0, 1], axes[1, 0], axes[1, 1], axes[2, 0], axes[2, 1]
-]
+axesList = [axes[0, 0], axes[0, 1], axes[1, 0], axes[1, 1], axes[2, 0], axes[2, 1]]
 
 # Create array of titles of each plot
 titles = [
-    'Opaque lines', 'Uniformly translucent', 'Independently translucent',
-    'Uniformly translucent markers', 'Independently translucent markers',
-    'Opacities still apply in MonoColor modes'
+    'Opaque lines',
+    'Uniformly translucent',
+    'Independently translucent',
+    'Uniformly translucent markers',
+    'Independently translucent markers',
+    'Opacities still apply in MonoColor modes',
 ]
 
 # Create ticks, axis limits, and titles for each of the 6 plots
 for ax in range(6):
-
     # Use geocat-viz function to set main title of plot
-    gv.set_titles_and_labels(axesList[ax],
-                             maintitle=titles[ax],
-                             maintitlefontsize=10)
+    gv.set_titles_and_labels(axesList[ax], maintitle=titles[ax], maintitlefontsize=10)
 
     # Use geocat-viz function to set limits and tick locations on x and y axes
-    gv.set_axes_limits_and_ticks(axesList[ax],
-                                 xlim=[0, 1],
-                                 ylim=[-1.2, 1.2],
-                                 yticks=np.arange(-1.5, 1.5, 0.5),
-                                 yticklabels=np.arange(-1.5, 1.5, 0.5))
+    gv.set_axes_limits_and_ticks(
+        axesList[ax],
+        xlim=[0, 1],
+        ylim=[-1.2, 1.2],
+        yticks=np.arange(-1.5, 1.5, 0.5),
+        yticklabels=np.arange(-1.5, 1.5, 0.5),
+    )
 
     # Use geocat-viz function to add major and minor ticks on the x and y axes
-    gv.add_major_minor_ticks(axesList[ax],
-                             x_minor_per_major=4,
-                             y_minor_per_major=5,
-                             labelsize="small")
+    gv.add_major_minor_ticks(
+        axesList[ax], x_minor_per_major=4, y_minor_per_major=5, labelsize="small"
+    )
 
 # Set standard alpha (transparency) value
 alpha = 0.4
@@ -107,36 +106,42 @@ line3 = axesList[2].plot(f, z, color='blue', alpha=0.15)
 # 'markevery' allows you to place a marker every num steps in the x direction
 # 'mec' is marker edge color
 # 'mfc' is marker face color
-line1 = axesList[3].plot(f,
-                         x,
-                         'o',
-                         ls='-',
-                         color='red',
-                         alpha=alpha,
-                         ms=3,
-                         markevery=.05,
-                         mec='None',
-                         mfc='limegreen')
-line2 = axesList[3].plot(f,
-                         y,
-                         'o',
-                         ls='-',
-                         color='limegreen',
-                         alpha=alpha,
-                         ms=3,
-                         markevery=.05,
-                         mec='None',
-                         mfc='blue')
-line3 = axesList[3].plot(f,
-                         z,
-                         'o',
-                         ls='-',
-                         color='blue',
-                         alpha=alpha,
-                         ms=3,
-                         markevery=.05,
-                         mec='None',
-                         mfc='red')
+line1 = axesList[3].plot(
+    f,
+    x,
+    'o',
+    ls='-',
+    color='red',
+    alpha=alpha,
+    ms=3,
+    markevery=0.05,
+    mec='None',
+    mfc='limegreen',
+)
+line2 = axesList[3].plot(
+    f,
+    y,
+    'o',
+    ls='-',
+    color='limegreen',
+    alpha=alpha,
+    ms=3,
+    markevery=0.05,
+    mec='None',
+    mfc='blue',
+)
+line3 = axesList[3].plot(
+    f,
+    z,
+    'o',
+    ls='-',
+    color='blue',
+    alpha=alpha,
+    ms=3,
+    markevery=0.05,
+    mec='None',
+    mfc='red',
+)
 
 # Plot fifth graph:
 
@@ -152,33 +157,15 @@ mcolor3 = colors.to_rgba('red', alpha=0.15)
 
 # Plot x, y, and z lines and markers- the lines have the same
 # transparency level, but the markers vary in alpha value
-line1 = axesList[4].plot(f,
-                         x,
-                         'o',
-                         ls='-',
-                         color=lcolor1,
-                         ms=3,
-                         markevery=.1,
-                         mec='None',
-                         mfc=mcolor1)
-line2 = axesList[4].plot(f,
-                         y,
-                         'o',
-                         ls='-',
-                         color=lcolor2,
-                         ms=3,
-                         markevery=.1,
-                         mec='None',
-                         mfc=mcolor2)
-line3 = axesList[4].plot(f,
-                         z,
-                         'o',
-                         ls='-',
-                         color=lcolor3,
-                         ms=3,
-                         markevery=.1,
-                         mec='None',
-                         mfc=mcolor3)
+line1 = axesList[4].plot(
+    f, x, 'o', ls='-', color=lcolor1, ms=3, markevery=0.1, mec='None', mfc=mcolor1
+)
+line2 = axesList[4].plot(
+    f, y, 'o', ls='-', color=lcolor2, ms=3, markevery=0.1, mec='None', mfc=mcolor2
+)
+line3 = axesList[4].plot(
+    f, z, 'o', ls='-', color=lcolor3, ms=3, markevery=0.1, mec='None', mfc=mcolor3
+)
 
 # Plot sixth graph:
 
@@ -194,32 +181,14 @@ mcolor3 = colors.to_rgba('black', alpha=0.15)
 
 # Plot x, y, and z lines and markers in black- the lines have the same
 # transparency level, but the markers vary in alpha value
-line1 = axesList[5].plot(f,
-                         x,
-                         'o',
-                         ls='-',
-                         color=lcolor1,
-                         ms=3,
-                         markevery=.1,
-                         mec='None',
-                         mfc=mcolor1)
-line2 = axesList[5].plot(f,
-                         y,
-                         'o',
-                         ls='-',
-                         color=lcolor2,
-                         ms=3,
-                         markevery=.1,
-                         mec='None',
-                         mfc=mcolor2)
-line3 = axesList[5].plot(f,
-                         z,
-                         'o',
-                         ls='-',
-                         color=lcolor3,
-                         ms=3,
-                         markevery=.1,
-                         mec='None',
-                         mfc=mcolor3)
+line1 = axesList[5].plot(
+    f, x, 'o', ls='-', color=lcolor1, ms=3, markevery=0.1, mec='None', mfc=mcolor1
+)
+line2 = axesList[5].plot(
+    f, y, 'o', ls='-', color=lcolor2, ms=3, markevery=0.1, mec='None', mfc=mcolor2
+)
+line3 = axesList[5].plot(
+    f, z, 'o', ls='-', color=lcolor3, ms=3, markevery=0.1, mec='None', mfc=mcolor3
+)
 
 plt.show()

--- a/Gallery/XY/NCL_xy_4.py
+++ b/Gallery/XY/NCL_xy_4.py
@@ -37,8 +37,7 @@ import geocat.viz as gv
 # Read in data:
 
 # Open a netCDF data file using xarray default engine and load the data into xarrays
-ds = xr.open_dataset(gdf.get('netcdf_files/AtmJan360_xy_4.nc'),
-                     decode_times=False)
+ds = xr.open_dataset(gdf.get('netcdf_files/AtmJan360_xy_4.nc'), decode_times=False)
 
 # Extract a slice of the data
 ds = ds['T']
@@ -52,16 +51,12 @@ ax = plt.axes()
 plt.scatter(t.time, t.data, color='red')
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Scatter Plot",
-                         xlabel=t['time'].long_name,
-                         ylabel=t.long_name)
+gv.set_titles_and_labels(
+    ax, maintitle="Scatter Plot", xlabel=t['time'].long_name, ylabel=t.long_name
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=4,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=4, labelsize=14)
 
 # Calculate xlim by rounding the min value down and the max value up to a
 # multiple of 5
@@ -73,7 +68,8 @@ gv.set_axes_limits_and_ticks(
     xlim=(xmin, xmax),
     ylim=(220.0, 232.0),
     xticklabels=[' ', 131160, ' ', 131170, ' ', 131180, ' ', 131190],
-    yticklabels=np.arange(220.0, 233.0, 2.0))
+    yticklabels=np.arange(220.0, 233.0, 2.0),
+)
 
 plt.show()
 
@@ -101,20 +97,14 @@ time4 = t.time[24:]
 plt.scatter(time1, data1, color='blue', marker='s', label='matplotlib.markers')
 
 # Use a mathematical symbol for a marker
-plt.scatter(time2,
-            data2,
-            color='green',
-            marker='$\Omega$',
-            s=100,
-            label='mathematical symbol')
+plt.scatter(
+    time2, data2, color='green', marker='$\Omega$', s=100, label='mathematical symbol'
+)
 
 # Unicode symbol marker
-plt.scatter(time3,
-            data3,
-            color='black',
-            marker='$\u2608$',
-            s=100,
-            label='unicode symbol')
+plt.scatter(
+    time3, data3, color='black', marker='$\u2608$', s=100, label='unicode symbol'
+)
 
 # Create custom path for marker
 verts = [(-0.5, -0.5), (-0.5, 0.5), (0, 0), (0.5, 0.5), (0.5, -0.5), (0, 0)]
@@ -125,22 +115,19 @@ plt.scatter(time4, data4, color='red', marker=path, s=100, label='custom path')
 plt.legend()
 
 # Use geocat.viz.util convenience function to set titles and labels
-gv.set_titles_and_labels(ax,
-                         maintitle="Make your own marker",
-                         xlabel=t['time'].long_name,
-                         ylabel=t.long_name)
+gv.set_titles_and_labels(
+    ax, maintitle="Make your own marker", xlabel=t['time'].long_name, ylabel=t.long_name
+)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=5,
-                         y_minor_per_major=4,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=5, y_minor_per_major=4, labelsize=14)
 
 gv.set_axes_limits_and_ticks(
     ax,
     xlim=(xmin, xmax),
     ylim=(220.0, 232.0),
     xticklabels=[' ', 131160, ' ', 131170, ' ', 131180, ' ', 131190],
-    yticklabels=np.arange(220.0, 233.0, 2.0))
+    yticklabels=np.arange(220.0, 233.0, 2.0),
+)
 
 plt.show()

--- a/Gallery/XY/NCL_xy_5.py
+++ b/Gallery/XY/NCL_xy_5.py
@@ -64,18 +64,17 @@ ax.fill_between(date_frac, dsoik, where=dsoik > 0, color='red')
 ax.fill_between(date_frac, dsoik, where=dsoik < 0, color='blue')
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=4,
-                         y_minor_per_major=5,
-                         labelsize=14)
+gv.add_major_minor_ticks(ax, x_minor_per_major=4, y_minor_per_major=5, labelsize=14)
 
 # Use geocat.viz.util convenience function to set axes parameters
-gv.set_axes_limits_and_ticks(ax,
-                             ylim=(-3, 3),
-                             yticks=np.linspace(-3, 3, 7),
-                             yticklabels=np.linspace(-3, 3, 7),
-                             xlim=(date_frac[0], date_frac[-1]),
-                             xticks=np.linspace(1880, 1980, 6))
+gv.set_axes_limits_and_ticks(
+    ax,
+    ylim=(-3, 3),
+    yticks=np.linspace(-3, 3, 7),
+    yticklabels=np.linspace(-3, 3, 7),
+    xlim=(date_frac[0], date_frac[-1]),
+    xticks=np.linspace(1880, 1980, 6),
+)
 
 # Use geocat.viz.util convenience function to set titles and labels
 gv.set_titles_and_labels(ax, maintitle="Darwin Southern Oscillation Index")

--- a/Gallery/XY/NCL_xy_6.py
+++ b/Gallery/XY/NCL_xy_6.py
@@ -57,34 +57,26 @@ ax = plt.gca()
 plt.plot(warm_yrs, y, color='grey', linewidth=1)
 
 # Use geocat.viz.util convenience function to add minor and major tick lines
-gv.add_major_minor_ticks(ax,
-                         x_minor_per_major=1,
-                         y_minor_per_major=4,
-                         labelsize=16)
+gv.add_major_minor_ticks(ax, x_minor_per_major=1, y_minor_per_major=4, labelsize=16)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, tick values, and tick labels
-gv.set_axes_limits_and_ticks(ax,
-                             xlim=(1951, 1991),
-                             ylim=(-1.5, 0.6),
-                             yticks=np.arange(-1.2, .6, .4),
-                             xticks=np.array([
-                                 1951, 1954, 1957, 1961, 1965, 1968.5, 1972,
-                                 1977, 1982, 1986.5, 1991
-                             ]),
-                             xticklabels=[
-                                 '1951', '', '1957', '', '1965', '', '1972', '',
-                                 '1982', '', '1991'
-                             ])
+gv.set_axes_limits_and_ticks(
+    ax,
+    xlim=(1951, 1991),
+    ylim=(-1.5, 0.6),
+    yticks=np.arange(-1.2, 0.6, 0.4),
+    xticks=np.array(
+        [1951, 1954, 1957, 1961, 1965, 1968.5, 1972, 1977, 1982, 1986.5, 1991]
+    ),
+    xticklabels=['1951', '', '1957', '', '1965', '', '1972', '', '1982', '', '1991'],
+)
 
 # Turn off minor ticks on y axis
 ax.tick_params(axis='x', which='minor', bottom=False, top=False)
 
 # Use geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-gv.set_titles_and_labels(ax,
-                         maintitle="Explicit axis labeling",
-                         xlabel="",
-                         ylabel="")
+gv.set_titles_and_labels(ax, maintitle="Explicit axis labeling", xlabel="", ylabel="")
 
 # Show the plot
 plt.tight_layout()

--- a/Gallery/XY/NCL_xy_7_2.py
+++ b/Gallery/XY/NCL_xy_7_2.py
@@ -47,16 +47,17 @@ gv.add_major_minor_ticks(ax1, x_minor_per_major=5, labelsize=14)
 
 # Usa geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, and tick values
-gv.set_axes_limits_and_ticks(ax1,
-                             xlim=(1970, 1973),
-                             ylim=(0.0, 16.0),
-                             yticks=np.arange(0, 17, 3))
+gv.set_axes_limits_and_ticks(
+    ax1, xlim=(1970, 1973), ylim=(0.0, 16.0), yticks=np.arange(0, 17, 3)
+)
 
 # Usa geocat.viz.util convenience function to set titles and labels without calling several matplotlib functions
-gv.set_titles_and_labels(ax1,
-                         maintitle="Curves Offset",
-                         xlabel=ds.time.long_name,
-                         ylabel=f"{ds.T.long_name} [solid]")
+gv.set_titles_and_labels(
+    ax1,
+    maintitle="Curves Offset",
+    xlabel=ds.time.long_name,
+    ylabel=f"{ds.T.long_name} [solid]",
+)
 
 # Create second y-axis
 ax2 = ax1.twinx()
@@ -65,18 +66,13 @@ ax2 = ax1.twinx()
 gv.add_major_minor_ticks(ax2, x_minor_per_major=5, labelsize=14)
 
 # Line-plot data
-ax2.plot(ds.time,
-         ds.P,
-         color="red",
-         linestyle="--",
-         dashes=[6.5, 3.7],
-         linewidth=0.9)
+ax2.plot(ds.time, ds.P, color="red", linestyle="--", dashes=[6.5, 3.7], linewidth=0.9)
 
 # Use geocat.viz.util convenience function to set axes parameters without calling several matplotlib functions
 # Set axes limits, and tick values
-gv.set_axes_limits_and_ticks(ax2,
-                             ylim=(1008.0, 1024.0),
-                             yticks=np.arange(1008, 1025, 3))
+gv.set_axes_limits_and_ticks(
+    ax2, ylim=(1008.0, 1024.0), yticks=np.arange(1008, 1025, 3)
+)
 
 # Set second y-axis label
 ax2.set_ylabel(f"{ds.P.long_name} [dash]", fontsize=16)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import os
 
 import logging
 
@@ -24,14 +23,13 @@ geocat.datafiles.get("registry.txt")
 
 # -- Project information -----------------------------------------------------
 
-project = u'GeoCAT-examples'
+project = 'GeoCAT-examples'
 
 import datetime
 
 current_year = datetime.datetime.now().year
-copyright = u'{}, University Corporation for Atmospheric Research'.format(
-    current_year)
-author = u'GeoCAT'
+copyright = '{}, University Corporation for Atmospheric Research'.format(current_year)
+author = 'GeoCAT'
 
 # -- General configuration ---------------------------------------------------
 
@@ -64,6 +62,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**/README.rst']
 # Set plotly renderer to capture _repr_html_ for sphinx-gallery
 try:
     import plotly.io as pio
+
     pio.renderers.default = 'sphinx_gallery'
 except ImportError:
     pass
@@ -72,18 +71,22 @@ except ImportError:
 import warnings
 
 # filter Matplotlib 'agg' warnings
-warnings.filterwarnings("ignore",
-                        category=UserWarning,
-                        message='Matplotlib is currently using agg, which is a'
-                        ' non-GUI backend, so cannot show the figure.')
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    message='Matplotlib is currently using agg, which is a'
+    ' non-GUI backend, so cannot show the figure.',
+)
 
 # filter seaborn warnings
-warnings.filterwarnings("ignore",
-                        category=UserWarning,
-                        message='As seaborn no longer sets a default style on'
-                        ' import, the seaborn.apionly module is'
-                        ' deprecated. It will be removed in a future'
-                        ' version.')
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    message='As seaborn no longer sets a default style on'
+    ' import, the seaborn.apionly module is'
+    ' deprecated. It will be removed in a future'
+    ' version.',
+)
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -108,28 +111,19 @@ html_theme_options = {
     "analytics": {
         "google_analytics_id": "G-BY9T11S8QG",
     },
-    "repository_url":
-        "https://github.com/NCAR/geocat-examples",
-    "repository_branch":
-        "main",
-    "path_to_docs":
-        "docs",
-    "use_edit_page_button":
-        True,
-    "use_repository_button":
-        True,
-    "use_issues_button":
-        True,
-    "home_page_in_toc":
-        False,
-    "navbar_footer_text":
-        "",
+    "repository_url": "https://github.com/NCAR/geocat-examples",
+    "repository_branch": "main",
+    "path_to_docs": "docs",
+    "use_edit_page_button": True,
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "home_page_in_toc": False,
+    "navbar_footer_text": "",
     "logo": {
         "image_light": '_static/images/NSF_NCAR_light.svg',
         "image_dark": '_static/images/NSF_NCAR_dark.svg',
     },
-    "extra_footer":
-        "<em>This material is based upon work supported by the NSF National Center for Atmospheric Research, a major facility sponsored by the U.S. National Science Foundation and managed by the University Corporation for Atmospheric Research. Any opinions, findings and conclusions or recommendations expressed in this material do not necessarily reflect the views of the U.S. National Science Foundation.</em>",
+    "extra_footer": "<em>This material is based upon work supported by the NSF National Center for Atmospheric Research, a major facility sponsored by the U.S. National Science Foundation and managed by the University Corporation for Atmospheric Research. Any opinions, findings and conclusions or recommendations expressed in this material do not necessarily reflect the views of the U.S. National Science Foundation.</em>",
 }
 
 # Specify master_doc (see https://github.com/readthedocs/readthedocs.org/issues/2569#issuecomment-485117471)
@@ -141,8 +135,9 @@ from sphinx_gallery.sorting import ExampleTitleSortKey
 sphinx_gallery_conf = {
     'examples_dirs': ['../Gallery'],  # path to your example scripts
     'filename_pattern': '^((?!sgskip).)*$',
-    'gallery_dirs': ['gallery',
-                    ],  # path to where to save gallery generated output
+    'gallery_dirs': [
+        'gallery',
+    ],  # path to where to save gallery generated output
     'within_subsection_order': ExampleTitleSortKey,
     'matplotlib_animations': True,
 }

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,8 @@
+[format]
+# preserve mixture of single and double quotes
+quote-style = "preserve"
+
+[lint]
+# Skip F841 Local variable name is assigned to but never used
+# Skip E402 Module level import not at top of cell
+ignore = ["E402", "F841"]


### PR DESCRIPTION
Updates pre-commit to transition from `docformatter` to `ruff`

Lot of files, but most of them are just formatting:
- Formatting, nothing functionality
- Adds in `ruff.toml` to handle ruff formatting rules

Ruff ignores `F841` (Local variable name is assigned to but never used) since multiple matplotlib examples setup fig or contour plots, while the variable `fig` is not used

Closes #619