### PR TITLE
Read the Docs configuration and dependency updates

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,14 +9,9 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
-    python: "mambaforge-4.10"
-
-submodules:
-  include:
-     - data
-  recursive: true
+    python: "miniforge3-latest"
 
 conda:
   environment: conda_environment.yml


### PR DESCRIPTION
Updates the Read the Docs configuration and dependencies and removes the submodule configuration that we don't actually use (perhaps we did at one point?).

Prompted by some recent [guidance](https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/) on OS deprecation from Read the Docs and a quick review of the current docs for the config file.

Relates to: ncar/geocat-planning#37