### PR TITLE
Update boxplot arguments following Matplotlib API changes

### DIFF
--- a/Gallery/Boxplots/NCL_box_1.py
+++ b/Gallery/Boxplots/NCL_box_1.py
@@ -37,7 +37,7 @@ for a in range(len(data)):
 w = 0.25
 fig, ax = plt.subplots(figsize=(6, 6))
 boxplots = ax.boxplot(
-    data, labels=['Control', '-2Xna', '2Xna'], widths=[w, w, w], showfliers=False
+    data, tick_labels=['Control', '-2Xna', '2Xna'], widths=[w, w, w], showfliers=False
 )
 
 # Set whiskers style to dashed

--- a/Gallery/Boxplots/NCL_box_2.py
+++ b/Gallery/Boxplots/NCL_box_2.py
@@ -56,7 +56,7 @@ def setBoxColor(boxplot, colors):
 w = 0.1
 fig, ax = plt.subplots(figsize=(6, 6))
 boxplots = ax.boxplot(
-    data, labels=['Control', '-2Xna', '2Xna'], widths=[w, w, w], showfliers=False
+    data, tick_labels=['Control', '-2Xna', '2Xna'], widths=[w, w, w], showfliers=False
 )
 
 # Set whiskers style to dashed

--- a/Gallery/Boxplots/NCL_box_3.py
+++ b/Gallery/Boxplots/NCL_box_3.py
@@ -64,7 +64,10 @@ fig, ax = plt.subplots(figsize=(6, 6))
 
 # Plot each boxplot, set tick labels, and determine box widths
 boxplots = ax.boxplot(
-    data, tick_labels=['Control', '-2Xna', '2Xna'], widths=[0.4, 0.4, 0.4], showfliers=False
+    data,
+    tick_labels=['Control', '-2Xna', '2Xna'],
+    widths=[0.4, 0.4, 0.4],
+    showfliers=False,
 )
 
 # Set whisker style to dashed

--- a/Gallery/Boxplots/NCL_box_3.py
+++ b/Gallery/Boxplots/NCL_box_3.py
@@ -64,7 +64,7 @@ fig, ax = plt.subplots(figsize=(6, 6))
 
 # Plot each boxplot, set tick labels, and determine box widths
 boxplots = ax.boxplot(
-    data, labels=['Control', '-2Xna', '2Xna'], widths=[0.4, 0.4, 0.4], showfliers=False
+    data, tick_labels=['Control', '-2Xna', '2Xna'], widths=[0.4, 0.4, 0.4], showfliers=False
 )
 
 # Set whisker style to dashed


### PR DESCRIPTION
Updates boxplot arguments following Matplotlib API changes

Documentation of the changes in Matplotlib:
https://matplotlib.org/devdocs/api/prev_api_changes/api_changes_3.9.0.html#boxplot-tick-labels

This should work back to Matplotlib v3.9.0 so hopefully shouldn't cause any issues.  In an ideal world though we might have a way of handling this as discussed in #623.

Closes #688 