### PR TITLE
Fix failure issue generation and remove CI Upstream badge

### DIFF
--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -4,9 +4,6 @@ on:
     - cron: "0 0 * * 0" # daily at 00:00 UTC
   workflow_dispatch: # allows you to trigger the workflow run manually
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-| CI | [![GitHub Workflow Status][github-ci-badge]][github-ci-link] [![GitHub Workflow Status][github-upstream-ci-badge]][github-upstream-ci-link] |
+| CI           | [![GitHub Workflow Status][github-ci-badge]][github-ci-link] |
 | :----------- | :----------------------------------------------------------: |
 | **Docs**     |       [![Documentation Status][rtd-badge]][rtd-link]         |
 | **License**  |           [![License][license-badge]][repo-link]             |
@@ -46,8 +46,6 @@ https://geocat-examples.readthedocs.io/en/latest/citation.html) page.
 
 [github-ci-badge]: https://img.shields.io/github/actions/workflow/status/NCAR/geocat-examples/ci.yml?label=CI&style=for-the-badge
 [github-ci-link]: https://github.com/NCAR/geocat-examples/actions/workflows/ci.yml
-[github-upstream-ci-badge]: https://img.shields.io/github/actions/workflow/status/NCAR/geocat-examples/upstream-dev-ci.yml?&label=Upstream%20CI&style=for-the-badge
-[github-upstream-ci-link]: https://github.com/NCAR/geocat-examples/actions/workflows/upstream-dev-ci.yml
 [rtd-badge]: https://img.shields.io/readthedocs/geocat-examples/latest.svg?style=for-the-badge
 [rtd-link]: https://geocat-examples.readthedocs.io/en/latest/?badge=latest
 [license-badge]: https://img.shields.io/github/license/NCAR/geocat-examples?style=for-the-badge


### PR DESCRIPTION
Fixes the failure issue generation and removes the CI Upstream badge from the README since it's no longer needed and not really important for users.