### PR TITLE
GitHub Actions updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * *' # Daily “At 00:00”
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -25,7 +28,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set environment variables
       run: |
         echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-15-intel" ]
-        python-version: [ "3.10", "3.11", "3.12" ]
+        os: [ "ubuntu-latest", "macos-latest" ]
+        python-version: [ "3.10", "3.14" ]
 
     steps:
     - name: checkout

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -4,6 +4,9 @@ on:
     - cron: "0 0 * * 0" # daily at 00:00 UTC
   workflow_dispatch: # allows you to trigger the workflow run manually
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -18,10 +21,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # fetch all history for all branches and tags.
       - name: set up environment


### PR DESCRIPTION
Makes the following changes to the GitHub Actions workflows:
* Pins additional third party actions
* More clearly defines permissions
* Updates Python versions
* Tests "macos-latest" now that this is supported by WRF-Python and drops the "macos-intel" testing since that's pretty unlikely to be used at this point

Closes #604